### PR TITLE
Added option to skip resetting ready state on map veto.

### DIFF
--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -81,6 +81,7 @@ ConVar g_TimeFormatCvar;
 ConVar g_VetoConfirmationTimeCvar;
 ConVar g_VetoCountdownCvar;
 ConVar g_WarmupCfgCvar;
+ConVar g_ResetReadyStateOnMapVetoCvar;
 
 // Autoset convars (not meant for users to set)
 ConVar g_GameStateCvar;
@@ -330,6 +331,8 @@ public void OnPluginStart() {
                    "Seconds to countdown before veto process commences. Set to \"0\" to disable.");
   g_WarmupCfgCvar =
       CreateConVar("get5_warmup_cfg", "get5/warmup.cfg", "Config file to exec in warmup periods");
+
+  g_ResetReadyStateOnMapVetoCvar = CreateConVar("get5_reset_ready_on_veto", "1", "Reset ready state on map veto. Set to \"0\" to disable.");
 
   /** Create and exec plugin's configuration file **/
   AutoExecConfig(true, "get5");

--- a/scripting/get5/mapveto.sp
+++ b/scripting/get5/mapveto.sp
@@ -13,7 +13,11 @@ public void CreateVeto() {
 
   g_VetoCaptains[MatchTeam_Team1] = GetTeamCaptain(MatchTeam_Team1);
   g_VetoCaptains[MatchTeam_Team2] = GetTeamCaptain(MatchTeam_Team2);
-  ResetReadyStatus();
+
+  if (g_ResetReadyStateOnMapVetoCvar.BoolValue) { 
+    ResetReadyStatus();
+  }
+  
   CreateTimer(1.0, Timer_VetoCountdown, _, TIMER_REPEAT);
 }
 


### PR DESCRIPTION
An option to auto ready after map veto is to keep the ready state. This is to prevent users failing to understand that they have to do !ready two times before a match starts causing unwanted forfeits.