### PR TITLE
Added command to add the last kicked player

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Some client commands are available also for admin usage. For example, sm_pause a
 - ``get5_creatematch``: creates a Bo1 match with the current players on the server on the current map
 - ``get5_scrim``: creates a Bo1 match with the using settings from ``configs/get5/scrim_template.cfg``
 - ``get5_addplayer``: adds a steamid to a team (any format for steamid)
+- ``get5_addkickedplayer``: adds the last kicked steamid to a team
 - ``get5_removeplayer``: removes a steamid from all teams (any format for steamid)
 - ``get5_forceready``: marks all teams as ready
 - ``get5_dumpstats``: dumps current match stats to a file

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -167,6 +167,8 @@ char g_DefaultTeamColors[][] = {
     TEAM1_COLOR, TEAM2_COLOR, "{NORMAL}", "{NORMAL}",
 };
 
+char g_LastKickedPlayerAuth[64];
+
 bool g_ForceWinnerSignal = false;
 MatchTeam g_ForcedWinner = MatchTeam_TeamNone;
 
@@ -382,6 +384,8 @@ public void OnPluginStart() {
   RegAdminCmd("get5_endmatch", Command_EndMatch, ADMFLAG_CHANGEMAP, "Force ends the current match");
   RegAdminCmd("get5_addplayer", Command_AddPlayer, ADMFLAG_CHANGEMAP,
               "Adds a steamid to a match team");
+  RegAdminCmd("get5_addkickedplayer", Command_AddKickedPlayer, ADMFLAG_CHANGEMAP,
+              "Adds the last kicked steamid to a match team");
   RegAdminCmd("get5_removeplayer", Command_RemovePlayer, ADMFLAG_CHANGEMAP,
               "Removes a steamid from a match team");
   RegAdminCmd("get5_creatematch", Command_CreateMatch, ADMFLAG_CHANGEMAP,
@@ -537,7 +541,7 @@ public void OnClientAuthorized(int client, const char[] auth) {
   if (g_GameState != Get5State_None && g_CheckAuthsCvar.BoolValue) {
     MatchTeam team = GetClientMatchTeam(client);
     if (team == MatchTeam_TeamNone) {
-      KickClient(client, "%t", "YourAreNotAPlayerInfoMessage");
+      RememberAndKickClient(client, "%t", "YourAreNotAPlayerInfoMessage");
     } else {
       int teamCount = CountPlayersOnMatchTeam(team, client);
       if (teamCount >= g_PlayersPerTeam && !g_CoachingEnabledCvar.BoolValue) {
@@ -545,6 +549,11 @@ public void OnClientAuthorized(int client, const char[] auth) {
       }
     }
   }
+}
+
+public void RememberAndKickClient(int client, const char[] format, const char[] translationPhrase) {
+  GetAuth(client, g_LastKickedPlayerAuth, sizeof(g_LastKickedPlayerAuth));
+  KickClient(client, format, translationPhrase);
 }
 
 public void OnClientPutInServer(int client) {

--- a/scripting/get5/teamlogic.sp
+++ b/scripting/get5/teamlogic.sp
@@ -365,7 +365,7 @@ public bool RemovePlayerFromTeams(const char[] auth) {
       GetTeamAuths(team).Erase(index);
       int target = AuthToClient(steam64);
       if (IsAuthedPlayer(target) && !g_InScrimMode) {
-        KickClient(target, "%t", "YourAreNotAPlayerInfoMessage");
+        RememberAndKickClient(target, "%t", "YourAreNotAPlayerInfoMessage");
       }
       return true;
     }


### PR DESCRIPTION
Closes #589 

The last kicked player is saved in `g_LastKickedPlayerAuth`. (By the way, I don't know why, but I couldn't use `AUTH_LENGTH` for the size of this char array, it wasn't compiling...)

All client kicks with reason "YourAreNotAPlayerInfoMessage" are now saving the player auth in the global variable.

If for whatever reason, an admin wants to undo the effect of this command (remove the added player), he can do the following :

- Fake a new `get5_addkickedplayer` call, with any team as argument (`team1|team2|spec`)
- This command will fail because the player is already added, but **it will print the steamid** that he needs in the error message
- Use `get5_removeplayer` with the aforementioned steamid (copy-paste)

I don't reset `g_LastKickedPlayerAuth` after the command to enable the latter scenario. This variable will be overwritten when another player gets kicked.

The command can't be used as long as no player is kicked.

Maybe a command `get5_removekickedplayer` would be a good thing to add to complete the pair of commands...

I didn't think about that before. This would save admins from having to use the workaround scenario 😅

