### PR TITLE
Fix get5_apistats build

### DIFF
--- a/scripting/get5_apistats.sp
+++ b/scripting/get5_apistats.sp
@@ -22,6 +22,7 @@
 #include "include/logdebug.inc"
 #include <cstrike>
 #include <sourcemod>
+#include <sdktools>
 
 
 #include "get5/util.sp"


### PR DESCRIPTION
Add missing sdktools reference on get5_apistats that causes `undefined symbol "GameRules_GetProp"`