### PR TITLE
Add quotes for teams in get5_listbackups

### DIFF
--- a/scripting/get5/backups.sp
+++ b/scripting/get5/backups.sp
@@ -92,7 +92,7 @@ public bool GetBackupInfo(const char[] path, char[] info, int maxlength) {
 
   // Try entering Valve's backup section (it doesn't always exist).
   if (!kv.JumpToKey("valve_backup")) {
-    Format(info, maxlength, "%s %s %s %s", path, timestamp, team1Name, team2Name);
+    Format(info, maxlength, "%s %s \"%s\" \"%s\"", path, timestamp, team1Name, team2Name);
     delete kv;
     return true;
   }
@@ -102,7 +102,7 @@ public bool GetBackupInfo(const char[] path, char[] info, int maxlength) {
 
   // Try entering FirstHalfScore section.
   if (!kv.JumpToKey("FirstHalfScore")) {
-    Format(info, maxlength, "%s %s %s %s %s %d %d", path, timestamp, team1Name, team2Name, map, 0, 0);
+    Format(info, maxlength, "%s %s \"%s\" \"%s\" %s %d %d", path, timestamp, team1Name, team2Name, map, 0, 0);
     delete kv;
     return true;
   }
@@ -115,7 +115,7 @@ public bool GetBackupInfo(const char[] path, char[] info, int maxlength) {
 
   // Try entering SecondHalfScore section.
   if (!kv.JumpToKey("SecondHalfScore")) {
-    Format(info, maxlength, "%s %s %s %s %s %d %d", path, timestamp, team1Name, team2Name, map, team1Score, team2Score);
+    Format(info, maxlength, "%s %s \"%s\" \"%s\" %s %d %d", path, timestamp, team1Name, team2Name, map, team1Score, team2Score);
     delete kv;
     return true;
   }
@@ -127,7 +127,7 @@ public bool GetBackupInfo(const char[] path, char[] info, int maxlength) {
   kv.GoBack();
   delete kv;
   
-  Format(info, maxlength, "%s %s %s %s %s %d %d", path, timestamp, team1Name, team2Name, map, team1Score, team2Score);
+  Format(info, maxlength, "%s %s \"%s\" \"%s\" %s %d %d", path, timestamp, team1Name, team2Name, map, team1Score, team2Score);
   return true;
 }
 


### PR DESCRIPTION
Here's a problematic output example of `get5_listbackups`:

```bash
get5_backup_match49639254-6032-45a6-8286-379637cd064c_map0_round3.cfg 2020-11-26 17:18:53 Les Petits Du Quartier Win Machines de_vertigo 2 1
```

The problem is... I didn't think about spaces in team names when I wrote the function.

Here, the first team is "Les Petits Du Quartier" and the second team is "Win Machines". So, first it's not very readable (from a human point of view) and second, it's not usable with regular expressions...

So, here's the output after this PR:

```bash
get5_backup_match49639254-6032-45a6-8286-379637cd064c_map0_round3.cfg 2020-11-26 17:18:53 "Les Petits Du Quartier" "Win Machines" de_vertigo 2 1
```

**Note:** for the curious, here is my regex : https://regex101.com/r/5Z6d4s/1 😊