### PR TITLE
CVAR for Team Ready Name Status and Fix Admin Immunity Kick Check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.zip
 *.tar.gz
 builds
+.vscode

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -531,13 +531,6 @@ public void OnClientAuthorized(int client, const char[] auth) {
     return;
   }
 
-  if (g_GameState == Get5State_None && g_KickClientsWithNoMatchCvar.BoolValue) {
-    if (!g_KickClientImmunity.BoolValue ||
-        !CheckCommandAccess(client, "get5_kickcheck", ADMFLAG_CHANGEMAP)) {
-      KickClient(client, "%t", "NoMatchSetupInfoMessage");
-    }
-  }
-
   if (g_GameState != Get5State_None && g_CheckAuthsCvar.BoolValue) {
     MatchTeam team = GetClientMatchTeam(client);
     if (team == MatchTeam_TeamNone) {
@@ -546,6 +539,17 @@ public void OnClientAuthorized(int client, const char[] auth) {
       int teamCount = CountPlayersOnMatchTeam(team, client);
       if (teamCount >= g_PlayersPerTeam && !g_CoachingEnabledCvar.BoolValue) {
         KickClient(client, "%t", "TeamIsFullInfoMessage");
+      }
+    }
+  }
+}
+
+public void AdminClientKickCheck(int client) {
+  if (IsPlayer(client)) {
+    if (g_GameState == Get5State_None && g_KickClientsWithNoMatchCvar.BoolValue) {
+      if (!g_KickClientImmunity.BoolValue ||
+          !CheckCommandAccess(client, "get5_kickcheck", ADMFLAG_CHANGEMAP)) {
+            KickClient(client, "%t", "NoMatchSetupInfoMessage");
       }
     }
   }
@@ -565,6 +569,10 @@ public void OnClientPutInServer(int client) {
   }
 
   Stats_ResetClientRoundValues(client);
+}
+
+public void OnClientPostAdminCheck(int client){
+  AdminClientKickCheck(client);
 }
 
 public void OnClientSayCommand_Post(int client, const char[] command, const char[] sArgs) {

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -70,6 +70,7 @@ ConVar g_MaxPauseTimeCvar;
 ConVar g_MessagePrefixCvar;
 ConVar g_PausingEnabledCvar;
 ConVar g_PrettyPrintJsonCvar;
+ConVar g_ReadyTeamTag;
 ConVar g_ResetPausesEachHalfCvar;
 ConVar g_ServerIdCvar;
 ConVar g_SetClientClanTagCvar;
@@ -296,6 +297,7 @@ public void OnPluginStart() {
                    "Maximum number of time the game can spend paused by a team, 0=unlimited");
   g_MessagePrefixCvar =
       CreateConVar("get5_message_prefix", DEFAULT_TAG, "The tag applied before plugin messages.");
+  g_ReadyTeamTag = CreateConVar ("get5_ready_team_tag", "1", "Add [READY][NOT READY] Tag before Team Names in Warmup. 0 to disable it");
   g_ResetPausesEachHalfCvar =
       CreateConVar("get5_reset_pauses_each_half", "1",
                    "Whether pause limits will be reset each halftime period");

--- a/scripting/get5/util.sp
+++ b/scripting/get5/util.sp
@@ -260,8 +260,7 @@ stock void SetTeamInfo(int csTeam, const char[] name, const char[] flag = "",
 
   // Add Ready/Not ready tags to team name if in warmup.
   char taggedName[MAX_CVAR_LENGTH];
-  if (g_ReadyTeamTag.BoolValue)
-  {
+  if (g_ReadyTeamTag.BoolValue){
     if ((g_GameState == Get5State_Warmup || g_GameState == Get5State_PreVeto) &&
         !g_DoingBackupRestoreNow) {
       MatchTeam matchTeam = CSTeamToMatchTeam(csTeam);
@@ -273,8 +272,7 @@ stock void SetTeamInfo(int csTeam, const char[] name, const char[] flag = "",
     } else {
       strcopy(taggedName, sizeof(taggedName), name);
     }
-  }
-  else {
+  } else {
     strcopy(taggedName, sizeof(taggedName), name);
   }
 

--- a/scripting/get5/util.sp
+++ b/scripting/get5/util.sp
@@ -260,15 +260,21 @@ stock void SetTeamInfo(int csTeam, const char[] name, const char[] flag = "",
 
   // Add Ready/Not ready tags to team name if in warmup.
   char taggedName[MAX_CVAR_LENGTH];
-  if ((g_GameState == Get5State_Warmup || g_GameState == Get5State_PreVeto) &&
-      !g_DoingBackupRestoreNow) {
-    MatchTeam matchTeam = CSTeamToMatchTeam(csTeam);
-    if (IsTeamReady(matchTeam)) {
-      Format(taggedName, sizeof(taggedName), "%T %s", "ReadyTag", LANG_SERVER, name);
+  if (g_ReadyTeamTag.BoolValue)
+  {
+    if ((g_GameState == Get5State_Warmup || g_GameState == Get5State_PreVeto) &&
+        !g_DoingBackupRestoreNow) {
+      MatchTeam matchTeam = CSTeamToMatchTeam(csTeam);
+      if (IsTeamReady(matchTeam)) {
+        Format(taggedName, sizeof(taggedName), "%T %s", "ReadyTag", LANG_SERVER, name);
+      } else {
+        Format(taggedName, sizeof(taggedName), "%T %s", "NotReadyTag", LANG_SERVER, name);
+      }
     } else {
-      Format(taggedName, sizeof(taggedName), "%T %s", "NotReadyTag", LANG_SERVER, name);
+      strcopy(taggedName, sizeof(taggedName), name);
     }
-  } else {
+  }
+  else {
     strcopy(taggedName, sizeof(taggedName), name);
   }
 


### PR DESCRIPTION
Added CVAR for Team Ready and Not Ready Status in warmup. The reason why i added this is a small workaround for [NOT READY] getting displayed after Round restores. This will disable the part if people dont want to use [READY] [NOT READY] on Team Names in Warmups.