### PR TITLE
Auto-ready spectators

### DIFF
--- a/scripting/get5/readysystem.sp
+++ b/scripting/get5/readysystem.sp
@@ -67,6 +67,10 @@ public bool IsTeamReady(MatchTeam team) {
   int playerCount = GetTeamPlayerCount(team);
   int readyCount = GetTeamReadyCount(team);
 
+  if (team == MatchTeam_TeamSpec && minReady == 0) {
+    return true;
+  }
+
   if (playerCount == readyCount && playerCount >= minPlayers) {
     return true;
   }


### PR DESCRIPTION
Fix #600

With that, spectators won't have to `!ready` if `min_spectators_to_ready` is set to 0, which is the default value.