### PR TITLE
Indicate the reason a round ended

### DIFF
--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -1068,6 +1068,7 @@ public Action Event_RoundEnd(Event event, const char[] name, bool dontBroadcast)
 
   if (g_GameState == GameState_Live) {
     int csTeamWinner = event.GetInt("winner");
+    int csReason = event.GetInt("reason");
 
     Get5_MessageToAll("%t", "CurrentScoreInfoMessage", g_TeamNames[MatchTeam_Team1],
                       CS_GetTeamScore(MatchTeamToCSTeam(MatchTeam_Team1)),
@@ -1078,7 +1079,7 @@ public Action Event_RoundEnd(Event event, const char[] name, bool dontBroadcast)
     Call_StartForward(g_OnRoundStatsUpdated);
     Call_Finish();
 
-    EventLogger_RoundEnd(csTeamWinner);
+    EventLogger_RoundEnd(csTeamWinner, csReason);
 
     int roundsPlayed = GameRules_GetProp("m_totalRoundsPlayed");
     LogDebug("m_totalRoundsPlayed = %d", roundsPlayed);

--- a/scripting/get5/eventlogger.sp
+++ b/scripting/get5/eventlogger.sp
@@ -136,11 +136,12 @@ public void EventLogger_PlayerDeath(int killer, int victim, bool headshot, int a
   EventLogger_EndEvent("player_death");
 }
 
-public void EventLogger_RoundEnd(int csTeamWinner) {
+public void EventLogger_RoundEnd(int csTeamWinner, int csReason) {
   EventLogger_StartEvent();
   AddMapData(params);
   AddCSTeam(params, "winner_side", csTeamWinner);
   AddTeam(params, "winner", CSTeamToMatchTeam(csTeamWinner));
+  set_json_int(params, "reason", csReason);
   set_json_int(params, "team1_score", CS_GetTeamScore(MatchTeamToCSTeam(MatchTeam_Team1)));
   set_json_int(params, "team2_score", CS_GetTeamScore(MatchTeamToCSTeam(MatchTeam_Team2)));
   EventLogger_EndEvent("round_end");


### PR DESCRIPTION
Get the reason a round ended as indicate in SourceMod: [https://sm.alliedmods.net/new-api/cstrike/CSRoundEndReason](https://sm.alliedmods.net/new-api/cstrike/CSRoundEndReason) (1 indexed) so the reason can be retrieved in the `round_end` event and `Get5_OnEvent` hook.
[Events log section](https://github.com/splewis/get5/wiki/Event-logs#map-flow) should be updated if this pull request is merged to show the param is availabe.