### PR TITLE
Initial value for g_LogoBasePath

### DIFF
--- a/scripting/get5_apistats.sp
+++ b/scripting/get5_apistats.sp
@@ -61,6 +61,7 @@ public void OnPluginStart() {
   LogDebug("OnPluginStart version=%s", PLUGIN_VERSION);
   g_UseSVGCvar = CreateConVar("get5_use_svg", "1", "support svg team logos");
   HookConVarChange(g_UseSVGCvar, LogoBasePathChanged);
+  g_LogoBasePath = g_UseSVGCvar.BoolValue ? LOGO_DIR : LEGACY_LOGO_DIR;
   g_APIKeyCvar =
       CreateConVar("get5_web_api_key", "", "Match API key, this is automatically set through rcon");
   HookConVarChange(g_APIKeyCvar, ApiInfoChanged);


### PR DESCRIPTION
I found error in logs about not able to check for logo path, I think it's due to g_LogoBasePath not having any value initally. Not sure if this is correct approach.
The error itself
```
L 06/01/2020 - 15:30:31: [SM] Exception reported: Invalid path. An empty path string is not valid, use "." to refer to the current working directory.
L 06/01/2020 - 15:30:31: [SM] Blaming: get5_apistats.smx
L 06/01/2020 - 15:30:31: [SM] Call stack trace:
L 06/01/2020 - 15:30:31: [SM]   [0] DirExists
L 06/01/2020 - 15:30:31: [SM]   [1] Line 160, ./scripting/get5_apistats.sp::Get5_OnSeriesInit
L 06/01/2020 - 15:30:31: [SM]   [3] Call_Finish
...
```

@MoritzLoewenstein Can you validate my PR?