### PR TITLE
Fixed readycheck system to only use one timer instead of a timer per team.

### DIFF
--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -150,7 +150,7 @@ bool g_TeamReadyForUnpause[MatchTeam_Count];
 bool g_TeamGivenStopCommand[MatchTeam_Count];
 int g_TeamPauseTimeUsed[MatchTeam_Count];
 int g_TeamPausesUsed[MatchTeam_Count];
-int g_ReadyTimeWaitingUsed[MatchTeam_Count];
+int g_ReadyTimeWaitingUsed = 0;
 char g_DefaultTeamColors[][] = {
     TEAM1_COLOR, TEAM2_COLOR, "{NORMAL}", "{NORMAL}",
 };
@@ -541,7 +541,6 @@ public void OnMapStart() {
     g_TeamReadyForUnpause[team] = false;
     g_TeamPauseTimeUsed[team] = 0;
     g_TeamPausesUsed[team] = 0;
-    g_ReadyTimeWaitingUsed[team] = 0;
   }
 
   if (g_WaitingForRoundBackup) {
@@ -610,6 +609,7 @@ public Action Timer_CheckReady(Handle timer) {
 
 static void CheckReadyWaitingTimes() {
   if (g_TeamTimeToStartCvar.IntValue > 0) {
+    g_ReadyTimeWaitingUsed++;
     CheckReadyWaitingTime(MatchTeam_Team1);
     CheckReadyWaitingTime(MatchTeam_Team2);
   }
@@ -617,8 +617,7 @@ static void CheckReadyWaitingTimes() {
 
 static void CheckReadyWaitingTime(MatchTeam team) {
   if (!IsTeamReady(team) && g_GameState != GameState_None) {
-    g_ReadyTimeWaitingUsed[team]++;
-    int timeLeft = g_TeamTimeToStartCvar.IntValue - g_ReadyTimeWaitingUsed[team];
+    int timeLeft = g_TeamTimeToStartCvar.IntValue - g_ReadyTimeWaitingUsed;
 
     if (timeLeft <= 0) {
       Get5_MessageToAll("%t", "TeamForfeitInfoMessage", g_FormattedTeamNames[team]);

--- a/scripting/get5/matchconfig.sp
+++ b/scripting/get5/matchconfig.sp
@@ -22,7 +22,6 @@ stock bool LoadMatchConfig(const char[] config, bool restoreBackup = false) {
     g_TeamGivenStopCommand[team] = false;
     g_TeamPauseTimeUsed[team] = 0;
     g_TeamPausesUsed[team] = 0;
-    g_ReadyTimeWaitingUsed[team] = 0;
     ClearArray(GetTeamAuths(team));
   }
 

--- a/scripting/get5/readysystem.sp
+++ b/scripting/get5/readysystem.sp
@@ -5,6 +5,7 @@
 public void ResetReadyStatus() {
   SetAllTeamsForcedReady(false);
   SetAllClientsReady(false);
+  g_ReadyTimeWaitingUsed = 0;
 }
 
 public bool IsReadyGameState() {


### PR DESCRIPTION
Fixes the issue #160.

I removed the g_ReadyTimeWaitingUsed[MatchTeam_Count] and replaced it with g_ReadyTimeWaitingUsed. I didn't see that there was any use for the seperate timer per team instead of one(unless it was planned for future release). 

And hopefully I didn't break anything else in the process.
