### PR TITLE
Deprecated sv_alltalk

### DIFF
--- a/cfg/get5/warmup.cfg
+++ b/cfg/get5/warmup.cfg
@@ -10,7 +10,7 @@ mp_spectators_max 20
 mp_startmoney 16000
 mp_timelimit 0
 mp_warmuptime_all_players_connected 0
-sv_alltalk 1
+sv_talk_enemy_living 1
 sv_auto_full_alltalk_during_warmup_half_end 1
 sv_coaching_enabled 1
 sv_competitive_official_5v5 1


### PR DESCRIPTION
"sv_alltalk" = "0" game notify replicated                                        - Deprecated. Replaced with sv_talk_enemy_dead and sv_talk_enemy_living.