### PR TITLE
Fix translations ('en' and 'fr')

### DIFF
--- a/translations/fr/get5.phrases.txt
+++ b/translations/fr/get5.phrases.txt
@@ -14,7 +14,7 @@
     }
     "ReadyToKnifeInfoMessage"
     {
-        "fr"            "Entrez {GREEN}!ready {NORMAL}quand pour être prêt(e) pour à démarrer un round au couteau."
+        "fr"            "Entrez {GREEN}!ready {NORMAL}quand vous êtes prêt(e) à démarrer un round au couteau."
     }
     "ReadyToStartInfoMessage"
     {
@@ -30,19 +30,19 @@
     }
     "WaitingForEnemySwapInfoMessage"
     {
-        "fr"            "{1} a gagné le round a couteau. Attente de leur choix entre !stay ou !swap."
+        "fr"            "{1} a gagné le round au couteau. En attente de leur choix entre !stay et !swap."
     }
     "WaitingForGOTVBrodcastEndingInfoMessage"
     {
-        "fr"            "La carte changera dès que la diffusion GOTV sera terminée."
+        "fr"            "La map changera dès que la diffusion GOTV sera terminée."
     }
     "WaitingForGOTVVetoInfoMessage"
     {
-        "fr"            "La map changera une fois que la GOTV aura diffusé le tour de veto."
+        "fr"            "La map changera dès que la diffusion GOTV aura diffusé le tour de veto."
     }
     "NoMatchSetupInfoMessage"
     {
-        "fr"			"Aucune configuration de match trouvée"
+        "fr"			"Aucune configuration n'est chargée"
     }
     "YourAreNotAPlayerInfoMessage"
     {
@@ -54,19 +54,19 @@
     }
     "TeamForfeitInfoMessage"
     {
-        "fr"            "{1} ne s'est pas déclarée prête à temps et a déclaré forfait."
+        "fr"            "{1} ne s'est pas déclarée prête à temps et a été déclarée forfait."
     }
     "MinutesToForfeitMessage"
     {
-        "fr"            "{1} dispose encore de {2} minutes pour se déclarer prête, sinon elle déclarera forfait.."
+        "fr"            "{1} dispose encore de {2} minutes pour se déclarer prête, sinon elle sera déclarée forfait."
     }
     "SecondsToForfeitInfoMessage"
     {
-        "fr"            "{1} dispose encore de {2} secondes pour se déclarer prête, sinon elle déclarera forfait."
+        "fr"            "{1} dispose encore de {2} secondes pour se déclarer prête, sinon elle sera déclarée forfait."
     }
     "10SecondsToForfeitInfoMessage"
     {
-        "fr"            "{1} a 10 secondes pour se déclarer prêt(e), sinon il/elle déclarera forfait"
+        "fr"            "{1} a 10 secondes pour se déclarer prêt(e), sinon elle sera déclarée forfait."
     }
     "PausePeriodSuffix"
     {
@@ -74,11 +74,11 @@
     }
     "MaxPausesUsedInfoMessage"
     {
-        "fr"            "Votre équipe a déjà utilisé son maximum de {1} pauses {2}."
+        "fr"            "Votre équipe a déjà utilisé son maximum de {1} pauses{2}."
     }
     "MaxPausesTimeUsedInfoMessage"
     {
-        "fr"            "Votre équipe a déjà utilisé son maximum de {1} secondes de pause {2}."
+        "fr"            "Votre équipe a déjà utilisé son maximum de {1} secondes de pause{2}."
     }
     "MatchPausedByTeamMessage"
     {
@@ -94,7 +94,7 @@
     }
     "PauseTimeExpiration10SecInfoMessage"
     {
-        "fr"            "{1} est bientôt parvenue à la fin de sa pause, fin dans 10 secondes."
+        "fr"            "{1} terminera sa pause dans 10 secondes."
     }
     "PauseTimeExpirationInfoMessage"
     {
@@ -122,7 +122,7 @@
     }
     "TeamFailToReadyMinPlayerCheck"
     {
-        "fr"            "Vous devez disposer d'au moins {1} joueur sur le serveur pour vous déclarer prêt(e)."
+        "fr"            "Vous devez disposer d'au moins {1} joueur(s) sur le serveur pour vous déclarer prêt(e)."
     }
     "TeamReadyToVetoInfoMessage"
     {
@@ -146,11 +146,11 @@
     }
     "ForceReadyInfoMessage"
     {
-        "fr"            "Vous pouvez entrer {GREEN}!forceready {NORMAL}pour forcer votre équipe à être prête si vous avez moins de {GREEN}{1}{NORMAL} joueurs"
+        "fr"            "Vous pouvez entrer {GREEN}!forceready {NORMAL}pour forcer le statut de votre équipe si vous avez moins de {GREEN}{1}{NORMAL} joueurs."
     }
     "TeammateForceReadied"
     {
-        "fr"            "Votre équipe s'est déclaré prête (de force) par {GREEN}{1}"
+        "fr"            "Votre équipe s'est déclaré prête (de force) par {GREEN}{1}."
     }
     "AdminForceReadyInfoMessage"
     {
@@ -162,7 +162,7 @@
     }
     "AdminForcePauseInfoMessage"
     {
-        "fr"            "Un admin a forcé le match en pause."
+        "fr"            "Un admin a forcé la pause du match."
     }
     "AdminForceUnPauseInfoMessage"
     {
@@ -170,15 +170,15 @@
     }
     "TeamWantsToReloadLastRoundInfoMessage"
     {
-        "fr"            "{1} veut arrêter et recommencer au dernier round, cela nécessite {2} pour confirmer avec !stop."
+        "fr"            "{1} souhaite arrêter et recommencer au dernier round, cela nécessite que {2} confirme avec !stop."
     }
     "TeamWinningSeriesInfoMessage"
     {
-        "fr"            "{1}{NORMAL} gagne les séries {2}-{3}"
+        "fr"            "{1}{NORMAL} gagne la série avec {2}-{3}"
     }
     "SeriesTiedInfoMessage"
     {
-        "fr"            "La série est ex-æquo at {1}-{2}"
+        "fr"            "La série est ex-æquo avec {1}-{2}"
     }
     "NextSeriesMapInfoMessage"
     {
@@ -194,7 +194,7 @@
     }
     "TeamsSplitSeriesBO2InfoMessage"
     {
-        "fr"            "{1} et {2} ont gagné autant de match (1-1)."
+        "fr"            "{1} et {2} ont gagné autant de matchs (1-1)."
     }
     "TeamWonSeriesInfoMessage"
     {
@@ -230,7 +230,7 @@
     }
     "TeamDecidedToStayInfoMessage"
     {
-        "fr"            "{1} {1} a décidé de rester.."
+        "fr"            "{1} {1} a décidé de rester."
     }
     "TeamDecidedToSwapInfoMessage"
     {
@@ -238,7 +238,7 @@
     }
     "TeamLostTimeToDecideInfoMessage"
     {
-        "fr"            "{1} restera car ils n'ont pas pris leur décision à temps."
+        "fr"            "{1} restera dans le même camp car ils n'ont pas pris leur décision à temps."
     }
     "ChangingMapInfoMessage"
     {
@@ -250,7 +250,7 @@
     }
     "MapIsInfoMessage"
     {
-        "fr"            "Map {1}: {GREEN}{2}"
+        "fr"            "Map {1} : {GREEN}{2}"
     }
     "TeamPickedMapInfoMessage"
     {
@@ -258,11 +258,11 @@
     }
     "TeamSelectSideInfoMessage"
     {
-        "fr"            "{1} a choisi de commencer sur {GREEN}{2} {NORMAL}sur {3}"
+        "fr"            "{1} a choisi de commencer en {GREEN}{2} {NORMAL}sur {3}"
     }
     "TeamVetoedMapInfoMessage"
     {
-        "fr"            "{1} a rejetté {LIGHT_RED}{2}"
+        "fr"            "{1} a rejeté {LIGHT_RED}{2}"
     }
     "CaptainLeftOnVetoInfoMessage"
     {
@@ -294,27 +294,27 @@
     }
     "MapVetoPickMenuText"
     {
-        "fr"        "Selectionnez une map à JOUER:"
+        "fr"        "Selectionnez une map à JOUER :"
     }
     "MapVetoPickConfirmMenuText"
     {
-        "fr"        "Confirmez que vous souhaitez la jouer {1}:"
+        "fr"        "Confirmez que vous souhaitez la jouer {1} :"
     }
     "MapVetoBanMenuText"
     {
-        "fr"        "Selectionnez une map à BANNIR:"
+        "fr"        "Selectionnez une map à BANNIR :"
     }
     "MapVetoBanConfirmMenuText"
     {
-        "fr"        "Confirmez que vous souhaitez la bannir {1}:"
+        "fr"        "Confirmez que vous souhaitez la bannir {1} :"
     }
     "MapVetoSidePickMenuText"
     {
-        "fr"        "Selectionner un côté pourr {1}"
+        "fr"        "Selectionner un côté pour {1}"
     }
     "MapVetoSidePickConfirmMenuText"
     {
-        "fr"        "Confirmez que vous voulez commencer {1}:"
+        "fr"        "Confirmez que vous voulez commencer {1} :"
     }
     "ConfirmPositiveOptionText"
     {
@@ -326,6 +326,6 @@
     }
     "VetoCountdown"
     {
-        "fr"        "Le Veto commencera dans {GREEN}{1} {NORMAL}secondes."
+        "fr"        "Le veto commencera dans {GREEN}{1} {NORMAL}secondes."
     }
 }

--- a/translations/get5.phrases.txt
+++ b/translations/get5.phrases.txt
@@ -140,7 +140,7 @@
     "TeamFailToReadyMinPlayerCheck"
     {
         "#format"       "{1:d}"
-        "en"            "You must have at least {1} players on the server to ready up."
+        "en"            "You must have at least {1} player(s) on the server to ready up."
     }
     "TeamReadyToVetoInfoMessage"
     {


### PR DESCRIPTION
I added an optional plural in both English and French for `TeamFailToReadyMinPlayerCheck` because `min_players_to_ready` can be set to `1`.

For French-only changes, it's just a matter of better language and fixed typos.