### PR TITLE
Added Team Ready | Not Ready Tag on Team Name CVAR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.zip
 *.tar.gz
 builds
+.vscode

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -70,6 +70,7 @@ ConVar g_MaxPauseTimeCvar;
 ConVar g_MessagePrefixCvar;
 ConVar g_PausingEnabledCvar;
 ConVar g_PrettyPrintJsonCvar;
+ConVar g_ReadyTeamTag;
 ConVar g_ResetPausesEachHalfCvar;
 ConVar g_ServerIdCvar;
 ConVar g_SetClientClanTagCvar;
@@ -301,6 +302,7 @@ public void OnPluginStart() {
                    "Whether pause limits will be reset each halftime period");
   g_PausingEnabledCvar = CreateConVar("get5_pausing_enabled", "1", "Whether pausing is allowed.");
   g_PrettyPrintJsonCvar = CreateConVar("get5_pretty_print_json", "1", "Whether all JSON output is in pretty-print format.");
+  g_ReadyTeamTag; = CreateConVar("get5_ready_team_tag","1","Add [READY] [NOT READY] Tags before Team Names in Warmup");
   g_ServerIdCvar = CreateConVar(
       "get5_server_id", "0",
       "Integer that identifies your server. This is used in temp files to prevent collisions.");

--- a/scripting/get5/util.sp
+++ b/scripting/get5/util.sp
@@ -260,15 +260,21 @@ stock void SetTeamInfo(int csTeam, const char[] name, const char[] flag = "",
 
   // Add Ready/Not ready tags to team name if in warmup.
   char taggedName[MAX_CVAR_LENGTH];
-  if ((g_GameState == Get5State_Warmup || g_GameState == Get5State_PreVeto) &&
-      !g_DoingBackupRestoreNow) {
-    MatchTeam matchTeam = CSTeamToMatchTeam(csTeam);
-    if (IsTeamReady(matchTeam)) {
-      Format(taggedName, sizeof(taggedName), "%T %s", "ReadyTag", LANG_SERVER, name);
-    } else {
-      Format(taggedName, sizeof(taggedName), "%T %s", "NotReadyTag", LANG_SERVER, name);
-    }
-  } else {
+  if(g_ReadyTeamTag.BoolValue)
+  {
+      if ((g_GameState == Get5State_Warmup || g_GameState == Get5State_PreVeto) &&
+          !g_DoingBackupRestoreNow) {
+        MatchTeam matchTeam = CSTeamToMatchTeam(csTeam);
+        if (IsTeamReady(matchTeam)) {
+          Format(taggedName, sizeof(taggedName), "%T %s", "ReadyTag", LANG_SERVER, name);
+        } else {
+          Format(taggedName, sizeof(taggedName), "%T %s", "NotReadyTag", LANG_SERVER, name);
+        }
+      } else {
+        strcopy(taggedName, sizeof(taggedName), name);
+      }
+  }
+  else {
     strcopy(taggedName, sizeof(taggedName), name);
   }
 


### PR DESCRIPTION
I have added a cvar that will enable / disable Team Ready and Not Ready Status in Warmup , this is a workaround for backup loading getting Team Names again with [NOT READY].  This will not at all remove the Tags if selected as 1 and the issue still stays but instead we can completely disable this area with CVAR and remove [READY] [NOT READY] tags indirectly. 