### PR TITLE
Delay replenishing money on spawn

### DIFF
--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -907,9 +907,13 @@ public bool RestoreLastRound() {
 public Action Event_PlayerSpawn(Event event, const char[] name, bool dontBroadcast) {
   if (g_GameState != Get5State_None && g_GameState < Get5State_KnifeRound) {
     int client = GetClientOfUserId(event.GetInt("userid"));
-    if (IsPlayer(client) && OnActiveTeam(client)) {
-      SetEntProp(client, Prop_Send, "m_iAccount", GetCvarIntSafe("mp_maxmoney"));
-    }
+    CreateTimer(0.1, Timer_ReplenishMoney, client, TIMER_FLAG_NO_MAPCHANGE);
+  }
+}
+
+public Action Timer_ReplenishMoney(Handle timer, int client) {
+  if (IsPlayer(client) && OnActiveTeam(client)) {
+    SetEntProp(client, Prop_Send, "m_iAccount", GetCvarIntSafe("mp_maxmoney"));
   }
 }
 


### PR DESCRIPTION
Currently giving 16000 to each player on spawn fails so often that I wasn't even aware this is a feature. After Googling the issue I came across a thread that said setting player money on spawn might fail because the player hasn't actually spawned yet when the event is fired and suggested adding a 0.1 second timer on it.

After adding the timer I can confirm that this fixes the issue and money is correctly replenished in warmup upon spawning.