### PR TITLE
Fixing AddPlayerStatus sql and import_stats.sql

### DIFF
--- a/misc/import_stats.sql
+++ b/misc/import_stats.sql
@@ -93,6 +93,7 @@ CREATE TABLE `get5_stats_players` (
   `firstkill_ct` smallint(5) unsigned NOT NULL,
   `firstdeath_t` smallint(5) unsigned NOT NULL,
   `firstdeath_ct` smallint(5) unsigned NOT NULL,
+  `tradekill` smallint(5) unsigned NOT NULL,
   `contribution_score` smallint(5) unsigned NOT NULL,
   PRIMARY KEY (`matchid`,`mapnumber`,`steamid64`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/scripting/get5_mysqlstats.sp
+++ b/scripting/get5_mysqlstats.sp
@@ -267,6 +267,7 @@ public void AddPlayerStats(KeyValues kv, MatchTeam team) {
       int firstkill_ct = kv.GetNum(STAT_FIRSTKILL_CT);
       int firstdeath_t = kv.GetNum(STAT_FIRSTDEATH_T);
       int firstdeath_ct = kv.GetNum(STAT_FIRSTDEATH_CT);
+      int tradekill = kv.GetNum(STAT_TRADEKILL);
       int contribution_score = kv.GetNum(STAT_CONTRIBUTION_SCORE);
 
       char teamString[16];
@@ -281,8 +282,8 @@ public void AddPlayerStats(KeyValues kv, MatchTeam team) {
                 bomb_plants, bomb_defuses, \
                 v1, v2, v3, v4, v5, \
                 2k, 3k, 4k, 5k, \
-                firstkill_t, firstkill_ct, firstdeath_t, firstdeath_ct \
-                contribution_score \
+                firstkill_t, firstkill_ct, firstdeath_t, firstdeath_ct, \
+                tradekill, contribution_score \
                 ) VALUES \
                 (%d, %d, '%s', '%s', \
                 %d, '%s', %d, %d, %d, \
@@ -290,11 +291,16 @@ public void AddPlayerStats(KeyValues kv, MatchTeam team) {
                 %d, %d, \
                 %d, %d, %d, %d, %d, \
                 %d, %d, %d, %d, \
-                %d, %d, %d, %d, %d)",
-             g_MatchID, mapNumber, authSz, teamString, roundsplayed, nameSz, kills, deaths,
-             flashbang_assists, assists, teamkills, headshot_kills, damage, plants, defuses, v1, v2,
-             v3, v4, v5, k2, k3, k4, k5, firstkill_t, firstkill_ct, firstdeath_t, firstdeath_ct,
-             contribution_score);
+                %d, %d, %d, %d, 
+                %d, %d)",
+             g_MatchID, mapNumber, authSz, teamString, 
+             roundsplayed, nameSz, kills, deaths, flashbang_assists, 
+             assists, teamkills, headshot_kills, damage, 
+             plants, defuses, 
+             v1, v2, v3, v4, v5, 
+             k2, k3, k4, k5, 
+             firstkill_t, firstkill_ct, firstdeath_t, firstdeath_ct,
+             tradekill, contribution_score);
 
       LogDebug(queryBuffer);
       db.Query(SQLErrorCheckCallback, queryBuffer);

--- a/scripting/get5_mysqlstats.sp
+++ b/scripting/get5_mysqlstats.sp
@@ -291,7 +291,7 @@ public void AddPlayerStats(KeyValues kv, MatchTeam team) {
                 %d, %d, \
                 %d, %d, %d, %d, %d, \
                 %d, %d, %d, %d, \
-                %d, %d, %d, %d, 
+                %d, %d, %d, %d, \
                 %d, %d)",
              g_MatchID, mapNumber, authSz, teamString, 
              roundsplayed, nameSz, kills, deaths, flashbang_assists, 


### PR DESCRIPTION
As @rdsedmundo mentioned in #497 it was missing a comma in the `AddPlayerStats` in `get5_mysqlstats`. Added tradekill as suggested as well.

Also some formatting to make Format() parameters easier to read.