### PR TITLE
Add player contribution score to recorded stats

### DIFF
--- a/misc/import_stats.sql
+++ b/misc/import_stats.sql
@@ -93,6 +93,7 @@ CREATE TABLE `get5_stats_players` (
   `firstkill_ct` smallint(5) unsigned NOT NULL,
   `firstdeath_t` smallint(5) unsigned NOT NULL,
   `firstdeath_ct` smallint(5) unsigned NOT NULL,
+  `contribution_score` smallint(5) unsigned NOT NULL,
   PRIMARY KEY (`matchid`,`mapnumber`,`steamid64`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/scripting/get5/stats.sp
+++ b/scripting/get5/stats.sp
@@ -122,6 +122,9 @@ public void Stats_RoundEnd(int csTeamWinner) {
         char name[MAX_NAME_LENGTH];
         GetClientName(i, name, sizeof(name));
         g_StatsKv.SetString(STAT_NAME, name);
+
+        g_StatsKv.SetNum(STAT_CONTRIBUTION_SCORE, CS_GetClientContributionScore(i));
+
         GoBackFromPlayer();
       }
     }

--- a/scripting/get5_apistats.sp
+++ b/scripting/get5_apistats.sp
@@ -316,6 +316,7 @@ public void UpdatePlayerStats(KeyValues kv, MatchTeam team) {
         AddIntStat(req, kv, STAT_FIRSTDEATH_T);
         AddIntStat(req, kv, STAT_FIRSTDEATH_CT);
         AddIntStat(req, kv, STAT_TRADEKILL);
+        AddIntStat(req, kv, STAT_CONTRIBUTION_SCORE);
         SteamWorks_SendHTTPRequest(req);
       }
 

--- a/scripting/get5_mysqlstats.sp
+++ b/scripting/get5_mysqlstats.sp
@@ -267,6 +267,7 @@ public void AddPlayerStats(KeyValues kv, MatchTeam team) {
       int firstkill_ct = kv.GetNum(STAT_FIRSTKILL_CT);
       int firstdeath_t = kv.GetNum(STAT_FIRSTDEATH_T);
       int firstdeath_ct = kv.GetNum(STAT_FIRSTDEATH_CT);
+      int contribution_score = kv.GetNum(STAT_CONTRIBUTION_SCORE);
 
       char teamString[16];
       GetTeamString(team, teamString, sizeof(teamString));
@@ -281,6 +282,7 @@ public void AddPlayerStats(KeyValues kv, MatchTeam team) {
                 v1, v2, v3, v4, v5, \
                 2k, 3k, 4k, 5k, \
                 firstkill_t, firstkill_ct, firstdeath_t, firstdeath_ct \
+                contribution_score \
                 ) VALUES \
                 (%d, %d, '%s', '%s', \
                 %d, '%s', %d, %d, %d, \
@@ -288,10 +290,11 @@ public void AddPlayerStats(KeyValues kv, MatchTeam team) {
                 %d, %d, \
                 %d, %d, %d, %d, %d, \
                 %d, %d, %d, %d, \
-                %d, %d, %d, %d)",
+                %d, %d, %d, %d, %d)",
              g_MatchID, mapNumber, authSz, teamString, roundsplayed, nameSz, kills, deaths,
              flashbang_assists, assists, teamkills, headshot_kills, damage, plants, defuses, v1, v2,
-             v3, v4, v5, k2, k3, k4, k5, firstkill_t, firstkill_ct, firstdeath_t, firstdeath_ct);
+             v3, v4, v5, k2, k3, k4, k5, firstkill_t, firstkill_ct, firstdeath_t, firstdeath_ct,
+             contribution_score);
 
       LogDebug(queryBuffer);
       db.Query(SQLErrorCheckCallback, queryBuffer);

--- a/scripting/include/get5.inc
+++ b/scripting/include/get5.inc
@@ -191,6 +191,7 @@ native int Get5_IncreasePlayerStat(int client, const char[] statName, int amount
 #define STAT_FIRSTDEATH_T "firstdeath_t"
 #define STAT_FIRSTDEATH_CT "firstdeath_ct"
 #define STAT_TRADEKILL "tradekill"
+#define STAT_CONTRIBUTION_SCORE "contribution_score"
 
 public SharedPlugin __pl_get5 = {
     name = "get5", file = "get5.smx",


### PR DESCRIPTION
Adds the player contribution score to recorded stats as discussed in #495.

Also adds the contribution score to apistats post request back to web server.

I chose to use the name `contribution_score` as this seems to be the correct term but most people might be familiar with is as just the player score. I don't have any preferences.