### PR TITLE
Add loaded config url in get5_status

### DIFF
--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -1343,6 +1343,7 @@ public Action Command_Status(int client, int args) {
   if (g_GameState != Get5State_None) {
     json.SetString("matchid", g_MatchID);
     json.SetString("loaded_config_file", g_LoadedConfigFile);
+    json.SetString("loaded_config_url", g_LoadedConfigUrl);
     json.SetInt("map_number", GetMapNumber());
 
     JSON_Object team1 = new JSON_Object();

--- a/scripting/get5/matchconfig.sp
+++ b/scripting/get5/matchconfig.sp
@@ -201,7 +201,6 @@ stock bool LoadMatchFromUrl(const char[] url, ArrayList paramNames = null,
                             ArrayList paramValues = null) {
   bool steamWorksAvaliable = LibraryExists("SteamWorks");
 
-
   char cleanedUrl[1024];
   strcopy(cleanedUrl, sizeof(cleanedUrl), url);
   ReplaceString(cleanedUrl, sizeof(cleanedUrl), "\"", "");
@@ -257,8 +256,6 @@ public int SteamWorks_OnMatchConfigReceived(Handle request, bool failure, bool r
   GetTempFilePath(remoteConfig, sizeof(remoteConfig), REMOTE_CONFIG_PATTERN);
   SteamWorks_WriteHTTPResponseBodyToFile(request, remoteConfig);
   LoadMatchConfig(remoteConfig);
-
-  strcopy(g_LoadedConfigFile, sizeof(g_LoadedConfigFile), g_LoadedConfigUrl);
 }
 
 public void WriteMatchToKv(KeyValues kv) {


### PR DESCRIPTION
This PR is an answer to [this comment](https://github.com/splewis/get5/pull/563#issuecomment-687699636).

- It removes the copy of the remote config **URL** in the **filepath** variable `g_LoadedConfigFile` and actually makes a distinction between `g_LoadedConfigFile` and `g_LoadedConfigUrl`.
- It adds `loaded_config_url` in the output of the `get5_status` command.

@jenrik beware that you wouldn't be able to have a URL inside `g_LoadedConfigFile` anymore if this PR is merged.

@splewis if you are willing to merge this PR, please take a look at #534 and merge it (if it suits you) first, so that I can add a last commit to update the README accordingly in this PR 😊