### PR TITLE
Set loaded url from get5_loadmatch_url as loaded file in get5_status

### DIFF
--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -150,6 +150,7 @@ KeyValues g_StatsKv;
 
 ArrayList g_TeamScoresPerMap = null;
 char g_LoadedConfigFile[PLATFORM_MAX_PATH];
+char g_LoadedConfigUrl[PLATFORM_MAX_PATH];
 int g_VetoCaptains[MATCHTEAM_COUNT];        // Clients doing the map vetos.
 int g_TeamSeriesScores[MATCHTEAM_COUNT];    // Current number of maps won per-team.
 bool g_TeamReadyOverride[MATCHTEAM_COUNT];  // Whether a team has been voluntarily force readied.

--- a/scripting/get5/matchconfig.sp
+++ b/scripting/get5/matchconfig.sp
@@ -201,9 +201,11 @@ stock bool LoadMatchFromUrl(const char[] url, ArrayList paramNames = null,
                             ArrayList paramValues = null) {
   bool steamWorksAvaliable = LibraryExists("SteamWorks");
 
+
   char cleanedUrl[1024];
   strcopy(cleanedUrl, sizeof(cleanedUrl), url);
   ReplaceString(cleanedUrl, sizeof(cleanedUrl), "\"", "");
+  strcopy(g_LoadedConfigUrl, sizeof(g_LoadedConfigUrl), cleanedUrl);
 
   if (steamWorksAvaliable) {
     // Add the protocl strings. Only allow http since SteamWorks doesn't support http it seems?
@@ -255,6 +257,8 @@ public int SteamWorks_OnMatchConfigReceived(Handle request, bool failure, bool r
   GetTempFilePath(remoteConfig, sizeof(remoteConfig), REMOTE_CONFIG_PATTERN);
   SteamWorks_WriteHTTPResponseBodyToFile(request, remoteConfig);
   LoadMatchConfig(remoteConfig);
+
+  strcopy(g_LoadedConfigFile, sizeof(g_LoadedConfigFile), g_LoadedConfigUrl);
 }
 
 public void WriteMatchToKv(KeyValues kv) {


### PR DESCRIPTION
This sets the path of the loaded match to the URL used in `get5_loadmatch_url` so that the URL shows up in `get5_status`