### PR TITLE
Absolute ready timer

### DIFF
--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -697,8 +697,7 @@ static void CheckReadyWaitingTimes() {
     if (team1Forfeited && team2Forfeited)
     {
       g_ForcedWinner = MatchTeam_TeamNone;
-      Stats_Forfeit(MatchTeam_Team1);
-      Stats_Forfeit(MatchTeam_Team2);
+      Stats_Forfeit(MatchTeam_None);
     }
     else if (team1Forfeited)
     {

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -693,8 +693,7 @@ static void CheckReadyWaitingTimes() {
 
     if (team1Forfeited && team2Forfeited) {
       g_ForcedWinner = MatchTeam_TeamNone;
-      Stats_Forfeit(MatchTeam_Team1);
-      Stats_Forfeit(MatchTeam_Team2);
+      Stats_Forfeit(MatchTeam_TeamNone);
     } else if (team1Forfeited) {
       g_ForcedWinner = MatchTeam_Team2;
       Stats_Forfeit(MatchTeam_Team1);

--- a/scripting/get5/debug.sp
+++ b/scripting/get5/debug.sp
@@ -114,6 +114,7 @@ static void AddGlobalStateInfo(File f) {
   f.WriteLine("g_WaitingForRoundBackup = %d", g_WaitingForRoundBackup);
   f.WriteLine("g_SavedValveBackup = %d", g_SavedValveBackup);
   f.WriteLine("g_DoingBackupRestoreNow = %d", g_DoingBackupRestoreNow);
+  f.WriteLine("g_ReadyTimeWaitingUsed = %d", g_ReadyTimeWaitingUsed);
 
   LOOP_TEAMS(team) {
     GetTeamString(team, buffer, sizeof(buffer));
@@ -133,7 +134,6 @@ static void AddGlobalStateInfo(File f) {
     f.WriteLine("g_TeamStartingSide = %d", g_TeamStartingSide[team]);
     f.WriteLine("g_TeamPauseTimeUsed = %d", g_TeamPauseTimeUsed[team]);
     f.WriteLine("g_TeamPausesUsed = %d", g_TeamPausesUsed[team]);
-    f.WriteLine("g_ReadyTimeWaitingUsed = %d", g_ReadyTimeWaitingUsed[team]);
   }
 }
 

--- a/scripting/get5/matchconfig.sp
+++ b/scripting/get5/matchconfig.sp
@@ -22,10 +22,10 @@ stock bool LoadMatchConfig(const char[] config, bool restoreBackup = false) {
     g_TeamGivenStopCommand[team] = false;
     g_TeamPauseTimeUsed[team] = 0;
     g_TeamPausesUsed[team] = 0;
-    g_ReadyTimeWaitingUsed[team] = 0;
     ClearArray(GetTeamAuths(team));
   }
 
+  g_ReadyTimeWaitingUsed = 0;
   g_ForceWinnerSignal = false;
   g_ForcedWinner = MatchTeam_TeamNone;
 


### PR DESCRIPTION
Sounds related to #160.

This PR replace the two independent time pools by an absolute one in order to bring a more consistent behaviour as well as preventing any stalling with the ready time.

Here are the problems we encountered with the original logic:
* If both teams ready up and then unready, the team that was ready for the most time is declared as winner. This is odd for the players as the winner seem to be randomly picked, it sound logical that both team should be forfeited
* With ready check set to N seconds, it is technically possible to stall the match for (N * 2) - 1 seconds. If you also take into account that the ready check seem to be reset when the first player join the server, you can go up to (N * 3) - 1
* If both team don't ready up, Team 1 is declared as winner. This gives an advantage to a team that was not ready as well as not properly detecting the case where both team do not show up - this was a killer for us

The single absolute timer fixes all of these problems by simply checking that after the specified time any team that is not ready is forfeited, no matter how long they were ready for or if they have been ready before.

While I can understand that replacing a behaviour is potentially annoying for existing setups, I would argue that the previous logic had several flaws while arguably not bringing much (except the feature itself of course).

Thanks for Get5, we really like it over here and though we could help to make it better ;)