### PR TITLE
Handle ties correctly

### DIFF
--- a/scripting/get5/teamlogic.sp
+++ b/scripting/get5/teamlogic.sp
@@ -321,11 +321,11 @@ public int GetMapScore(int mapNumber, MatchTeam team) {
 }
 
 public bool HasMapScore(int mapNumber) {
-  return GetMapScore(mapNumber, MatchTeam_Team1) != 0 || GetMapScore(mapNumber, MatchTeam_Team2);
+  return GetMapScore(mapNumber, MatchTeam_Team1) != 0 || GetMapScore(mapNumber, MatchTeam_Team2) != 0;
 }
 
 public int GetMapNumber() {
-  return g_TeamSeriesScores[MatchTeam_Team1] + g_TeamSeriesScores[MatchTeam_Team2];
+  return g_TeamSeriesScores[MatchTeam_Team1] + g_TeamSeriesScores[MatchTeam_Team2] + g_TeamSeriesScores[MatchTeam_TeamNone];
 }
 
 public bool AddPlayerToTeam(const char[] auth, MatchTeam team) {

--- a/scripting/get5_apistats.sp
+++ b/scripting/get5_apistats.sp
@@ -360,9 +360,10 @@ public void Get5_OnRoundStatsUpdated() {
 }
 
 static int MapNumber() {
-  int t1, t2;
+  int t1, t2, n;
   int buf;
   Get5_GetTeamScores(MatchTeam_Team1, t1, buf);
   Get5_GetTeamScores(MatchTeam_Team2, t2, buf);
-  return t1 + t2;
+  Get5_GetTeamScores(MatchTeam_TeamNone, n, buf);
+  return t1 + t2 + n;
 }

--- a/translations/get5.phrases.txt
+++ b/translations/get5.phrases.txt
@@ -204,6 +204,11 @@
         "#format"       "{1:s}"
         "en"            "{1} has won the match."
     }
+    "TeamTiedMatchInfoMessage"
+    {
+        "#format"       "{1:s},{2:s}"
+        "en"            "{1} and {2} have tied the match."
+    }
     "TeamsSplitSeriesBO2InfoMessage"
     {
         "#format"       "{1:s},{2:s}"


### PR DESCRIPTION
Turns out it was not just a matter of sending none through the api. Once
that was done, the tied map was no longer counted, and thus, the map
number never increased, and the series never ended.

This fixes that.