### PR TITLE
MVP Stats + MySQL best practices and UTF8

### DIFF
--- a/misc/import_stats.sql
+++ b/misc/import_stats.sql
@@ -65,6 +65,7 @@ CREATE TABLE `get5_stats_players`
     `tradekill`          smallint(5) unsigned NOT NULL,
     `kast`               smallint(5) unsigned NOT NULL,
     `contribution_score` smallint(5) unsigned NOT NULL,
+    `mvp`                smallint(5) unsigned NOT NULL,
     PRIMARY KEY (`matchid`, `mapnumber`, `steamid64`),
     KEY `steamid64` (`steamid64`),
     CONSTRAINT `get5_stats_players_matchid` FOREIGN KEY (`matchid`) REFERENCES `get5_stats_matches` (`matchid`)

--- a/misc/import_stats.sql
+++ b/misc/import_stats.sql
@@ -1,112 +1,72 @@
---
--- Table structure for table `get5_stats_maps`
---
-
-DROP TABLE IF EXISTS `get5_stats_maps`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `get5_stats_maps` (
-  `matchid` int(10) unsigned NOT NULL,
-  `mapnumber` smallint(5) unsigned NOT NULL,
-  `start_time` datetime NOT NULL,
-  `end_time` datetime,
-  `winner` varchar(16) NOT NULL DEFAULT '',
-  `mapname` varchar(64) NOT NULL DEFAULT '',
-  `team1_score` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `team2_score` smallint(5) unsigned NOT NULL DEFAULT '0',
-  PRIMARY KEY (`matchid`,`mapnumber`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-/*!40101 SET character_set_client = @saved_cs_client */;
-
---
--- Dumping data for table `get5_stats_maps`
---
-
-LOCK TABLES `get5_stats_maps` WRITE;
-/*!40000 ALTER TABLE `get5_stats_maps` DISABLE KEYS */;
-/*!40000 ALTER TABLE `get5_stats_maps` ENABLE KEYS */;
-UNLOCK TABLES;
-
---
--- Table structure for table `get5_stats_matches`
---
-
-DROP TABLE IF EXISTS `get5_stats_matches`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `get5_stats_matches` (
-  `matchid` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `start_time` datetime NOT NULL,
-  `end_time` datetime,
-  `winner` varchar(16) NOT NULL DEFAULT '',
-  `series_type` varchar(64) NOT NULL DEFAULT '',
-  `team1_name` varchar(64) NOT NULL DEFAULT '',
-  `team1_score` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `team2_name` varchar(64) NOT NULL DEFAULT '',
-  `team2_score` smallint(5) unsigned NOT NULL DEFAULT '0',
-  PRIMARY KEY (`matchid`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-/*!40101 SET character_set_client = @saved_cs_client */;
-
---
--- Dumping data for table `get5_stats_matches`
---
-
-LOCK TABLES `get5_stats_matches` WRITE;
-/*!40000 ALTER TABLE `get5_stats_matches` DISABLE KEYS */;
-/*!40000 ALTER TABLE `get5_stats_matches` ENABLE KEYS */;
-UNLOCK TABLES;
-
---
--- Table structure for table `get5_stats_players`
---
-
 DROP TABLE IF EXISTS `get5_stats_players`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `get5_stats_players` (
-  `matchid` int(10) unsigned NOT NULL,
-  `mapnumber` smallint(5) unsigned NOT NULL,
-  `steamid64` varchar(32) NOT NULL,
-  `team` varchar(16) NOT NULL DEFAULT '',
-  `rounds_played` smallint(5) unsigned NOT NULL,
-  `name` varchar(64) NOT NULL,
-  `kills` smallint(5) unsigned NOT NULL,
-  `deaths` smallint(5) unsigned NOT NULL,
-  `assists` smallint(5) unsigned NOT NULL,
-  `flashbang_assists` smallint(5) unsigned NOT NULL,
-  `teamkills` smallint(5) unsigned NOT NULL,
-  `headshot_kills` smallint(5) unsigned NOT NULL,
-  `damage` int(10) unsigned NOT NULL,
-  `bomb_plants` smallint(5) unsigned NOT NULL,
-  `bomb_defuses` smallint(5) unsigned NOT NULL,
-  `v1` smallint(5) unsigned NOT NULL,
-  `v2` smallint(5) unsigned NOT NULL,
-  `v3` smallint(5) unsigned NOT NULL,
-  `v4` smallint(5) unsigned NOT NULL,
-  `v5` smallint(5) unsigned NOT NULL,
-  `2k` smallint(5) unsigned NOT NULL,
-  `3k` smallint(5) unsigned NOT NULL,
-  `4k` smallint(5) unsigned NOT NULL,
-  `5k` smallint(5) unsigned NOT NULL,
-  `firstkill_t` smallint(5) unsigned NOT NULL,
-  `firstkill_ct` smallint(5) unsigned NOT NULL,
-  `firstdeath_t` smallint(5) unsigned NOT NULL,
-  `firstdeath_ct` smallint(5) unsigned NOT NULL,
-  `tradekill` smallint(5) unsigned NOT NULL,
-  `kast` smallint(5) unsigned NOT NULL,
-  `contribution_score` smallint(5) unsigned NOT NULL,
-  PRIMARY KEY (`matchid`,`mapnumber`,`steamid64`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `get5_stats_maps`;
+DROP TABLE IF EXISTS `get5_stats_matches`;
 
---
--- Dumping data for table `get5_stats_players`
---
+CREATE TABLE `get5_stats_matches`
+(
+    `matchid`     int(10) unsigned     NOT NULL AUTO_INCREMENT,
+    `start_time`  datetime             NOT NULL,
+    `end_time`    datetime             NULL     DEFAULT NULL,
+    `winner`      varchar(16)          NOT NULL DEFAULT '',
+    `series_type` varchar(64)          NOT NULL DEFAULT '',
+    `team1_name`  varchar(64)          NOT NULL DEFAULT '',
+    `team1_score` smallint(5) unsigned NOT NULL DEFAULT '0',
+    `team2_name`  varchar(64)          NOT NULL DEFAULT '',
+    `team2_score` smallint(5) unsigned NOT NULL DEFAULT '0',
+    PRIMARY KEY (`matchid`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4;
 
-LOCK TABLES `get5_stats_players` WRITE;
-/*!40000 ALTER TABLE `get5_stats_players` DISABLE KEYS */;
-/*!40000 ALTER TABLE `get5_stats_players` ENABLE KEYS */;
-UNLOCK TABLES;
+CREATE TABLE `get5_stats_maps`
+(
+    `matchid`     int(10) unsigned     NOT NULL,
+    `mapnumber`   smallint(5) unsigned NOT NULL,
+    `start_time`  datetime             NOT NULL,
+    `end_time`    datetime             NULL     DEFAULT NULL,
+    `winner`      varchar(16)          NOT NULL DEFAULT '',
+    `mapname`     varchar(64)          NOT NULL DEFAULT '',
+    `team1_score` smallint(5) unsigned NOT NULL DEFAULT '0',
+    `team2_score` smallint(5) unsigned NOT NULL DEFAULT '0',
+    PRIMARY KEY (`matchid`, `mapnumber`),
+    CONSTRAINT `get5_stats_maps_matchid` FOREIGN KEY (`matchid`) REFERENCES `get5_stats_matches` (`matchid`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4;
 
--- Dump completed on 2016-07-03  1:10:28
+CREATE TABLE `get5_stats_players`
+(
+    `matchid`            int(10) unsigned     NOT NULL,
+    `mapnumber`          smallint(5) unsigned NOT NULL,
+    `steamid64`          varchar(32)          NOT NULL,
+    `team`               varchar(16)          NOT NULL DEFAULT '',
+    `rounds_played`      smallint(5) unsigned NOT NULL,
+    `name`               varchar(64)          NOT NULL,
+    `kills`              smallint(5) unsigned NOT NULL,
+    `deaths`             smallint(5) unsigned NOT NULL,
+    `assists`            smallint(5) unsigned NOT NULL,
+    `flashbang_assists`  smallint(5) unsigned NOT NULL,
+    `teamkills`          smallint(5) unsigned NOT NULL,
+    `headshot_kills`     smallint(5) unsigned NOT NULL,
+    `damage`             int(10) unsigned     NOT NULL,
+    `bomb_plants`        smallint(5) unsigned NOT NULL,
+    `bomb_defuses`       smallint(5) unsigned NOT NULL,
+    `v1`                 smallint(5) unsigned NOT NULL,
+    `v2`                 smallint(5) unsigned NOT NULL,
+    `v3`                 smallint(5) unsigned NOT NULL,
+    `v4`                 smallint(5) unsigned NOT NULL,
+    `v5`                 smallint(5) unsigned NOT NULL,
+    `2k`                 smallint(5) unsigned NOT NULL,
+    `3k`                 smallint(5) unsigned NOT NULL,
+    `4k`                 smallint(5) unsigned NOT NULL,
+    `5k`                 smallint(5) unsigned NOT NULL,
+    `firstkill_t`        smallint(5) unsigned NOT NULL,
+    `firstkill_ct`       smallint(5) unsigned NOT NULL,
+    `firstdeath_t`       smallint(5) unsigned NOT NULL,
+    `firstdeath_ct`      smallint(5) unsigned NOT NULL,
+    `tradekill`          smallint(5) unsigned NOT NULL,
+    `kast`               smallint(5) unsigned NOT NULL,
+    `contribution_score` smallint(5) unsigned NOT NULL,
+    PRIMARY KEY (`matchid`, `mapnumber`, `steamid64`),
+    KEY `steamid64` (`steamid64`),
+    CONSTRAINT `get5_stats_players_matchid` FOREIGN KEY (`matchid`) REFERENCES `get5_stats_matches` (`matchid`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4;

--- a/scripting/get5/stats.sp
+++ b/scripting/get5/stats.sp
@@ -8,6 +8,7 @@ public void Stats_PluginStart() {
   HookEvent("bomb_exploded", Stats_BombExplodedEvent);
   HookEvent("flashbang_detonate", Stats_FlashbangDetonateEvent, EventHookMode_Pre);
   HookEvent("player_blind", Stats_PlayerBlindEvent);
+  HookEvent("round_mvp", Stats_RoundMVPEvent);
 }
 
 public void Stats_Reset() {
@@ -388,6 +389,21 @@ public Action Stats_PlayerBlindEvent(Event event, const char[] name, bool dontBr
   int userid = event.GetInt("userid");
   int client = GetClientOfUserId(userid);
   RequestFrame(GetFlashInfo, GetClientSerial(client));
+
+  return Plugin_Continue;
+}
+
+public Action Stats_RoundMVPEvent(Event event, const char[] name, bool dontBroadcast) {
+  if (g_GameState != Get5State_Live) {
+    return Plugin_Continue;
+  }
+
+  int userid = event.GetInt("userid");
+  int client = GetClientOfUserId(userid);
+
+  if (IsValidClient(client)) {
+    IncrementPlayerStat(client, STAT_MVP);
+  }
 
   return Plugin_Continue;
 }

--- a/scripting/get5_mysqlstats.sp
+++ b/scripting/get5_mysqlstats.sp
@@ -259,6 +259,7 @@ public void AddPlayerStats(KeyValues kv, MatchTeam team) {
       int tradekill = kv.GetNum(STAT_TRADEKILL);
       int kast = kv.GetNum(STAT_KAST);
       int contribution_score = kv.GetNum(STAT_CONTRIBUTION_SCORE);
+      int mvp = kv.GetNum(STAT_MVP);
 
       char teamString[16];
       GetTeamString(team, teamString, sizeof(teamString));
@@ -275,7 +276,7 @@ public void AddPlayerStats(KeyValues kv, MatchTeam team) {
                 `v1`, `v2`, `v3`, `v4`, `v5`, \
                 `2k`, `3k`, `4k`, `5k`, \
                 `firstkill_t`, `firstkill_ct`, `firstdeath_t`, `firstdeath_ct`, \
-                `tradekill`, `kast`, `contribution_score` \
+                `tradekill`, `kast`, `contribution_score`, `mvp` \
                 ) VALUES \
                 (%d, %d, '%s', '%s', \
                 %d, '%s', %d, %d, %d, \
@@ -284,7 +285,7 @@ public void AddPlayerStats(KeyValues kv, MatchTeam team) {
                 %d, %d, %d, %d, %d, \
                 %d, %d, %d, %d, \
                 %d, %d, %d, %d, \
-                %d, %d, %d) \
+                %d, %d, %d, %d) \
                 ON DUPLICATE KEY UPDATE \
                 `rounds_played` = VALUES(`rounds_played`), \
                 `kills` = VALUES(`kills`), \
@@ -311,7 +312,8 @@ public void AddPlayerStats(KeyValues kv, MatchTeam team) {
                 `firstdeath_ct` = VALUES(`firstdeath_ct`), \
                 `tradekill` = VALUES(`tradekill`), \
                 `kast` = VALUES(`kast`), \
-                `contribution_score` = VALUES(`contribution_score`)",
+                `contribution_score` = VALUES(`contribution_score`), \
+                `mvp` = VALUES(`mvp`)",
              g_MatchID, mapNumber, authSz, teamString, 
              roundsplayed, nameSz, kills, deaths, flashbang_assists, 
              assists, teamkills, headshot_kills, damage, 
@@ -319,7 +321,7 @@ public void AddPlayerStats(KeyValues kv, MatchTeam team) {
              v1, v2, v3, v4, v5, 
              k2, k3, k4, k5, 
              firstkill_t, firstkill_ct, firstdeath_t, firstdeath_ct,
-             tradekill, kast, contribution_score);
+             tradekill, kast, contribution_score, mvp);
       // clang-format on
 
       LogDebug(queryBuffer);

--- a/scripting/include/get5.inc
+++ b/scripting/include/get5.inc
@@ -195,6 +195,7 @@ native int Get5_IncreasePlayerStat(int client, const char[] statName, int amount
 #define STAT_TRADEKILL "tradekill"
 #define STAT_KAST "kast"
 #define STAT_CONTRIBUTION_SCORE "contribution_score"
+#define STAT_MVP "mvp"
 
 public SharedPlugin __pl_get5 = {
     name = "get5",


### PR DESCRIPTION
Hello

I plan on starting to collect stats via MySQL and I came across some minor problems with the current integration.

1. Use of `SELECT LAST_INSERT_ID()` to retrieve the latest insert ID is unnecessary given the SourceMod driver. You can retrieve the latest auto-increment ID used from the `InsertId` property of the result-set returned after performing an insert. I've adjusted this and tested that it works as expected. It gets rid of the transaction altogether.

3. Use of `REPLACE INTO ...` instead of `INSERT INTO (...) ON DUPLICATE KEY UPDATE` is a bad idea. Not only is it much, much slower, but it actually deletes and re-inserts the row(s), which can cause problems for foreign keys if the rows are referenced elsewhere. I've changed this behavior when updating player stats.

3. UTF8 in MySQL is not really UTF8. It's only 3 bytes. The "real" UTF8 charset is called `utf8mb4`, which is also the default in MySQL 8+. The "old" `utf8` won't support emojis and other 4-byte characters. I adjusted this in the `import_stats.sql` script. See https://stackoverflow.com/questions/30074492/what-is-the-difference-between-utf8mb4-and-utf8-charsets-in-mysql.

4. There is no index defined on the `steamid64` column in the player stats table. This is highly relevant as it would be used when querying stats for any specific player. I've added this.

5. There are no foreign keys defined on tables that reference each other. I've added these, so the players and maps tables reference the match table.