### PR TITLE
Fix team scores when swap sides

### DIFF
--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -1237,6 +1237,8 @@ public Action Event_RoundEnd(Event event, const char[] name, bool dontBroadcast)
 
 public void SwapSides() {
   LogDebug("SwapSides");
+  EventLogger_SideSwap(g_TeamSide[MatchTeam_Team1], g_TeamSide[MatchTeam_Team2]);
+
   int tmp = g_TeamSide[MatchTeam_Team1];
   g_TeamSide[MatchTeam_Team1] = g_TeamSide[MatchTeam_Team2];
   g_TeamSide[MatchTeam_Team2] = tmp;
@@ -1247,8 +1249,6 @@ public void SwapSides() {
       g_TeamPausesUsed[team] = 0;
     }
   }
-
-  EventLogger_SideSwap(g_TeamSide[MatchTeam_Team1], g_TeamSide[MatchTeam_Team2]);
 }
 
 /**


### PR DESCRIPTION
This PR fixes a bug whenever a `side_swap` event happen. Currently it logs the wrong score from each team. 

As you are swapping teams in the array before the logging, `g_TeamSide[MatchTeam_Team1]` is already `team2` and vice-versa. Therefore when you call `EventLogger_SideSwap` it has the wrong value for `team1` and `team2`.

This is an example from my server with the bug. The final match is `team1_score = 6` and `team2_score = 16`, and in the `side_swap` event it says that `team2_score = 4` and `team1_score = 11` which is wrong.

```
L 05/26/2020 - 20:40:42: {"matchid`":"15","params":{"team2_score":4,"map_number":0,"team1_score":11,"team1_side":"T","team2_side":"CT","map_name":"de_dust2"},"event":"side_swap"}
L 05/26/2020 - 20:50:12: {"matchid`":"15","params":{"winner":"team2","team2_score":16,"map_number":1,"map_name":"de_dust2","team1_score":6},"event":"map_end"}

```