### PR TITLE
Fixed black screen error when no match setup

### DIFF
--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -530,7 +530,7 @@ public void OnClientAuthorized(int client, const char[] auth) {
   }
 
   if (g_GameState == Get5State_None && g_KickClientsWithNoMatchCvar.BoolValue) {
-    if (!g_KickClientImmunity.BoolValue &&
+    if (!g_KickClientImmunity.BoolValue ||
         !CheckCommandAccess(client, "get5_kickcheck", ADMFLAG_CHANGEMAP)) {
       KickClient(client, "%t", "NoMatchSetupInfoMessage");
     }


### PR DESCRIPTION
I'm not really sure why this was changed before but it was just allowing anyone to join the server even when there was no match setup