### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,11 +118,11 @@ See the example config in [Valve KeyValues format](configs/get5/example_match.cf
 Of the below fields, only the ``team1`` and ``team2`` fields are actually required. Reasonable defaults are used for entires (bo3 series, 5v5, empty strings for team names, etc.)
 
 - ``matchid``: a string matchid used to identify the match
-- ``num_maps``: number of maps in the series. This must be an odd number of 2.
+- ``num_maps``: number of maps in the series. This must be an odd number or 2.
 - ``maplist``: list of the maps in use (an array of strings in JSON, mapnames as keys for KeyValues), you should always use an odd-sized maplist
 - ``skip_veto``: whether the veto will be skipped and the maps will come from the maplist (in the order given)
 - ``veto_first``: either "team1", or "team2". If not set, or set to any other value, team 1 will veto first.
-- ``side_type``: either "standard", "never_knife", or "always_knife"; standard means the team that doesn't pick a map gets the side choice, never_knife means team is always on CT first, and always knife means there is always a knife round
+- ``side_type``: either "standard", "never_knife", or "always_knife"; standard means the team that doesn't pick a map gets the side choice, never_knife means team1 is always on CT first, and always knife means there is always a knife round
 - ``players_per_team``: maximum players per team (doesn't include a coach spot, default: 5)
 - ``min_players_to_ready``: minimum players a team needs to be able to ready up (default: 1)
 - ``favored_percentage_team1``: wrapper for ``mp_teamprediction_pct``


### PR DESCRIPTION
This line says that `num_maps` must be an "odd number **or** 2":

https://github.com/splewis/get5/blob/2da6d78e46bd4f82b25ee2042a7411480ec76ec6/scripting/get5/matchconfig.sp#L353

And this line says the first team to be CT when `never_knife` is set is team1.

https://github.com/splewis/get5/blob/2da6d78e46bd4f82b25ee2042a7411480ec76ec6/scripting/get5/matchconfig.sp#L90
