### PR TITLE
Build on GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,8 +33,13 @@ jobs:
     - run: spcomp get5/scripting/get5_mysqlstats.sp -i steamworks -i $SM_JSON_INC_PATH -o $OUTPUT_SM_PATH/plugins/disabled/get5_mysqlstats.smx
 
     - run: tar -zcvf build.tar.gz output/
-
     - uses: actions/upload-artifact@v2
       with:
         name: build.tar.gz
         path: build.tar.gz
+
+    - run: zip -r build.zip output/
+    - uses: actions/upload-artifact@v2
+      with:
+        name: build.zip
+        path: build.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: Build
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v2
+      with:
+        repository: clugg/sm-json
+        path: 'json'
+
+    - uses: actions/checkout@v2
+      with:
+        path: 'get5'
+
+    - uses: rumblefrog/setup-sp@master
+      with:
+        version: '1.10.x'
+
+    - run: wget https://raw.githubusercontent.com/KyleSanderson/SteamWorks/master/Pawn/includes/SteamWorks.inc -P steamworks
+
+    - run: mkdir -p output/addons/sourcemod/plugins/disabled
+    - run: cp -R get5/cfg output
+    - run: cp -R get5/translations output/addons/sourcemod
+    - run: cp -R get5/configs output/addons/sourcemod
+    - run: cp -R get5/scripting output/addons/sourcemod
+    - run: cp README.md output
+    - run: cp LICENSE output
+    - run: spcomp get5/scripting/get5.sp -i steamworks -i json/addons/sourcemod/scripting/include -o output/addons/sourcemod/plugins/get5.smx
+    - run: spcomp get5/scripting/get5_apistats.sp -i steamworks -i json/addons/sourcemod/scripting/include -o output/addons/sourcemod/plugins/disabled/get5_apistats.smx
+    - run: spcomp get5/scripting/get5_mysqlstats.sp -i steamworks -i json/addons/sourcemod/scripting/include -o output/addons/sourcemod/plugins/disabled/get5_mysqlstats.smx
+
+    - run: tar -zcvf build.tar.gz output/
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: build.tar.gz
+        path: build.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,8 +27,8 @@ jobs:
     - run: cp -R get5/translations output/addons/sourcemod
     - run: cp -R get5/configs output/addons/sourcemod
     - run: cp -R get5/scripting output/addons/sourcemod
-    - run: cp README.md output
-    - run: cp LICENSE output
+    - run: cp get5/README.md output
+    - run: cp get5/LICENSE output
     - run: spcomp get5/scripting/get5.sp -i steamworks -i json/addons/sourcemod/scripting/include -o output/addons/sourcemod/plugins/get5.smx
     - run: spcomp get5/scripting/get5_apistats.sp -i steamworks -i json/addons/sourcemod/scripting/include -o output/addons/sourcemod/plugins/disabled/get5_apistats.smx
     - run: spcomp get5/scripting/get5_mysqlstats.sp -i steamworks -i json/addons/sourcemod/scripting/include -o output/addons/sourcemod/plugins/disabled/get5_mysqlstats.smx

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
 
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,16 +5,14 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-18.04
+    env:
+      OUTPUT_SM_PATH: output/addons/sourcemod
+      SM_JSON_INC_PATH: dependencies/sm-json/addons/sourcemod/scripting/include
     steps:
-
-    - uses: actions/checkout@v2
-      with:
-        repository: clugg/sm-json
-        path: 'json'
-
     - uses: actions/checkout@v2
       with:
         path: 'get5'
+        submodules: true
 
     - uses: rumblefrog/setup-sp@master
       with:
@@ -22,16 +20,16 @@ jobs:
 
     - run: wget https://raw.githubusercontent.com/KyleSanderson/SteamWorks/master/Pawn/includes/SteamWorks.inc -P steamworks
 
-    - run: mkdir -p output/addons/sourcemod/plugins/disabled
+    - run: mkdir -p $OUTPUT_SM_PATH/plugins/disabled
     - run: cp -R get5/cfg output
-    - run: cp -R get5/translations output/addons/sourcemod
-    - run: cp -R get5/configs output/addons/sourcemod
-    - run: cp -R get5/scripting output/addons/sourcemod
+    - run: cp -R get5/translations $OUTPUT_SM_PATH
+    - run: cp -R get5/configs $OUTPUT_SM_PATH
+    - run: cp -R get5/scripting $OUTPUT_SM_PATH
     - run: cp get5/README.md output
     - run: cp get5/LICENSE output
-    - run: spcomp get5/scripting/get5.sp -i steamworks -i json/addons/sourcemod/scripting/include -o output/addons/sourcemod/plugins/get5.smx
-    - run: spcomp get5/scripting/get5_apistats.sp -i steamworks -i json/addons/sourcemod/scripting/include -o output/addons/sourcemod/plugins/disabled/get5_apistats.smx
-    - run: spcomp get5/scripting/get5_mysqlstats.sp -i steamworks -i json/addons/sourcemod/scripting/include -o output/addons/sourcemod/plugins/disabled/get5_mysqlstats.smx
+    - run: spcomp get5/scripting/get5.sp -i steamworks -i $SM_JSON_INC_PATH -o $OUTPUT_SM_PATH/plugins/get5.smx
+    - run: spcomp get5/scripting/get5_apistats.sp -i steamworks -i $SM_JSON_INC_PATH -o $OUTPUT_PATH/plugins/disabled/get5_apistats.smx
+    - run: spcomp get5/scripting/get5_mysqlstats.sp -i steamworks -i $SM_JSON_INC_PATH -o $OUTPUT_PATH/plugins/disabled/get5_mysqlstats.smx
 
     - run: tar -zcvf build.tar.gz output/
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,14 +33,11 @@ jobs:
     - run: spcomp get5/scripting/get5_apistats.sp -i steamworks -i $SM_JSON_INC_PATH -o $OUTPUT_SM_PATH/plugins/disabled/get5_apistats.smx
     - run: spcomp get5/scripting/get5_mysqlstats.sp -i steamworks -i $SM_JSON_INC_PATH -o $OUTPUT_SM_PATH/plugins/disabled/get5_mysqlstats.smx
 
-    - run: tar -zcvf get5.tar.gz $OUTPUT_PATH/
-    - uses: actions/upload-artifact@v2
-      with:
-        name: get5.tar.gz
-        path: get5.tar.gz
+    - run: mkdir -p artifacts
+    - run: tar -zcvf artifacts/get5.tar.gz $OUTPUT_PATH/
+    - run: zip -r artifacts/get5.zip $OUTPUT_PATH/
 
-    - run: zip -r get5.zip $OUTPUT_PATH/
     - uses: actions/upload-artifact@v2
       with:
-        name: get5.zip
-        path: get5.zip
+        name: build
+        path: artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,8 @@ jobs:
     - run: cp get5/README.md output
     - run: cp get5/LICENSE output
     - run: spcomp get5/scripting/get5.sp -i steamworks -i $SM_JSON_INC_PATH -o $OUTPUT_SM_PATH/plugins/get5.smx
-    - run: spcomp get5/scripting/get5_apistats.sp -i steamworks -i $SM_JSON_INC_PATH -o $OUTPUT_PATH/plugins/disabled/get5_apistats.smx
-    - run: spcomp get5/scripting/get5_mysqlstats.sp -i steamworks -i $SM_JSON_INC_PATH -o $OUTPUT_PATH/plugins/disabled/get5_mysqlstats.smx
+    - run: spcomp get5/scripting/get5_apistats.sp -i steamworks -i $SM_JSON_INC_PATH -o $OUTPUT_SM_PATH/plugins/disabled/get5_apistats.smx
+    - run: spcomp get5/scripting/get5_mysqlstats.sp -i steamworks -i $SM_JSON_INC_PATH -o $OUTPUT_SM_PATH/plugins/disabled/get5_mysqlstats.smx
 
     - run: tar -zcvf build.tar.gz output/
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-18.04
     env:
       OUTPUT_SM_PATH: output/addons/sourcemod
-      SM_JSON_INC_PATH: dependencies/sm-json/addons/sourcemod/scripting/include
+      SM_JSON_INC_PATH: get5/dependencies/sm-json/addons/sourcemod/scripting/include
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,8 @@ jobs:
   build:
     runs-on: ubuntu-18.04
     env:
-      OUTPUT_SM_PATH: output/addons/sourcemod
+      OUTPUT_PATH: output/get5
+      OUTPUT_SM_PATH: output/get5/addons/sourcemod
       SM_JSON_INC_PATH: get5/dependencies/sm-json/addons/sourcemod/scripting/include
       STEAMWORKS_URL: https://raw.githubusercontent.com/KyleSanderson/SteamWorks/1.2.3c/Pawn/includes/SteamWorks.inc
     steps:
@@ -22,24 +23,24 @@ jobs:
     - run: wget $STEAMWORKS_URL -P steamworks
 
     - run: mkdir -p $OUTPUT_SM_PATH/plugins/disabled
-    - run: cp -R get5/cfg output
+    - run: cp -R get5/cfg $OUTPUT_PATH
     - run: cp -R get5/translations $OUTPUT_SM_PATH
     - run: cp -R get5/configs $OUTPUT_SM_PATH
     - run: cp -R get5/scripting $OUTPUT_SM_PATH
-    - run: cp get5/README.md output
-    - run: cp get5/LICENSE output
+    - run: cp get5/README.md $OUTPUT_PATH
+    - run: cp get5/LICENSE $OUTPUT_PATH
     - run: spcomp get5/scripting/get5.sp -i steamworks -i $SM_JSON_INC_PATH -o $OUTPUT_SM_PATH/plugins/get5.smx
     - run: spcomp get5/scripting/get5_apistats.sp -i steamworks -i $SM_JSON_INC_PATH -o $OUTPUT_SM_PATH/plugins/disabled/get5_apistats.smx
     - run: spcomp get5/scripting/get5_mysqlstats.sp -i steamworks -i $SM_JSON_INC_PATH -o $OUTPUT_SM_PATH/plugins/disabled/get5_mysqlstats.smx
 
-    - run: tar -zcvf build.tar.gz output/
+    - run: tar -zcvf get5.tar.gz $OUTPUT_PATH/
     - uses: actions/upload-artifact@v2
       with:
-        name: build.tar.gz
-        path: build.tar.gz
+        name: get5.tar.gz
+        path: get5.tar.gz
 
-    - run: zip -r build.zip output/
+    - run: zip -r get5.zip $OUTPUT_PATH/
     - uses: actions/upload-artifact@v2
       with:
-        name: build.zip
-        path: build.zip
+        name: get5.zip
+        path: get5.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ jobs:
     env:
       OUTPUT_SM_PATH: output/addons/sourcemod
       SM_JSON_INC_PATH: get5/dependencies/sm-json/addons/sourcemod/scripting/include
+      STEAMWORKS_URL: https://raw.githubusercontent.com/KyleSanderson/SteamWorks/1.2.3c/Pawn/includes/SteamWorks.inc
     steps:
     - uses: actions/checkout@v2
       with:
@@ -18,7 +19,7 @@ jobs:
       with:
         version: '1.10.x'
 
-    - run: wget https://raw.githubusercontent.com/KyleSanderson/SteamWorks/master/Pawn/includes/SteamWorks.inc -P steamworks
+    - run: wget $STEAMWORKS_URL -P steamworks
 
     - run: mkdir -p $OUTPUT_SM_PATH/plugins/disabled
     - run: cp -R get5/cfg output


### PR DESCRIPTION
This is a basic config for building plugin using github actions. 
Not sure if you prefer to keep using travis amd smbuilder. Anyway i decided to share this. I can help with tweaking/finishing this if you are interested.
Almost solves #183 

Possible improvements:
- [x] use git submodules instead of downloading sm-json
- [ ] post a download link in PR / Create releases
- [x] also create .zip archive
