### PR TITLE
Add "veto_first" setting and implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Of the below fields, only the ``team1`` and ``team2`` fields are actually requir
 - ``bo2_series``: whether the series is a bo2 series (will ignore ``maps_to_win`` if it is)
 - ``maplist``: list of the maps in use (an array of strings in JSON, mapnames as keys for KeyValues), you should always use an odd-sized maplist
 - ``skip_veto``: whether the veto will be skipped and the maps will come from the maplist (in the order given)
+- ``veto_first``: either "team1", or "team2". If not set, or set to any other value, team 1 will veto first.
 - ``side_type``: either "standard", "never_knife", or "always_knife"; standard means the team that doesn't pick a map gets the side choice, never_knife means team is always on CT first, and always knife means there is always a knife round
 - ``players_per_team``: maximum players per team (doesn't include a coach spot, default: 5)
 - ``min_players_to_ready``: minimum players a team needs to be able to ready up (default: 1)

--- a/configs/get5/example_match.cfg
+++ b/configs/get5/example_match.cfg
@@ -16,6 +16,8 @@
 
 	"skip_veto"		"0" // If set to 1, the maps will be preset using the first maps in the maplist below.
 
+	"veto_first"	"team1"  // Set to "team1" or "team2" to select who starts the veto. Any other values will default to team1 starting.
+
 	"side_type"		"standard" // Either "standard", "always_knife", or "never_knife"
 
 	"maplist"

--- a/configs/get5/example_match.json
+++ b/configs/get5/example_match.json
@@ -4,6 +4,7 @@
 	"bo2_series": false,
 	"players_per_team": 1,
 	"skip_veto": false,
+	"veto_first": "team1",
 	"side_type": "standard",
 
 	"spectators": {

--- a/scripting/get5/matchconfig.sp
+++ b/scripting/get5/matchconfig.sp
@@ -6,6 +6,7 @@
 #define CONFIG_MAPSTOWIN_DEFAULT 2
 #define CONFIG_BO2_DEFAULT false
 #define CONFIG_SKIPVETO_DEFAULT false
+#define CONFIG_VETOFIRST_DEFAULT "team1"
 #define CONFIG_SIDETYPE_DEFAULT "standard"
 
 stock bool LoadMatchConfig(const char[] config, bool restoreBackup = false) {
@@ -347,9 +348,13 @@ static bool LoadMatchFromKv(KeyValues kv) {
   g_BO2Match = kv.GetNum("bo2_series", CONFIG_BO2_DEFAULT) != 0;
   g_SkipVeto = kv.GetNum("skip_veto", CONFIG_SKIPVETO_DEFAULT) != 0;
 
-  char buf[64];
-  kv.GetString("side_type", buf, sizeof(buf), CONFIG_SIDETYPE_DEFAULT);
-  g_MatchSideType = MatchSideTypeFromString(buf);
+  char vetoFirstBuffer[64];
+  kv.GetString("veto_first", vetoFirstBuffer, sizeof(vetoFirstBuffer), CONFIG_VETOFIRST_DEFAULT);
+  g_LastVetoTeam = OtherMatchTeam(VetoFirstFromString(vetoFirstBuffer));
+
+  char sideTypeBuffer[64];
+  kv.GetString("side_type", sideTypeBuffer, sizeof(sideTypeBuffer), CONFIG_SIDETYPE_DEFAULT);
+  g_MatchSideType = MatchSideTypeFromString(sideTypeBuffer);
 
   g_FavoredTeamPercentage = kv.GetNum("favored_percentage_team1", 0);
   kv.GetString("favored_percentage_text", g_FavoredTeamText, sizeof(g_FavoredTeamText));
@@ -428,9 +433,13 @@ static bool LoadMatchFromJson(Handle json) {
   g_BO2Match = json_object_get_bool_safe(json, "bo2_series", CONFIG_BO2_DEFAULT);
   g_SkipVeto = json_object_get_bool_safe(json, "skip_veto", CONFIG_SKIPVETO_DEFAULT);
 
-  char buf[64];
-  json_object_get_string_safe(json, "side_type", buf, sizeof(buf), CONFIG_SIDETYPE_DEFAULT);
-  g_MatchSideType = MatchSideTypeFromString(buf);
+  char vetoFirstBuffer[64];
+  json_object_get_string_safe(json, "veto_first", vetoFirstBuffer, sizeof(vetoFirstBuffer), CONFIG_VETOFIRST_DEFAULT);
+  g_LastVetoTeam = OtherMatchTeam(VetoFirstFromString(vetoFirstBuffer));
+
+  char sideTypeBuffer[64];
+  json_object_get_string_safe(json, "side_type", sideTypeBuffer, sizeof(sideTypeBuffer), CONFIG_SIDETYPE_DEFAULT);
+  g_MatchSideType = MatchSideTypeFromString(sideTypeBuffer);
 
   json_object_get_string_safe(json, "favored_percentage_text", g_FavoredTeamText,
                               sizeof(g_FavoredTeamText));

--- a/scripting/get5/util.sp
+++ b/scripting/get5/util.sp
@@ -450,6 +450,14 @@ stock bool IsPlayerTeam(MatchTeam team) {
   return team == MatchTeam_Team1 || team == MatchTeam_Team2;
 }
 
+public MatchTeam VetoFirstFromString(const char[] str) {
+  if (StrEqual(str, "team2", false)) {
+    return MatchTeam_Team2;
+  } else {
+    return MatchTeam_Team1;
+  }
+}
+
 stock bool GetAuth(int client, char[] auth, int size) {
   bool ret = GetClientAuthId(client, AuthId_SteamID64, auth, size);
   if (!ret) {


### PR DESCRIPTION
Adds a setting on the root level of the match config called "veto_first"
which allows for selecting the team to get first veto.

Not setting it, or setting it to anything but "team1" or "team2" will
default it to "team1", and thus work as it does currently.