### PR TITLE
Fix warning 241 when compiling in SM 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ addons:
         - lib32stdc++6  # needed for spcomp
 
 env:
-    - SMVERSION=1.9
+    - SMVERSION=1.10
 
 before_script:
     # setup submodules

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -96,14 +96,14 @@ int g_MapsToWin = 1;  // Maps needed to win the series.
 bool g_BO2Match = false;
 char g_MatchID[MATCH_ID_LENGTH];
 ArrayList g_MapPoolList = null;
-ArrayList g_TeamAuths[MatchTeam_Count];
+ArrayList g_TeamAuths[MATCHTEAM_COUNT];
 StringMap g_PlayerNames;
-char g_TeamNames[MatchTeam_Count][MAX_CVAR_LENGTH];
-char g_TeamTags[MatchTeam_Count][MAX_CVAR_LENGTH];
-char g_FormattedTeamNames[MatchTeam_Count][MAX_CVAR_LENGTH];
-char g_TeamFlags[MatchTeam_Count][MAX_CVAR_LENGTH];
-char g_TeamLogos[MatchTeam_Count][MAX_CVAR_LENGTH];
-char g_TeamMatchTexts[MatchTeam_Count][MAX_CVAR_LENGTH];
+char g_TeamNames[MATCHTEAM_COUNT][MAX_CVAR_LENGTH];
+char g_TeamTags[MATCHTEAM_COUNT][MAX_CVAR_LENGTH];
+char g_FormattedTeamNames[MATCHTEAM_COUNT][MAX_CVAR_LENGTH];
+char g_TeamFlags[MATCHTEAM_COUNT][MAX_CVAR_LENGTH];
+char g_TeamLogos[MATCHTEAM_COUNT][MAX_CVAR_LENGTH];
+char g_TeamMatchTexts[MATCHTEAM_COUNT][MAX_CVAR_LENGTH];
 char g_MatchTitle[MAX_CVAR_LENGTH];
 int g_FavoredTeamPercentage = 0;
 char g_FavoredTeamText[MAX_CVAR_LENGTH];
@@ -138,8 +138,8 @@ int g_RoundClutchingEnemyCount[MAXPLAYERS +
                                1];  // number of enemies left alive when last alive on your team
 int g_LastFlashBangThrower = -1;    // last client to have a flashbang detonate
 int g_RoundFlashedBy[MAXPLAYERS + 1];
-bool g_TeamFirstKillDone[MatchTeam_Count];
-bool g_TeamFirstDeathDone[MatchTeam_Count];
+bool g_TeamFirstKillDone[MATCHTEAM_COUNT];
+bool g_TeamFirstDeathDone[MATCHTEAM_COUNT];
 int g_PlayerKilledBy[MAXPLAYERS + 1];
 float g_PlayerKilledByTime[MAXPLAYERS + 1];
 int g_DamageDone[MAXPLAYERS + 1][MAXPLAYERS + 1];
@@ -148,17 +148,17 @@ KeyValues g_StatsKv;
 
 ArrayList g_TeamScoresPerMap = null;
 char g_LoadedConfigFile[PLATFORM_MAX_PATH];
-int g_VetoCaptains[MatchTeam_Count];        // Clients doing the map vetos.
-int g_TeamSeriesScores[MatchTeam_Count];    // Current number of maps won per-team.
-bool g_TeamReadyOverride[MatchTeam_Count];  // Whether a team has been voluntarily force readied.
+int g_VetoCaptains[MATCHTEAM_COUNT];        // Clients doing the map vetos.
+int g_TeamSeriesScores[MATCHTEAM_COUNT];    // Current number of maps won per-team.
+bool g_TeamReadyOverride[MATCHTEAM_COUNT];  // Whether a team has been voluntarily force readied.
 bool g_ClientReady[MAXPLAYERS + 1];         // Whether clients are marked ready.
-int g_TeamSide[MatchTeam_Count];            // Current CS_TEAM_* side for the team.
-int g_TeamStartingSide[MatchTeam_Count];
-bool g_TeamReadyForUnpause[MatchTeam_Count];
-bool g_TeamGivenStopCommand[MatchTeam_Count];
+int g_TeamSide[MATCHTEAM_COUNT];            // Current CS_TEAM_* side for the team.
+int g_TeamStartingSide[MATCHTEAM_COUNT];
+bool g_TeamReadyForUnpause[MATCHTEAM_COUNT];
+bool g_TeamGivenStopCommand[MATCHTEAM_COUNT];
 bool g_InExtendedPause;
-int g_TeamPauseTimeUsed[MatchTeam_Count];
-int g_TeamPausesUsed[MatchTeam_Count];
+int g_TeamPauseTimeUsed[MATCHTEAM_COUNT];
+int g_TeamPausesUsed[MATCHTEAM_COUNT];
 int g_ReadyTimeWaitingUsed = 0;
 char g_DefaultTeamColors[][] = {
     TEAM1_COLOR, TEAM2_COLOR, "{NORMAL}", "{NORMAL}",
@@ -438,7 +438,7 @@ public void OnPluginStart() {
   g_MapSides = new ArrayList();
   g_CvarNames = new ArrayList(MAX_CVAR_LENGTH);
   g_CvarValues = new ArrayList(MAX_CVAR_LENGTH);
-  g_TeamScoresPerMap = new ArrayList(view_as<int>(MatchTeam_Count));
+  g_TeamScoresPerMap = new ArrayList(MATCHTEAM_COUNT);
 
   for (int i = 0; i < sizeof(g_TeamAuths); i++) {
     g_TeamAuths[i] = new ArrayList(AUTH_LENGTH);

--- a/scripting/get5/teamlogic.sp
+++ b/scripting/get5/teamlogic.sp
@@ -214,7 +214,7 @@ public MatchTeam GetAuthMatchTeam(const char[] steam64) {
     return IsAuthOnTeam(steam64, MatchTeam_Team1) ? MatchTeam_Team1 : MatchTeam_Team2;
   }
 
-  for (int i = 0; i < view_as<int>(MatchTeam_Count); i++) {
+  for (int i = 0; i < MATCHTEAM_COUNT; i++) {
     MatchTeam team = view_as<MatchTeam>(i);
     if (IsAuthOnTeam(steam64, team)) {
       return team;
@@ -358,7 +358,7 @@ public bool RemovePlayerFromTeams(const char[] auth) {
   char steam64[AUTH_LENGTH];
   ConvertAuthToSteam64(auth, steam64);
 
-  for (int i = 0; i < view_as<int>(MatchTeam_Count); i++) {
+  for (int i = 0; i < MATCHTEAM_COUNT; i++) {
     MatchTeam team = view_as<MatchTeam>(i);
     int index = GetTeamAuths(team).FindString(steam64);
     if (index >= 0) {

--- a/scripting/include/get5.inc
+++ b/scripting/include/get5.inc
@@ -15,6 +15,8 @@ enum Get5State {
   Get5State_PostGame,                      // postgame screen + waiting for GOTV to finish broadcast
 };
 
+#define MATCHTEAM_COUNT 4
+
 enum MatchTeam {
   MatchTeam_Team1,
   MatchTeam_Team2,


### PR DESCRIPTION
When I compiled with SourceMod 1.10, I used to get this warning for every line where there is an `ArrayList` or array of size `MatchTeam_Count`.

> Warning 241: Array-based enum structs will be removed in 1.11. See https://wiki.alliedmods.net/SourcePawn_Transitional_Syntax#Enum_Structs

It annoyed me, so I introduced the constant `MATCHTEAM_COUNT` set to `4` and used it everywhere.

I couldn't remove `MatchTeam_Count` from the enum because of the loop in the macro `LoopTeams()`. It's enumerating over the enum, so an element of the enum is also needed in the loop's condition.

Maybe someone will find a better fix and, by the way, maybe using SM 1.10 is not advised? (I didn't find anything about that.)