### PR TITLE
add ready events

### DIFF
--- a/scripting/get5/eventlogger.sp
+++ b/scripting/get5/eventlogger.sp
@@ -230,3 +230,20 @@ public void EventLogger_PlayerDisconnect(int client) {
   AddPlayer(params, "client", client);
   EventLogger_EndEvent("player_disconnect");
 }
+
+public void EventLogger_TeamReady(MatchTeam team, const char[] stage) {
+  EventLogger_StartEvent();
+
+  AddTeam(params, "team", team);
+  params.SetString("stage", stage);
+
+  EventLogger_EndEvent("team_ready");
+}
+
+public void EventLogger_TeamUnready(MatchTeam team) {
+  EventLogger_StartEvent();
+
+  AddTeam(params, "team", team);
+
+  EventLogger_EndEvent("team_unready");
+}

--- a/scripting/get5/readysystem.sp
+++ b/scripting/get5/readysystem.sp
@@ -147,7 +147,7 @@ public Action Command_Ready(int client, int args) {
   SetClientReady(client, true);
   if (IsTeamReady(team)) {
     SetMatchTeamCvars();
-    PrintReadyMessage(team);
+    HandleReadyMessage(team);
   }
 
   return Plugin_Handled;
@@ -167,6 +167,7 @@ public Action Command_NotReady(int client, int args) {
   if (teamWasReady) {
     SetMatchTeamCvars();
     Get5_MessageToAll("%t", "TeamNotReadyInfoMessage", g_FormattedTeamNames[team]);
+    EventLogger_TeamUnready(team);
   }
 
   return Plugin_Handled;
@@ -194,26 +195,30 @@ public Action Command_ForceReadyClient(int client, int args) {
   }
   SetTeamForcedReady(team, true);
   SetMatchTeamCvars();
-  PrintReadyMessage(team);
+  HandleReadyMessage(team);
 
   return Plugin_Handled;
 }
 
 // Messages
 
-static void PrintReadyMessage(MatchTeam team) {
+static void HandleReadyMessage(MatchTeam team) {
   CheckTeamNameStatus(team);
 
   if (g_GameState == Get5State_PreVeto) {
     Get5_MessageToAll("%t", "TeamReadyToVetoInfoMessage", g_FormattedTeamNames[team]);
+    EventLogger_TeamReady(team, "veto");
   } else if (g_GameState == Get5State_Warmup) {
     SideChoice sides = view_as<SideChoice>(g_MapSides.Get(GetMapNumber()));
     if (g_WaitingForRoundBackup) {
       Get5_MessageToAll("%t", "TeamReadyToRestoreBackupInfoMessage", g_FormattedTeamNames[team]);
+      EventLogger_TeamReady(team, "backup_restore");
     } else if (sides == SideChoice_KnifeRound) {
       Get5_MessageToAll("%t", "TeamReadyToKnifeInfoMessage", g_FormattedTeamNames[team]);
+      EventLogger_TeamReady(team, "knife");
     } else {
       Get5_MessageToAll("%t", "TeamReadyToBeginInfoMessage", g_FormattedTeamNames[team]);
+      EventLogger_TeamReady(team, "start");
     }
   }
 }


### PR DESCRIPTION
Hello

I added events for team ready/unread. We are not using strict timers and forfeits, but still in times of someone abusing the ready system we are logging it and issuing manual penalties and this helps to get get exact timing of ready/unready.

