### PR TITLE
#122 Add configurable veto confirmation

### DIFF
--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -72,7 +72,7 @@ ConVar g_TeamTimeToKnifeDecisionCvar;
 ConVar g_TeamTimeToStartCvar;
 ConVar g_TimeFormatCvar;
 ConVar g_VetoConfirmationTimeCvar;
-ConVar g_VetoCountdown;
+ConVar g_VetoCountdownCvar;
 ConVar g_WarmupCfgCvar;
 
 // Autoset convars (not meant for users to set)
@@ -282,7 +282,7 @@ public void OnPluginStart() {
   g_VetoConfirmationTimeCvar = CreateConVar(
       "get5_veto_confirmation_time", "0",
       "Time (in seconds) from presenting a veto menu to a selection being made, during which a confirmation will be required, 0 to disable");
-  g_VetoCountdown =
+  g_VetoCountdownCvar =
       CreateConVar("get5_veto_countdown", "5", "Seconds to countdown before veto process commences. Set to \"0\" to disable.");
   g_WarmupCfgCvar =
       CreateConVar("get5_warmup_cfg", "get5/warmup.cfg", "Config file to exec in warmup periods");

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -71,6 +71,7 @@ ConVar g_StopCommandEnabledCvar;
 ConVar g_TeamTimeToKnifeDecisionCvar;
 ConVar g_TeamTimeToStartCvar;
 ConVar g_TimeFormatCvar;
+ConVar g_VetoConfirmationTimeCvar;
 ConVar g_WarmupCfgCvar;
 
 // Autoset convars (not meant for users to set)
@@ -99,6 +100,7 @@ char g_FavoredTeamText[MAX_CVAR_LENGTH];
 int g_PlayersPerTeam = 5;
 int g_MinPlayersPerTeam = 4;
 bool g_SkipVeto = false;
+float g_VetoMenuTime = 0.0;
 MatchSideType g_MatchSideType = MatchSideType_Standard;
 ArrayList g_CvarNames = null;
 ArrayList g_CvarValues = null;
@@ -276,6 +278,9 @@ public void OnPluginStart() {
   g_TimeFormatCvar = CreateConVar(
       "get5_time_format", "%Y-%m-%d_%H",
       "Time format to use when creating file names. Don't tweak this unless you know what you're doing! Avoid using spaces or colons.");
+  g_VetoConfirmationTimeCvar = CreateConVar(
+      "get5_veto_confirmation_time", "0",
+      "Time (in seconds) from presenting a veto menu to a selection being made, during which a confirmation will be required, 0 to disable");
   g_WarmupCfgCvar =
       CreateConVar("get5_warmup_cfg", "get5/warmup.cfg", "Config file to exec in warmup periods");
 

--- a/scripting/get5/mapveto.sp
+++ b/scripting/get5/mapveto.sp
@@ -211,7 +211,7 @@ public int MapVetoMenuHandler(Menu menu, MenuAction action, int param1, int para
       GiveMapVetoMenu(client);
       return;
     }
-    // If a selection was made too fast, show a confirmation menu
+    // Show a confirmation menu if needed
     if (ConfirmationNeeded()) {
       GiveConfirmationMenu(client, MapVetoMenuHandler, "MapVetoBanConfirmMenuText", mapName);
       return;
@@ -273,7 +273,7 @@ public int MapPickMenuHandler(Menu menu, MenuAction action, int param1, int para
       GiveMapPickMenu(client);
       return;
     }
-    // If a selection was made too fast, show a confirmation menu
+    // Show a confirmation menu if needed
     if (ConfirmationNeeded()) {
       GiveConfirmationMenu(client, MapPickMenuHandler, "MapVetoPickConfirmMenuText", mapName);
       return;
@@ -330,7 +330,7 @@ public int SidePickMenuHandler(Menu menu, MenuAction action, int param1, int par
       GiveSidePickMenu(client);
       return;
     }
-    // If a selection was made too fast, show a confirmation menu
+    // Show a confirmation menu if needed
     if (ConfirmationNeeded()) {
       GiveConfirmationMenu(client, SidePickMenuHandler, "MapVetoSidePickConfirmMenuText", choice);
       return;

--- a/scripting/get5/mapveto.sp
+++ b/scripting/get5/mapveto.sp
@@ -19,8 +19,8 @@ public void CreateVeto() {
 
 public Action Timer_VetoCountdown(Handle timer) {
     static int warningsPrinted = 0;
-    int secondsRemaining = g_VetoCountdown.IntValue;
-    if (warningsPrinted >= g_VetoCountdown.IntValue) {
+    int secondsRemaining = g_VetoCountdownCvar.IntValue;
+    if (warningsPrinted >= g_VetoCountdownCvar.IntValue) {
         warningsPrinted = 0;
         MatchTeam startingTeam = OtherMatchTeam(g_LastVetoTeam);
         VetoController(g_VetoCaptains[startingTeam]);

--- a/scripting/get5/mapveto.sp
+++ b/scripting/get5/mapveto.sp
@@ -134,7 +134,7 @@ public void GiveConfirmationMenu(int client, MenuHandler handler, const char[] t
 
   // Add rows of padding to move selection out of "danger zone"
   for (int i = 0; i < 7; i++) {
-    menu.AddItem("spacer", "", ITEMDRAW_NOTEXT);
+    menu.AddItem(CONFIRM_NEGATIVE_VALUE, "", ITEMDRAW_NOTEXT);
   }
 
   // Add actual choices

--- a/scripting/get5/mapveto.sp
+++ b/scripting/get5/mapveto.sp
@@ -1,6 +1,9 @@
 /**
  * Map vetoing functions
  */
+
+#define CONFIRM_NEGATIVE_VALUE "_"
+
 public void CreateVeto() {
   if (g_MapPoolList.Length % 2 == 0) {
     LogError(
@@ -115,6 +118,66 @@ public void VetoController(int client) {
 }
 
 
+// Confirmations
+
+public void GiveConfirmationMenu(int client, MenuHandler handler, const char[] title, const char[] confirmChoice) {
+  // Figure out text for positive and negative values
+  char positiveBuffer[1024], negativeBuffer[1024];
+  Format(positiveBuffer, sizeof(positiveBuffer), "%T", "ConfirmPositiveOptionText", client);
+  Format(negativeBuffer, sizeof(negativeBuffer), "%T", "ConfirmNegativeOptionText", client);
+
+  // Create menu
+  Menu menu = new Menu(handler);
+  menu.SetTitle("%T", title, client, confirmChoice);
+  menu.ExitButton = false;
+  menu.Pagination = MENU_NO_PAGINATION;
+
+  // Add rows of padding to move selection out of "danger zone"
+  for (int i = 0; i < 7; i++) {
+    menu.AddItem("spacer", "", ITEMDRAW_NOTEXT);
+  }
+
+  // Add actual choices
+  menu.AddItem(confirmChoice, positiveBuffer);
+  menu.AddItem(CONFIRM_NEGATIVE_VALUE, negativeBuffer);
+
+  // Show menu and disable confirmations
+  menu.Display(client, MENU_TIME_FOREVER);
+  SetConfirmationTime(false);
+}
+
+static void SetConfirmationTime(bool enabled) {
+  if (enabled) {
+    g_VetoMenuTime = GetTickedTime();
+  } else {
+    // Set below 0 to signal that we don't want confirmation
+    g_VetoMenuTime = -1.0;
+  }
+}
+
+static bool ConfirmationNeeded() {
+  // Don't give confirmations if it's been disabled
+  if (g_VetoConfirmationTimeCvar.IntValue == 0) {
+    return false;
+  }
+  // Don't give confirmation if the veto time is less than 0
+  // (in case we're presenting a menu that doesn't need confirmation)
+  if (g_VetoMenuTime < 0.0) {
+    return false;
+  }
+
+  // Figure out if we need to require a confirmation. Round to ceiling
+  // since the convar is an integer, and we don't want e.g. 2.1 seconds to
+  // be equal or less than a setting of 2
+  int diff = RoundToCeil(GetTickedTime() - g_VetoMenuTime);
+  return diff <= g_VetoConfirmationTimeCvar.IntValue;
+}
+
+static bool ConfirmationNegative(const char[] choice) {
+  return StrEqual(choice, CONFIRM_NEGATIVE_VALUE);
+}
+
+
 // Map Vetos
 
 public void GiveMapVetoMenu(int client) {
@@ -133,16 +196,29 @@ public void GiveMapVetoMenu(int client) {
     menu.AddItem(mapName, mapName);
   }
   menu.Display(client, MENU_TIME_FOREVER);
+  SetConfirmationTime(true);
 }
 
 public int MapVetoMenuHandler(Menu menu, MenuAction action, int param1, int param2) {
   if (action == MenuAction_Select) {
     int client = param1;
+    MatchTeam team = GetClientMatchTeam(client);
     char mapName[PLATFORM_MAX_PATH];
     menu.GetItem(param2, mapName, sizeof(mapName));
+
+    // Go back if we were called from a confirmation menu and client selected no
+    if (ConfirmationNegative(mapName)) {
+      GiveMapVetoMenu(client);
+      return;
+    }
+    // If a selection was made too fast, show a confirmation menu
+    if (ConfirmationNeeded()) {
+      GiveConfirmationMenu(client, MapVetoMenuHandler, "MapVetoBanConfirmMenuText", mapName);
+      return;
+    }
+
     RemoveStringFromArray(g_MapsLeftInVetoPool, mapName);
 
-    MatchTeam team = GetClientMatchTeam(client);
     Get5_MessageToAll("%t", "TeamVetoedMapInfoMessage", g_FormattedTeamNames[team], mapName);
 
     EventLogger_MapVetoed(team, mapName);
@@ -182,6 +258,7 @@ public void GiveMapPickMenu(int client) {
     menu.AddItem(mapName, mapName);
   }
   menu.Display(client, MENU_TIME_FOREVER);
+  SetConfirmationTime(true);
 }
 
 public int MapPickMenuHandler(Menu menu, MenuAction action, int param1, int param2) {
@@ -190,6 +267,17 @@ public int MapPickMenuHandler(Menu menu, MenuAction action, int param1, int para
     MatchTeam team = GetClientMatchTeam(client);
     char mapName[PLATFORM_MAX_PATH];
     menu.GetItem(param2, mapName, sizeof(mapName));
+
+    // Go back if we were called from a confirmation menu and client selected no
+    if (ConfirmationNegative(mapName)) {
+      GiveMapPickMenu(client);
+      return;
+    }
+    // If a selection was made too fast, show a confirmation menu
+    if (ConfirmationNeeded()) {
+      GiveConfirmationMenu(client, MapPickMenuHandler, "MapVetoPickConfirmMenuText", mapName);
+      return;
+    }
 
     g_MapsToPlay.PushString(mapName);
     RemoveStringFromArray(g_MapsLeftInVetoPool, mapName);
@@ -227,17 +315,28 @@ public void GiveSidePickMenu(int client) {
   menu.AddItem("CT", "CT");
   menu.AddItem("T", "T");
   menu.Display(client, MENU_TIME_FOREVER);
+  SetConfirmationTime(true);
 }
 
 public int SidePickMenuHandler(Menu menu, MenuAction action, int param1, int param2) {
   if (action == MenuAction_Select) {
     int client = param1;
     MatchTeam team = GetClientMatchTeam(client);
-
     char choice[PLATFORM_MAX_PATH];
     menu.GetItem(param2, choice, sizeof(choice));
-    int selectedSide;
 
+    // Go back if we were called from a confirmation menu and client selected no
+    if (ConfirmationNegative(choice)) {
+      GiveSidePickMenu(client);
+      return;
+    }
+    // If a selection was made too fast, show a confirmation menu
+    if (ConfirmationNeeded()) {
+      GiveConfirmationMenu(client, SidePickMenuHandler, "MapVetoSidePickConfirmMenuText", choice);
+      return;
+    }
+
+    int selectedSide;
     if (StrEqual(choice, "CT")) {
       selectedSide = CS_TEAM_CT;
       if (team == MatchTeam_Team1)

--- a/translations/get5.phrases.txt
+++ b/translations/get5.phrases.txt
@@ -321,13 +321,36 @@
     {
         "en"        "Select a map to PLAY:"
     }
+    "MapVetoPickConfirmMenuText"
+    {
+        "#format"       "{1:s}"
+        "en"        "Confirm you want to PLAY {1}:"
+    }
     "MapVetoBanMenuText"
     {
         "en"        "Select a map to VETO:"
+    }
+    "MapVetoBanConfirmMenuText"
+    {
+        "#format"       "{1:s}"
+        "en"        "Confirm you want to VETO {1}:"
     }
     "MapVetoSidePickMenuText"
     {
         "#format"       "{1:s}"
         "en"        "Select a side for {1}"
+    }
+    "MapVetoSidePickConfirmMenuText"
+    {
+        "#format"       "{1:s}"
+        "en"        "Confirm you want to start {1}:"
+    }
+    "ConfirmPositiveOptionText"
+    {
+        "en"        "Yes"
+    }
+    "ConfirmNegativeOptionText"
+    {
+        "en"        "No"
     }
 }


### PR DESCRIPTION
Introduces a new setting get5_veto_confirmation_time, which is the time
in seconds from a menu has been presented to a choice is made, that will
result in a confirmation menu.

If set to 0, confirmations will never be shown. If set to a high number
(e.g. 3600 for an hour), confirmations will always be shown. Set to a
small value (e.g. 1 or 2) to prevent accidental vetos/picks, when a
player doesn't notice the menu while spamming buttons `1` through `5`.

Menu titles and options are customizable and translatable, and the
yes/no options are placed on button 8 and 9 respectively, to make sure
they won't get chosen by mistake.

Relates to: splewis/get5#122