### PR TITLE
Fix pauses when pauses left is equal to 0.

### DIFF
--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -612,10 +612,10 @@ public Action Command_Pause(int client, int args) {
         }
 
         int pausesLeft = g_MaxPausesCvar.IntValue - g_TeamPausesUsed[team];
-        if (pausesLeft == 1) {
+        if (pausesLeft == 1 && g_MaxPausesCvar.IntValue > 0) {
             Get5_MessageToAll("%t", "OnePauseLeftInfoMessage",
                 g_FormattedTeamNames[team], g_TeamPausesUsed[team], pausePeriodString);
-        } else {
+        } else if (g_MaxPausesCvar.IntValue > 0) {
             Get5_MessageToAll("%t", "PausesLeftInfoMessage",
                 g_FormattedTeamNames[team], g_TeamPausesUsed[team], pausePeriodString);
         }


### PR DESCRIPTION
Probably did it a really bad way, but gave it a go nonetheless. When max pauses is set to 0, the value of pauses used continues to go up as there is no max cvar value. This is an attempt at fixing that.