### PR TITLE
Add KAST stat

### DIFF
--- a/misc/import_stats.sql
+++ b/misc/import_stats.sql
@@ -94,6 +94,7 @@ CREATE TABLE `get5_stats_players` (
   `firstdeath_t` smallint(5) unsigned NOT NULL,
   `firstdeath_ct` smallint(5) unsigned NOT NULL,
   `tradekill` smallint(5) unsigned NOT NULL,
+  `kast` smallint(5) unsigned NOT NULL,
   `contribution_score` smallint(5) unsigned NOT NULL,
   PRIMARY KEY (`matchid`,`mapnumber`,`steamid64`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -144,6 +144,8 @@ int g_PlayerKilledBy[MAXPLAYERS + 1];
 float g_PlayerKilledByTime[MAXPLAYERS + 1];
 int g_DamageDone[MAXPLAYERS + 1][MAXPLAYERS + 1];
 int g_DamageDoneHits[MAXPLAYERS + 1][MAXPLAYERS + 1];
+bool g_PlayerRoundKillOrAssistOrTradedDeath[MAXPLAYERS + 1];
+bool g_PlayerSurvived[MAXPLAYERS + 1];
 KeyValues g_StatsKv;
 
 ArrayList g_TeamScoresPerMap = null;

--- a/scripting/get5_apistats.sp
+++ b/scripting/get5_apistats.sp
@@ -335,6 +335,7 @@ public void UpdatePlayerStats(KeyValues kv, MatchTeam team) {
         AddIntStat(req, kv, STAT_FIRSTDEATH_T);
         AddIntStat(req, kv, STAT_FIRSTDEATH_CT);
         AddIntStat(req, kv, STAT_TRADEKILL);
+        AddIntStat(req, kv, STAT_KAST);
         AddIntStat(req, kv, STAT_CONTRIBUTION_SCORE);
         SteamWorks_SendHTTPRequest(req);
       }

--- a/scripting/get5_mysqlstats.sp
+++ b/scripting/get5_mysqlstats.sp
@@ -268,6 +268,7 @@ public void AddPlayerStats(KeyValues kv, MatchTeam team) {
       int firstdeath_t = kv.GetNum(STAT_FIRSTDEATH_T);
       int firstdeath_ct = kv.GetNum(STAT_FIRSTDEATH_CT);
       int tradekill = kv.GetNum(STAT_TRADEKILL);
+      int kast = kv.GetNum(STAT_KAST);
       int contribution_score = kv.GetNum(STAT_CONTRIBUTION_SCORE);
 
       char teamString[16];
@@ -283,7 +284,7 @@ public void AddPlayerStats(KeyValues kv, MatchTeam team) {
                 v1, v2, v3, v4, v5, \
                 2k, 3k, 4k, 5k, \
                 firstkill_t, firstkill_ct, firstdeath_t, firstdeath_ct, \
-                tradekill, contribution_score \
+                tradekill, kast, contribution_score \
                 ) VALUES \
                 (%d, %d, '%s', '%s', \
                 %d, '%s', %d, %d, %d, \
@@ -292,7 +293,7 @@ public void AddPlayerStats(KeyValues kv, MatchTeam team) {
                 %d, %d, %d, %d, %d, \
                 %d, %d, %d, %d, \
                 %d, %d, %d, %d, \
-                %d, %d)",
+                %d, %d, %d)",
              g_MatchID, mapNumber, authSz, teamString, 
              roundsplayed, nameSz, kills, deaths, flashbang_assists, 
              assists, teamkills, headshot_kills, damage, 
@@ -300,7 +301,7 @@ public void AddPlayerStats(KeyValues kv, MatchTeam team) {
              v1, v2, v3, v4, v5, 
              k2, k3, k4, k5, 
              firstkill_t, firstkill_ct, firstdeath_t, firstdeath_ct,
-             tradekill, contribution_score);
+             tradekill, kast, contribution_score);
 
       LogDebug(queryBuffer);
       db.Query(SQLErrorCheckCallback, queryBuffer);

--- a/scripting/include/get5.inc
+++ b/scripting/include/get5.inc
@@ -193,6 +193,7 @@ native int Get5_IncreasePlayerStat(int client, const char[] statName, int amount
 #define STAT_FIRSTDEATH_T "firstdeath_t"
 #define STAT_FIRSTDEATH_CT "firstdeath_ct"
 #define STAT_TRADEKILL "tradekill"
+#define STAT_KAST "kast"
 #define STAT_CONTRIBUTION_SCORE "contribution_score"
 
 public SharedPlugin __pl_get5 = {


### PR DESCRIPTION
This PR adds the KAST statistic (number of rounds where a player either had **K**ill, **A**ssist, **S**urvival or **T**raded death). The KAST percentage can be easily derived by calculating KAST/Rounds_Played.

It's an useful stat used for calculating player ratings, more info here: https://www.hltv.org/news/20695/introducing-rating-20