### PR TITLE
Added CVAR to enable [READY] tags in Team Names

### DIFF
--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -70,6 +70,7 @@ ConVar g_MaxPauseTimeCvar;
 ConVar g_MessagePrefixCvar;
 ConVar g_PausingEnabledCvar;
 ConVar g_PrettyPrintJsonCvar;
+ConVar g_ReadyTeamTag;
 ConVar g_ResetPausesEachHalfCvar;
 ConVar g_ServerIdCvar;
 ConVar g_SetClientClanTagCvar;
@@ -296,6 +297,7 @@ public void OnPluginStart() {
                    "Maximum number of time the game can spend paused by a team, 0=unlimited");
   g_MessagePrefixCvar =
       CreateConVar("get5_message_prefix", DEFAULT_TAG, "The tag applied before plugin messages.");
+   g_ReadyTeamTag = CreateConVar ("get5_ready_team_tag", "1", "Add [READY][NOT READY] Tag before Team Names in Warmup. 0 to disable it");
   g_ResetPausesEachHalfCvar =
       CreateConVar("get5_reset_pauses_each_half", "1",
                    "Whether pause limits will be reset each halftime period");

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -297,7 +297,7 @@ public void OnPluginStart() {
                    "Maximum number of time the game can spend paused by a team, 0=unlimited");
   g_MessagePrefixCvar =
       CreateConVar("get5_message_prefix", DEFAULT_TAG, "The tag applied before plugin messages.");
-   g_ReadyTeamTag =
+  g_ReadyTeamTag =
       CreateConVar("get5_ready_team_tag", "1", "Add [READY][NOT READY] Tag before Team Names in Warmup. 0 to disable it");
   g_ResetPausesEachHalfCvar =
       CreateConVar("get5_reset_pauses_each_half", "1",

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -297,7 +297,7 @@ public void OnPluginStart() {
                    "Maximum number of time the game can spend paused by a team, 0=unlimited");
   g_MessagePrefixCvar =
       CreateConVar("get5_message_prefix", DEFAULT_TAG, "The tag applied before plugin messages.");
-   g_ReadyTeamTag = 
+   g_ReadyTeamTag =
       CreateConVar ("get5_ready_team_tag", "1", "Add [READY][NOT READY] Tag before Team Names in Warmup. 0 to disable it");
   g_ResetPausesEachHalfCvar =
       CreateConVar("get5_reset_pauses_each_half", "1",

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -297,7 +297,8 @@ public void OnPluginStart() {
                    "Maximum number of time the game can spend paused by a team, 0=unlimited");
   g_MessagePrefixCvar =
       CreateConVar("get5_message_prefix", DEFAULT_TAG, "The tag applied before plugin messages.");
-   g_ReadyTeamTag = CreateConVar ("get5_ready_team_tag", "1", "Add [READY][NOT READY] Tag before Team Names in Warmup. 0 to disable it");
+   g_ReadyTeamTag = 
+      CreateConVar ("get5_ready_team_tag", "1", "Add [READY][NOT READY] Tag before Team Names in Warmup. 0 to disable it");
   g_ResetPausesEachHalfCvar =
       CreateConVar("get5_reset_pauses_each_half", "1",
                    "Whether pause limits will be reset each halftime period");

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -298,7 +298,7 @@ public void OnPluginStart() {
   g_MessagePrefixCvar =
       CreateConVar("get5_message_prefix", DEFAULT_TAG, "The tag applied before plugin messages.");
    g_ReadyTeamTag =
-      CreateConVar ("get5_ready_team_tag", "1", "Add [READY][NOT READY] Tag before Team Names in Warmup. 0 to disable it");
+      CreateConVar("get5_ready_team_tag", "1", "Add [READY][NOT READY] Tag before Team Names in Warmup. 0 to disable it");
   g_ResetPausesEachHalfCvar =
       CreateConVar("get5_reset_pauses_each_half", "1",
                    "Whether pause limits will be reset each halftime period");

--- a/scripting/get5/util.sp
+++ b/scripting/get5/util.sp
@@ -271,6 +271,7 @@ stock void SetTeamInfo(int csTeam, const char[] name, const char[] flag = "",
       }
     } else {
       strcopy(taggedName, sizeof(taggedName), name);
+    }
   } else {
     strcopy(taggedName, sizeof(taggedName), name);
   }

--- a/scripting/get5/util.sp
+++ b/scripting/get5/util.sp
@@ -260,14 +260,17 @@ stock void SetTeamInfo(int csTeam, const char[] name, const char[] flag = "",
 
   // Add Ready/Not ready tags to team name if in warmup.
   char taggedName[MAX_CVAR_LENGTH];
-  if ((g_GameState == Get5State_Warmup || g_GameState == Get5State_PreVeto) &&
-      !g_DoingBackupRestoreNow) {
-    MatchTeam matchTeam = CSTeamToMatchTeam(csTeam);
-    if (IsTeamReady(matchTeam)) {
-      Format(taggedName, sizeof(taggedName), "%T %s", "ReadyTag", LANG_SERVER, name);
+  if (g_ReadyTeamTag.BoolValue){
+    if ((g_GameState == Get5State_Warmup || g_GameState == Get5State_PreVeto) &&
+        !g_DoingBackupRestoreNow) {
+      MatchTeam matchTeam = CSTeamToMatchTeam(csTeam);
+      if (IsTeamReady(matchTeam)) {
+        Format(taggedName, sizeof(taggedName), "%T %s", "ReadyTag", LANG_SERVER, name);
+      } else {
+        Format(taggedName, sizeof(taggedName), "%T %s", "NotReadyTag", LANG_SERVER, name);
+      }
     } else {
-      Format(taggedName, sizeof(taggedName), "%T %s", "NotReadyTag", LANG_SERVER, name);
-    }
+      strcopy(taggedName, sizeof(taggedName), name);
   } else {
     strcopy(taggedName, sizeof(taggedName), name);
   }


### PR DESCRIPTION
This will add CVAR in get5 allowing host to enable / disable [READY] [NOT READY] Tags in Team Names while they are in Warmup stage . [NOT READY] Tag is by default and after the whole team is ready either all players are ready or someone use !forceready the status of the Team becomes to Ready status changing it to [READY] in Team Name.
Eg. 
Team 1 Name : ABC
Team 2 Name : CBA
Match is loaded via config file and automatically in Team Name on top it will add Team 1 Name as [NOT READY] ABC and Team 2 Name as [NOT READY] CBA . After all the players ready up or forceready their teams it will change status to [READY] ABC and [READY] CBA  on Team Names. This CVAR will just disable [NOT READY] [READY] status. 


`get5_ready_team_tag 1 ` will enable [READY] [NOT READY] Tags in Team Names.
`get5_ready_team_tag 0` will disable it and only show Team Names.

Note : This has been added to give one small workaround for one Major issue of Backup Loading making the Team Names again as [NOT READY] Team1 and [NOT READY] Team2 and will never get update . If you keep `get5_ready_team_tag 0` it will never add back [NOT READY] tags as it is never used. 