### PR TITLE
Fix broken query

### DIFF
--- a/scripting/get5_mysqlstats.sp
+++ b/scripting/get5_mysqlstats.sp
@@ -274,8 +274,8 @@ public void AddPlayerStats(KeyValues kv, MatchTeam team) {
                 assists, teamkills, headshot_kills, damage, \
                 bomb_plants, bomb_defuses, \
                 v1, v2, v3, v4, v5, \
-                2k, 3k, 4k, 5k \
-                firstkill_t, firstkill_ct, firstdeath_t, firstdeath_ct, \
+                2k, 3k, 4k, 5k, \
+                firstkill_t, firstkill_ct, firstdeath_t, firstdeath_ct \
                 ) VALUES \
                 (%d, %d, '%s', '%s', \
                 %d, '%s', %d, %d, %d, \


### PR DESCRIPTION
Query was broken resulted in errors being thrown eg.
L 09/30/2016 - 20:26:56: [get5_mysqlstats.smx] Last Connect SQL Error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'firstkill_t, firstkill_ct, firstdeath_t, firstdeath_ct, ) VALUES (6, 0, '**' at line 1