### PR TITLE
Reset g_HasKnifeRoundStarted when knife round ends

### DIFF
--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -1142,6 +1142,8 @@ public Action Event_RoundEnd(Event event, const char[] name, bool dontBroadcast)
   }
 
   if (g_GameState == Get5State_KnifeRound && g_HasKnifeRoundStarted) {
+    g_HasKnifeRoundStarted = false;
+
     ChangeState(Get5State_WaitingForKnifeRoundDecision);
     CreateTimer(1.0, Timer_PostKnife);
 


### PR DESCRIPTION
I'm struggling with a hard-to-replicate bug where the knife round ends before it even starts. I haven't been able to get more debug information than seeing it happen on video yet.

You can see it for yourself here: https://www.twitch.tv/videos/543586511?t=03h56m48s

Last player readies up, the knife winner is announced before the "The knife round will begin in 5 seconds" message and it's just a mess after that.

This seems to happen only when a match has been played, ended, and another match loaded & started without restarting the server. My hunch looking at the code is that there is a race condition due to `g_HasKnifeRoundStarted` not being reset anywhere except in the knife start function.

It might be that having `mp_ignore_round_win_conditions 1` in `warmup.cfg` and `mp_ignore_round_win_conditions 0` in `knife.cfg` triggers the otherwise hidden bug, in some cases.