### PR TITLE
Add JSON pretty printing

### DIFF
--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -1353,7 +1353,7 @@ public Action Command_Status(int client, int args) {
   }
 
   char buffer[4096];
-  json.Encode(buffer, sizeof(buffer));
+  json.Encode(buffer, sizeof(buffer), true);
   ReplyToCommand(client, buffer);
 
   json.Cleanup();

--- a/scripting/get5_apistats.sp
+++ b/scripting/get5_apistats.sp
@@ -86,7 +86,7 @@ public Action Command_Avaliable(int client, int args) {
   json.SetString("plugin_version", versionString);
 
   char buffer[128];
-  json.Encode(buffer, sizeof(buffer));
+  json.Encode(buffer, sizeof(buffer), true);
   ReplyToCommand(client, buffer);
 
   delete json;


### PR DESCRIPTION
I recently found the [issue](/splewis/get5/issues/253#issuecomment-413752703) discussing the move to sm-json, and one of the caveats mentioned was the lack of indentation/line breaks in JSON output. Pretty printing has been possible for a while now as per the [docs](/clugg/sm-json#pretty-printing).

I believe both buffers are big enough to hold the encoded contents of the objects but I would recommend further testing just to be safe. I also found a third instance of json.Encode [here](/splewis/get5/blob/68472315e38426454d5624cb1c98f0e51871ca13/scripting/get5/eventlogger.sp#L15) but I assumed this wouldn't require pretty printing since it is only stored in logs.