### PR TITLE
Log native status on match going live

### DIFF
--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -53,6 +53,7 @@ ConVar g_AllowTechPauseCvar;
 ConVar g_AutoLoadConfigCvar;
 ConVar g_BackupSystemEnabledCvar;
 ConVar g_CheckAuthsCvar;
+ConVar g_StatusLogCvar;
 ConVar g_DamagePrintCvar;
 ConVar g_DamagePrintFormat;
 ConVar g_DemoNameFormatCvar;
@@ -255,6 +256,8 @@ public void OnPluginStart() {
                    "Name of a match config file to automatically load when the server loads");
   g_BackupSystemEnabledCvar =
       CreateConVar("get5_backup_system_enabled", "1", "Whether the get5 backup system is enabled");
+  g_StatusLogCvar =
+      CreateConVar("get5_log_status", "0", "Whether the native status is logged when a match is going live.");
   g_DamagePrintCvar =
       CreateConVar("get5_print_damage", "0", "Whether damage reports are printed on round end.");
   g_DamagePrintFormat = CreateConVar(

--- a/scripting/get5/goinglive.sp
+++ b/scripting/get5/goinglive.sp
@@ -16,6 +16,10 @@ public Action StartGoingLive(Handle timer) {
   // Always disable sv_cheats!
   ServerCommand("sv_cheats 0");
 
+  if (g_StatusLogCvar.BoolValue) {
+    ServerCommand("status");
+  }
+
   // Delayed an extra 5 seconds for the final 3-second countdown
   // the game uses after the origina countdown.
   float delay = float(5 + g_LiveCountdownTimeCvar.IntValue);


### PR DESCRIPTION
This is answering the issue https://github.com/splewis/get5/issues/565.

It adds a console variable `get5_log_status`, disabled by default. If enabled, a `status` command will be run each time a match goes live.

This would be useful to check that a player doesn't give its account to a friend to play in his place.