### PR TITLE
#119 map advantage

### DIFF
--- a/scripting/get5/mapveto.sp
+++ b/scripting/get5/mapveto.sp
@@ -42,7 +42,7 @@ public void VetoController(int client) {
     AbortVeto();
   }
 
-  int mapsLeft = GetNumMapsLeft();
+  int mapsLeft = g_MapsLeftInVetoPool.Length;
   int maxMaps = MaxMapsToPlay(g_MapsToWin);
 
   int mapsPicked = g_MapsToPlay.Length;
@@ -267,11 +267,4 @@ public int SidePickMenuHandler(Menu menu, MenuAction action, int param1, int par
   } else if (action == MenuAction_End) {
     delete menu;
   }
-}
-
-
-// Helpers
-
-static int GetNumMapsLeft() {
-  return g_MapsLeftInVetoPool.Length;
 }

--- a/scripting/get5/mapveto.sp
+++ b/scripting/get5/mapveto.sp
@@ -4,7 +4,7 @@
 public void CreateVeto() {
   if (g_MapPoolList.Length % 2 == 0) {
     LogError(
-        "Warning, the maplist is odd number sized (%d maps), vetos may not function correctly!",
+        "Warning, the maplist is even number sized (%d maps), vetos may not function correctly!",
         g_MapPoolList.Length);
   }
 


### PR DESCRIPTION
This is done by stopping the veto process once we hit the total series score, and then adding maps to the front of the list of maps to play so that they will be skipped.

There are a couple of downsides to this:
 - OnMapPicked and OnSidePicked map numbers are incorrect
 - It is no longer possible to use series_score + vetos as backup

I'm not 100% happy with this way of doing it now that i've tested it a little, but it does fix our main problem.

Relates to: splewis/get5#119