### PR TITLE
Fix #540

### DIFF
--- a/scripting/get5/mapveto.sp
+++ b/scripting/get5/mapveto.sp
@@ -286,7 +286,9 @@ public int MapVetoMenuHandler(Menu menu, MenuAction action, int param1, int para
     g_LastVetoTeam = team;
 
   } else if (action == MenuAction_Cancel) {
-    AbortVeto();
+    if(g_GameState == Get5State_Veto) {
+      AbortVeto();
+    }
 
   } else if (action == MenuAction_End) {
     delete menu;
@@ -351,7 +353,9 @@ public int MapPickMenuHandler(Menu menu, MenuAction action, int param1, int para
     VetoController(GetNextTeamCaptain(client));
 
   } else if (action == MenuAction_Cancel) {
-    AbortVeto();
+    if(g_GameState == Get5State_Veto) {
+      AbortVeto();
+    }
 
   } else if (action == MenuAction_End) {
     delete menu;
@@ -424,7 +428,9 @@ public int SidePickMenuHandler(Menu menu, MenuAction action, int param1, int par
     VetoController(client);
 
   } else if (action == MenuAction_Cancel) {
-    AbortVeto();
+    if(g_GameState == Get5State_Veto) {
+      AbortVeto();
+    }
 
   } else if (action == MenuAction_End) {
     delete menu;


### PR DESCRIPTION
After studying the code I found that when you call get5_endmatch ,in the callback it will cancel the veto menu if it was displayed. So in the menu handler the MenuAction_Cancel will be passed to the parameter action.,and AbortVeto function will be called ,as a result game state will be changed from Get5State_None to Get5State_PreVeto.  

There is supposed to be a limit when calling AbortVeto function, to prevent miscalling the function in command get5_endmatch.