### PR TITLE
Adjusted the SetPlayer function to force name change.

### DIFF
--- a/scripting/get5/natives.sp
+++ b/scripting/get5/natives.sp
@@ -141,10 +141,21 @@ public int Native_SetPlayerName(Handle plugin, int numParams) {
   char name[MAX_NAME_LENGTH];
   GetNativeString(1, auth, sizeof(auth));
   GetNativeString(2, name, sizeof(name));
+  char nameFile[] = "get5_names.txt";
+  KeyValues namesKv = new KeyValues("Names");
   char steam64[AUTH_LENGTH];
   ConvertAuthToSteam64(auth, steam64);
   if (strlen(name) > 0 && !StrEqual(name, KEYVALUE_STRING_PLACEHOLDER)) {
     g_PlayerNames.SetString(steam64, name);
+    // Create temp namesKv to only load one name at a time, 
+    // instead of loading in every PlayerName.
+    namesKv.SetString(steam64, name);
+    DeleteFile(nameFile);
+    if (namesKv.ExportToFile(nameFile)) {
+      ServerCommand("sv_load_forced_client_names_file %s", nameFile);
+    } else {
+      LogError("Failed to write names keyvalue file to %s", nameFile);
+    }
   }
 }
 

--- a/scripting/get5/natives.sp
+++ b/scripting/get5/natives.sp
@@ -151,11 +151,11 @@ public int Native_SetPlayerName(Handle plugin, int numParams) {
         namesKv.ImportFromFile(nameFile);
         DeleteFile(nameFile);
         if(namesKv.JumpToKey(steam64)) {
-            namesKv.DeleteThis();
-	          namesKv.Rewind();
-            namesKv.SetString(steam64, name);
+          namesKv.DeleteThis();
+          namesKv.Rewind();
+          namesKv.SetString(steam64, name);
         } else {
-            namesKv.SetString(steam64, name);
+          namesKv.SetString(steam64, name);
         }
     } else {
       namesKv.SetString(steam64, name);
@@ -165,6 +165,7 @@ public int Native_SetPlayerName(Handle plugin, int numParams) {
     }
   }
 }
+
 
 public int Native_RemovePlayerFromTeam(Handle plugin, int numParams) {
   char auth[AUTH_LENGTH];

--- a/scripting/get5/natives.sp
+++ b/scripting/get5/natives.sp
@@ -139,30 +139,13 @@ public int Native_AddPlayerToTeam(Handle plugin, int numParams) {
 public int Native_SetPlayerName(Handle plugin, int numParams) {
   char auth[AUTH_LENGTH];
   char name[MAX_NAME_LENGTH];
-  KeyValues namesKv = new KeyValues("Names");
-  char nameFile[] = "get5_names.txt";
   GetNativeString(1, auth, sizeof(auth));
   GetNativeString(2, name, sizeof(name));
   char steam64[AUTH_LENGTH];
   ConvertAuthToSteam64(auth, steam64);
   if (strlen(name) > 0 && !StrEqual(name, KEYVALUE_STRING_PLACEHOLDER)) {
     g_PlayerNames.SetString(steam64, name);
-    if(FileExists(nameFile)) {
-        namesKv.ImportFromFile(nameFile);
-        DeleteFile(nameFile);
-        if(namesKv.JumpToKey(steam64)) {
-          namesKv.DeleteThis();
-          namesKv.Rewind();
-          namesKv.SetString(steam64, name);
-        } else {
-          namesKv.SetString(steam64, name);
-        }
-    } else {
-      namesKv.SetString(steam64, name);
-    }
-    if(namesKv.ExportToFile(nameFile)) {
-      ServerCommand("sv_load_forced_client_names_file %s", nameFile);
-    }
+    LoadPlayerNames();
   }
 }
 

--- a/scripting/get5/natives.sp
+++ b/scripting/get5/natives.sp
@@ -141,21 +141,11 @@ public int Native_SetPlayerName(Handle plugin, int numParams) {
   char name[MAX_NAME_LENGTH];
   GetNativeString(1, auth, sizeof(auth));
   GetNativeString(2, name, sizeof(name));
-  char nameFile[] = "get5_names.txt";
-  KeyValues namesKv = new KeyValues("Names");
   char steam64[AUTH_LENGTH];
   ConvertAuthToSteam64(auth, steam64);
   if (strlen(name) > 0 && !StrEqual(name, KEYVALUE_STRING_PLACEHOLDER)) {
     g_PlayerNames.SetString(steam64, name);
-    // Create temp namesKv to only load one name at a time, 
-    // instead of loading in every PlayerName.
-    namesKv.SetString(steam64, name);
-    DeleteFile(nameFile);
-    if (namesKv.ExportToFile(nameFile)) {
-      ServerCommand("sv_load_forced_client_names_file %s", nameFile);
-    } else {
-      LogError("Failed to write names keyvalue file to %s", nameFile);
-    }
+    LoadPlayerNames();
   }
 }
 

--- a/scripting/get5/natives.sp
+++ b/scripting/get5/natives.sp
@@ -139,13 +139,30 @@ public int Native_AddPlayerToTeam(Handle plugin, int numParams) {
 public int Native_SetPlayerName(Handle plugin, int numParams) {
   char auth[AUTH_LENGTH];
   char name[MAX_NAME_LENGTH];
+  KeyValues namesKv = new KeyValues("Names");
+  char nameFile[] = "get5_names.txt";
   GetNativeString(1, auth, sizeof(auth));
   GetNativeString(2, name, sizeof(name));
   char steam64[AUTH_LENGTH];
   ConvertAuthToSteam64(auth, steam64);
   if (strlen(name) > 0 && !StrEqual(name, KEYVALUE_STRING_PLACEHOLDER)) {
     g_PlayerNames.SetString(steam64, name);
-    LoadPlayerNames();
+    if(FileExists(nameFile)) {
+        namesKv.ImportFromFile(nameFile);
+        DeleteFile(nameFile);
+        if(namesKv.JumpToKey(steam64)) {
+            namesKv.DeleteThis();
+	          namesKv.Rewind();
+            namesKv.SetString(steam64, name);
+        } else {
+            namesKv.SetString(steam64, name);
+        }
+    } else {
+      namesKv.SetString(steam64, name);
+    }
+    if(namesKv.ExportToFile(nameFile)) {
+      ServerCommand("sv_load_forced_client_names_file %s", nameFile);
+    }
   }
 }
 

--- a/scripting/get5/teamlogic.sp
+++ b/scripting/get5/teamlogic.sp
@@ -348,6 +348,7 @@ public bool AddPlayerToTeam(const char[] auth, MatchTeam team, const char[] name
   if (GetAuthMatchTeam(steam64) == MatchTeam_TeamNone) {
     GetTeamAuths(team).PushString(steam64);
     Get5_SetPlayerName(auth, name);
+    LoadPlayerNames();
     return true;
   } else {
     return false;

--- a/scripting/get5/teamlogic.sp
+++ b/scripting/get5/teamlogic.sp
@@ -348,7 +348,6 @@ public bool AddPlayerToTeam(const char[] auth, MatchTeam team, const char[] name
   if (GetAuthMatchTeam(steam64) == MatchTeam_TeamNone) {
     GetTeamAuths(team).PushString(steam64);
     Get5_SetPlayerName(auth, name);
-    LoadPlayerNames();
     return true;
   } else {
     return false;


### PR DESCRIPTION
It is now reloading the playernames in the given kV list, so users names can be custom once they are added, without having to reinit the match, or not have them load at all.

Tested with adding one player to a team after create match. Console reports sv_load_forced_client_names_file: loaded 1 client name(s) to enforce!

