### PR TITLE
Added auto-ready active players option + !switch alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Some client commands are available also for admin usage. For example, sm_pause a
 - ``!tech``: requests a technical pause (technical pauses have no time limit or max number of uses)
 - ``!coach``: moves a client to coach for their team
 - ``!stay``: elects to stay after a knife round win
-- ``!swap``: elects to swap after a knife round win
+- ``!swap`` or ``!switch``: elects to swap team side after a knife round win
 - ``!stop``: asks to reload the last match backup file, requires other team to confirm
 - ``!forceready``: force readies your team, letting your team start regardless of player numbers/whether they are ready
 

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -51,6 +51,7 @@
 /** ConVar handles **/
 ConVar g_AllowTechPauseCvar;
 ConVar g_AutoLoadConfigCvar;
+ConVar g_AutoReadyActivePlayers;
 ConVar g_BackupSystemEnabledCvar;
 ConVar g_CheckAuthsCvar;
 ConVar g_DamagePrintCvar;
@@ -258,6 +259,8 @@ public void OnPluginStart() {
   g_AutoLoadConfigCvar =
       CreateConVar("get5_autoload_config", "",
                    "Name of a match config file to automatically load when the server loads");
+  g_AutoReadyActivePlayers = CreateConVar("get5_auto_ready_active_players", "0",
+                   "Whether to automatically mark players as ready if they kill anyone in the warmup or veto phase.");
   g_BackupSystemEnabledCvar =
       CreateConVar("get5_backup_system_enabled", "1", "Whether the get5 backup system is enabled");
   g_DamagePrintCvar =
@@ -370,6 +373,8 @@ public void OnPluginStart() {
   AddAliasedCommand("stay", Command_Stay,
                     "Elects to stay on the current team after winning a knife round");
   AddAliasedCommand("swap", Command_Swap,
+                    "Elects to swap the current teams after winning a knife round");
+  AddAliasedCommand("switch", Command_Swap,
                     "Elects to swap the current teams after winning a knife round");
   AddAliasedCommand("t", Command_T, "Elects to start on T side after winning a knife round");
   AddAliasedCommand("ct", Command_Ct, "Elects to start on CT side after winning a knife round");

--- a/scripting/get5/readysystem.sp
+++ b/scripting/get5/readysystem.sp
@@ -139,14 +139,23 @@ public Action Command_AdminForceReady(int client, int args) {
 }
 
 // Client commands
+// Re-used to automatically ready players on warmup-activity, hence the helper-method.
+public void HandleReadyCommand(int client, bool autoReady) {
 
-public Action Command_Ready(int client, int args) {
+  if (!IsReadyGameState()) {
+    return;
+  }
+
   MatchTeam team = GetClientMatchTeam(client);
-  if (!IsReadyGameState() || team == MatchTeam_TeamNone || IsClientReady(client)) {
-    return Plugin_Handled;
+  if (team == MatchTeam_TeamNone || IsClientReady(client)) {
+    return;
   }
 
   Get5_Message(client, "%t", "YouAreReady");
+
+  if (autoReady) {
+    PrintHintText(client, "%t", "YouAreReadyAuto");
+  }
 
   SetClientReady(client, true);
   if (IsTeamReady(team)) {
@@ -154,6 +163,10 @@ public Action Command_Ready(int client, int args) {
     HandleReadyMessage(team);
   }
 
+}
+
+public Action Command_Ready(int client, int args) {
+  HandleReadyCommand(client, false);
   return Plugin_Handled;
 }
 

--- a/scripting/get5/stats.sp
+++ b/scripting/get5/stats.sp
@@ -180,12 +180,18 @@ public void Stats_SeriesEnd(MatchTeam winner) {
 }
 
 public Action Stats_PlayerDeathEvent(Event event, const char[] name, bool dontBroadcast) {
+
+  int attacker = GetClientOfUserId(event.GetInt("attacker"));
+
   if (g_GameState != Get5State_Live) {
+    if (g_AutoReadyActivePlayers.BoolValue) {
+      // HandleReadyCommand checks for game state, so we don't need to do that here as well.
+      HandleReadyCommand(attacker, true);
+    }
     return Plugin_Continue;
   }
 
   int victim = GetClientOfUserId(event.GetInt("userid"));
-  int attacker = GetClientOfUserId(event.GetInt("attacker"));
   int assister = GetClientOfUserId(event.GetInt("assister"));
   bool headshot = event.GetBool("headshot");
 

--- a/translations/get5.phrases.txt
+++ b/translations/get5.phrases.txt
@@ -25,6 +25,10 @@
     {
         "en"            "You have been marked as ready."
     }
+    "YouAreReadyAuto"
+    {
+        "en"            "NOTE: You have been marked as ready due to game activity. Type !unready if you are not ready."
+    }
     "YouAreNotReady"
     {
         "en"            "You have been marked as NOT ready."


### PR DESCRIPTION
Hello

I often find players fooling around in the warmup-phase - especially in the new 1v1 arenas - without typing `.ready`, leading to unnecessarily long wait-times where people yell at each other to ready up while others run around killing each other, so to mitigate this I added an option that will automatically ready players during warmup or veto if they _shoot_ someone. It defaults to disabled to maintain current functionality but can be enabled with a cvar.

I used `PrintHintText` instead of the chat, as the message is quite important and could easily be overlooked. If you don't like this change I can use the regular method instead.

I also added a `!switch` alias as that's what FaceIT uses and it seems to annoy people that only `!swap` works.