### PR TITLE
changed docker building process to one time docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,11 @@ RUN apt-get update -qqy && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     curl wget nano net-tools gnupg2 git lib32stdc++6 python \
     python-pip tar bash  && $_apt_clean
 
-COPY . /get5
+RUN mkdir /get5
+RUN mkdir /runscripts
+RUN mkdir /get5src
+COPY dockerrunscript.sh /runscripts
 WORKDIR /get5
-
-RUN git submodule update --init
 
 RUN git clone https://github.com/splewis/sm-builder
 WORKDIR /get5/sm-builder
@@ -30,8 +31,7 @@ ENV PATH "$PATH:/get5/addons/sourcemod/scripting:/root/.local/bin"
 WORKDIR /get5/addons/sourcemod/scripting/include
 RUN wget https://raw.githubusercontent.com/KyleSanderson/SteamWorks/master/Pawn/includes/SteamWorks.inc
 WORKDIR /get5
-RUN cp -r ./dependencies/sm-json/addons/sourcemod/scripting/include/* ./addons/sourcemod/scripting/include
 
 VOLUME /get5/builds
-CMD ["smbuilder", "--flags='-E'"]
-
+VOLUME /get5src
+CMD ["/runscripts/dockerrunscript.sh"]

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ You can use Docker to Build get5. At first you need to build the container image
 
 	docker build . -t get5build:latest
 
-Afterwards you can build get5 with the following command: (specify /path/to/your/build/output)
+Afterwards you can build get5 with the following command: (specify /path/to/your/build/output and /path/to/your/get5src)
 
-	docker run -v /path/to/your/build/output:/get5/builds get5build:latest
-
+	docker run --rm -v /path/to/your/get5src:/get5src -v /path/to/your/build/output:/get5/builds get5build:latest
+	

--- a/dockerrunscript.sh
+++ b/dockerrunscript.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+cd /get5src && git submodule update --init
+cp -rf /get5src/* /get5/
+cd /get5
+cp -r ./dependencies/sm-json/addons/sourcemod/scripting/include/* ./addons/sourcemod/scripting/include
+smbuilder --flags='-E'


### PR DESCRIPTION
Thanks to @Drarig29 's [comment](https://github.com/splewis/get5/pull/572#issuecomment-718088614) on the docker build process i have updated the Dockerfile so it is CI compatible.
You can now build the Docker container only one time and use the run command to build get5 as often you need without the need of a rebuild if you change code on get5.