### PR TITLE
added return on match config loading initialisation in Command_LoadMatchUrl

### DIFF
--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -846,6 +846,10 @@ public Action Command_LoadMatchUrl(int client, int args) {
       if (!LoadMatchFromUrl(arg)) {
         ReplyToCommand(client, "Failed to load match config.");
       }
+      else
+      {
+        ReplyToCommand(client, "Match config loading initialized.");
+      }
     } else {
       ReplyToCommand(client, "Usage: get5_loadmatch_url <url>");
     }


### PR DESCRIPTION
We have added a little feedback text when the Command_LoadMatchUrl was successfully triggered so it can be detected as executed by external rcon librarys.