### PR TITLE
In-game timeout counter

### DIFF
--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -1248,6 +1248,11 @@ public void SwapSides() {
       g_TeamPauseTimeUsed[team] = 0;
       g_TeamPausesUsed[team] = 0;
     }
+    //Reset the built-in timeout counter of the game
+    if (g_MaxPausesCvar.IntValue > 0){
+      GameRules_SetProp("m_nTerroristTimeOuts", g_MaxPausesCvar.IntValue);
+      GameRules_SetProp("m_nCTTimeOuts", g_MaxPausesCvar.IntValue);
+    }
   }
 }
 

--- a/scripting/get5/goinglive.sp
+++ b/scripting/get5/goinglive.sp
@@ -45,7 +45,7 @@ public Action MatchLive(Handle timer) {
   ExecuteMatchConfigCvars();
 
 
-  //If there is a set amount of timeouts available update the built-in convar and game rule properties to show the correct amount of timeouts remainning in gsi and in-game
+  //If there is a set amount of timeouts available update the built-in convar and game rule properties to show the correct amount of timeouts remaining in gsi and in-game
   if (g_MaxPausesCvar.IntValue > 0){
     ServerCommand("mp_team_timeout_max %d", g_MaxPausesCvar.IntValue);
     GameRules_SetProp("m_nTerroristTimeOuts", g_MaxPausesCvar.IntValue);

--- a/scripting/get5/goinglive.sp
+++ b/scripting/get5/goinglive.sp
@@ -44,6 +44,14 @@ public Action MatchLive(Handle timer) {
   SetMatchTeamCvars();
   ExecuteMatchConfigCvars();
 
+
+  //If there is a set amount of timeouts available update the built-in convar and game rule properties to show the correct amount of timeouts remainning in gsi and in-game
+  if (g_MaxPausesCvar.IntValue > 0){
+    ServerCommand("mp_team_timeout_max %d", g_MaxPausesCvar.IntValue);
+    GameRules_SetProp("m_nTerroristTimeOuts", g_MaxPausesCvar.IntValue);
+    GameRules_SetProp("m_nCTTimeOuts", g_MaxPausesCvar.IntValue);
+  }
+
   // We force the match end-delay to extend for the duration of the GOTV broadcast here.
   g_PendingSideSwap = false;
   ConVar mp_match_restart_delay = FindConVar("mp_match_restart_delay");

--- a/scripting/get5/pausing.sp
+++ b/scripting/get5/pausing.sp
@@ -57,8 +57,15 @@ public Action Command_Pause(int client, int args) {
   g_TeamReadyForUnpause[MatchTeam_Team1] = false;
   g_TeamReadyForUnpause[MatchTeam_Team2] = false;
 
+  int pausesLeft = 1;
+  if (g_MaxPausesCvar.IntValue > 0 && IsPlayerTeam(team)) {
+    //Update the built-in convar to ensure correct max amount is displayed
+    ServerCommand("mp_team_timeout_max %d", g_MaxPausesCvar.IntValue);
+    pausesLeft = g_MaxPausesCvar.IntValue - g_TeamPausesUsed[team] - 1;
+  }
+
   // If the pause will need explicit resuming, we will create a timer to poll the pause status.
-  bool need_resume = Pause(g_FixedPauseTimeCvar.IntValue, MatchTeamToCSTeam(team));
+  bool need_resume = Pause(g_FixedPauseTimeCvar.IntValue, MatchTeamToCSTeam(team), pausesLeft);
   if (IsPlayer(client)) {
     Get5_MessageToAll("%t", "MatchPausedByTeamMessage", client);
   }
@@ -76,7 +83,6 @@ public Action Command_Pause(int client, int args) {
     }
 
     if (g_MaxPausesCvar.IntValue > 0) {
-      int pausesLeft = g_MaxPausesCvar.IntValue - g_TeamPausesUsed[team];
       if (pausesLeft == 1 && g_MaxPausesCvar.IntValue > 0) {
         Get5_MessageToAll("%t", "OnePauseLeftInfoMessage", g_FormattedTeamNames[team], pausesLeft,
                           pausePeriodString);

--- a/scripting/get5/util.sp
+++ b/scripting/get5/util.sp
@@ -209,7 +209,7 @@ stock bool IsPaused() {
 }
 
 // Pauses and returns if the match will automatically unpause after the duration ends.
-stock bool Pause(int pauseTime = 0, int csTeam = CS_TEAM_NONE) {
+stock bool Pause(int pauseTime = 0, int csTeam = CS_TEAM_NONE, int pausesLeft = 1) {
   if (pauseTime == 0 || csTeam == CS_TEAM_SPECTATOR || csTeam == CS_TEAM_NONE) {
     ServerCommand("mp_pause_match");
     return false;
@@ -218,9 +218,11 @@ stock bool Pause(int pauseTime = 0, int csTeam = CS_TEAM_NONE) {
     if (csTeam == CS_TEAM_T) {
       GameRules_SetProp("m_bTerroristTimeOutActive", true);
       GameRules_SetPropFloat("m_flTerroristTimeOutRemaining", float(pauseTime));
+      GameRules_SetProp("m_nTerroristTimeOuts", pausesLeft);
     } else if (csTeam == CS_TEAM_CT) {
       GameRules_SetProp("m_bCTTimeOutActive", true);
       GameRules_SetPropFloat("m_flCTTimeOutRemaining", float(pauseTime));
+      GameRules_SetProp("m_nCTTimeOuts", pausesLeft);
     }
     return true;
   }


### PR DESCRIPTION
Fixes #479 

The amount of remaining timeouts is now shown correctly in-game and in custom huds that use the game state integration.