### PR TITLE
Attempt to resolve last round backup of each map

### DIFF
--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -823,13 +823,15 @@ public Action Event_MatchOver(Event event, const char[] name, bool dontBroadcast
       winningTeam = MatchTeam_Team2;
     }
 
+    //Write backup before series score increments
+    WriteBackup();
+    
     // Update series scores
     Stats_UpdateMapScore(winningTeam);
     AddMapScore();
     g_TeamSeriesScores[winningTeam]++;
 
-    // Handle map end
-    WriteBackup();
+    //Handle map end
 
     EventLogger_MapEnd(winningTeam);
 


### PR DESCRIPTION
Before, the last round of each map would write the map number as 2 if the current map was actually still map 1. This is because the way it calculates map# uses the series scores of each team. To fix this we just write the backup prior to the series score being incremented.

The issue this causes if we do not fix it is that, say map 1 goes 23 rounds and map 2 goes 25 rounds, the backup will be written over as the filename would be the same.