### PR TITLE
Added auto ready after map veto config option.

### DIFF
--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -81,6 +81,7 @@ ConVar g_TimeFormatCvar;
 ConVar g_VetoConfirmationTimeCvar;
 ConVar g_VetoCountdownCvar;
 ConVar g_WarmupCfgCvar;
+ConVar g_AutoReadyAfterVetoCvar;
 
 // Autoset convars (not meant for users to set)
 ConVar g_GameStateCvar;
@@ -329,7 +330,9 @@ public void OnPluginStart() {
       CreateConVar("get5_veto_countdown", "5",
                    "Seconds to countdown before veto process commences. Set to \"0\" to disable.");
   g_WarmupCfgCvar =
-      CreateConVar("get5_warmup_cfg", "get5/warmup.cfg", "Config file to exec in warmup periods");
+      CreateConVar("get5_warmup_cfg", "get5/warmup.cfg", "Config file to exec in warmup periods");  
+  g_AutoReadyAfterVetoCvar = CreateConVar("get5_autoready_after_veto", "0",
+                                            "Auto ready after map veto");
 
   /** Create and exec plugin's configuration file **/
   AutoExecConfig(true, "get5");

--- a/scripting/get5/mapveto.sp
+++ b/scripting/get5/mapveto.sp
@@ -41,6 +41,10 @@ static void AbortVeto() {
 public void VetoFinished() {
   ChangeState(Get5State_Warmup);
   Get5_MessageToAll("%t", "MapDecidedInfoMessage");
+  
+  if (g_AutoReadyAfterVetoCvar.BoolValue) { 
+      SetAllClientsReady(true);
+  }
 
   // Use total series score as starting point, to not print skipped maps
   int seriesScore = g_TeamSeriesScores[MatchTeam_Team1] + g_TeamSeriesScores[MatchTeam_Team2];


### PR DESCRIPTION
This option is added due to the following flow when having map veto: players join and have 10 minutes to ready up. Veto commences and map changes. Then there is 10 new minutes where the player has to ready up again. We want a fast-track approach where we expect every player to be ready after veto.