### PR TITLE
Add ip address in player_connect event

### DIFF
--- a/scripting/get5/eventlogger.sp
+++ b/scripting/get5/eventlogger.sp
@@ -62,7 +62,7 @@ static void AddPlayer(JSON_Object params, const char[] key, int client) {
 }
 
 static void AddIpAddress(JSON_Object params, int client) {
-    char value[15];
+    char value[32];
     if (IsValidClient(client)) {
         GetClientIP(client, value, sizeof(value));
     }

--- a/scripting/get5/eventlogger.sp
+++ b/scripting/get5/eventlogger.sp
@@ -61,6 +61,14 @@ static void AddPlayer(JSON_Object params, const char[] key, int client) {
   params.SetString(key, value);
 }
 
+static void AddIpAddress(JSON_Object params, int client) {
+    char value[15];
+    if (IsValidClient(client)) {
+        GetClientIP(client, value, sizeof(value));
+    }
+    params.SetString("ip", value);
+}
+
 public void EventLogger_SeriesStart() {
   EventLogger_StartEvent();
   params.SetString("team1_name", g_TeamNames[MatchTeam_Team1]);
@@ -221,6 +229,7 @@ public void EventLogger_PlayerConnect(int client) {
   EventLogger_StartEvent();
   AddMapData(params);
   AddPlayer(params, "client", client);
+  AddIpAddress(params, client);
   EventLogger_EndEvent("player_connect");
 }
 


### PR DESCRIPTION
Fix #565 

With this, the event should look like this:

```
03/28/2020 - 18:17:13: get5_event: {"matchid`":"c096526a-78e0-4b7e-a0bd-a7d502114cef","params":{"client":"oof<14><STEAM_1:1:115783675><>","ip":"xxx.xxx.xxx.xxx","map_number":0,"map_name":"de_vertigo"},"event":"player_connect"}
```

I havent't had the opportunity to test the code yet.