### PR TITLE
Add information in get5_listbackups

### DIFF
--- a/scripting/get5/backups.sp
+++ b/scripting/get5/backups.sp
@@ -40,7 +40,7 @@ public Action Command_ListBackups(int client, int args) {
   DirectoryListing files = OpenDirectory(".");
   if (files != null) {
     char path[PLATFORM_MAX_PATH];
-    char backupInfo[150];
+    char backupInfo[256];
 
     while (files.GetNext(path, sizeof(path))) {
       if (StrContains(path, pattern) == 0) {
@@ -97,7 +97,7 @@ public bool GetBackupInfo(const char[] path, char[] info, int maxlength) {
     return true;
   }
 
-  char map[15];
+  char map[128];
   kv.GetString("map", map, sizeof(map));
 
   // Try entering FirstHalfScore section.


### PR DESCRIPTION
Closes #578 

This PR adds the function `GetBackupInfo()` which reads a backup file to retrieve more information about it.

The possible output of the function is the following:
- If there is no Valve backup in the file: `filename date team1_name team2_name`
- Otherwise: `filename date team1_name team2_name map_name team1_score team2_score`
- Returns `false` if it fails (read failure or at least one empty team name, which would break the format) and logs an error

If this function fails, the fallback line for a backup will be the old style line (only `filename`).