### PR TITLE
Pause/Unpause events and forwards

### DIFF
--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -162,6 +162,7 @@ bool g_TeamGivenStopCommand[MATCHTEAM_COUNT];
 bool g_InExtendedPause;
 int g_TeamPauseTimeUsed[MATCHTEAM_COUNT];
 int g_TeamPausesUsed[MATCHTEAM_COUNT];
+int g_PauseTimeUsed = 0;
 int g_ReadyTimeWaitingUsed = 0;
 char g_DefaultTeamColors[][] = {
     TEAM1_COLOR,
@@ -208,6 +209,8 @@ Handle g_OnPreLoadMatchConfig = INVALID_HANDLE;
 Handle g_OnRoundStatsUpdated = INVALID_HANDLE;
 Handle g_OnSeriesInit = INVALID_HANDLE;
 Handle g_OnSeriesResult = INVALID_HANDLE;
+Handle g_OnMatchPaused = INVALID_HANDLE;
+Handle g_OnMatchUnpaused = INVALID_HANDLE;
 
 #include "get5/util.sp"
 #include "get5/version.sp"
@@ -488,6 +491,8 @@ public void OnPluginStart() {
   g_OnSeriesInit = CreateGlobalForward("Get5_OnSeriesInit", ET_Ignore);
   g_OnSeriesResult =
       CreateGlobalForward("Get5_OnSeriesResult", ET_Ignore, Param_Cell, Param_Cell, Param_Cell);
+  g_OnMatchPaused = CreateGlobalForward("Get5_OnMatchPaused", ET_Ignore, Param_Cell, Param_Cell);
+  g_OnMatchUnpaused = CreateGlobalForward("Get5_OnMatchUnpaused", ET_Ignore, Param_Cell);
 
   /** Start any repeating timers **/
   CreateTimer(CHECK_READY_TIMER_INTERVAL, Timer_CheckReady, _, TIMER_REPEAT);

--- a/scripting/get5/eventlogger.sp
+++ b/scripting/get5/eventlogger.sp
@@ -52,6 +52,12 @@ static void AddTeam(JSON_Object params, const char[] key, MatchTeam team) {
   params.SetString(key, value);
 }
 
+static void AddPause(JSON_Object params, const char[] key, PauseType pause) {
+  char value[16];
+  GetPauseType(pause, value, sizeof(value));
+  params.SetString(key, value);
+}
+
 static void AddCSTeam(JSON_Object params, const char[] key, int team) {
   char value[16];
   CSTeamString(team, value, sizeof(value));
@@ -269,4 +275,19 @@ public void EventLogger_TeamUnready(MatchTeam team) {
   AddTeam(params, "team", team);
 
   EventLogger_EndEvent("team_unready");
+}
+
+public void EventLogger_PauseCommand(MatchTeam team, PauseType pauseReason) {
+  EventLogger_StartEvent();
+  AddMapData(params);
+  AddTeam(params, "request_team", team);
+  AddPause(params, "pause_reason", pauseReason);
+  EventLogger_EndEvent("pause_command");
+}
+
+public void EventLogger_UnpauseCommand(MatchTeam team) { 
+  EventLogger_StartEvent();
+  AddMapData(params);
+  AddTeam(params, "request_team", team);
+  EventLogger_EndEvent("unpause_command");
 }

--- a/scripting/get5/pausing.sp
+++ b/scripting/get5/pausing.sp
@@ -11,11 +11,24 @@ public Action Command_TechPause(int client, int args) {
 
   if (client == 0) {
     Pause();
+    EventLogger_PauseCommand(MatchTeam_TeamNone, PauseType_Tech);
+    LogDebug("Calling Get5_OnMatchPaused(team=%d, pauseReason=%d)", MatchTeam_TeamNone, PauseType_Tech);
+    Call_StartForward(g_OnMatchPaused);
+    Call_PushCell(MatchTeam_TeamNone);
+    Call_PushCell(PauseType_Tech);
+    Call_Finish();
     Get5_MessageToAll("%t", "AdminForceTechPauseInfoMessage");
     return Plugin_Handled;
   }
 
+  MatchTeam team = GetClientMatchTeam(client);
   Pause();
+  EventLogger_PauseCommand(team, PauseType_Tech);
+  LogDebug("Calling Get5_OnMatchPaused(team=%d, pauseReason=%d)", team, PauseType_Tech);
+  Call_StartForward(g_OnMatchPaused);
+  Call_PushCell(team);
+  Call_PushCell(PauseType_Tech);
+  Call_Finish();
   Get5_MessageToAll("%t", "MatchTechPausedByTeamMessage", client);
 
   return Plugin_Handled;
@@ -32,6 +45,12 @@ public Action Command_Pause(int client, int args) {
     g_InExtendedPause = true;
 
     Pause();
+    EventLogger_PauseCommand(MatchTeam_TeamNone, PauseType_Tactical);
+    LogDebug("Calling Get5_OnMatchPaused(team=%d, pauseReason=%d)", MatchTeam_TeamNone, PauseType_Tactical);
+    Call_StartForward(g_OnMatchPaused);
+    Call_PushCell(MatchTeam_TeamNone);
+    Call_PushCell(PauseType_Tactical);
+    Call_Finish();
     Get5_MessageToAll("%t", "AdminForcePauseInfoMessage");
     return Plugin_Handled;
   }
@@ -65,14 +84,24 @@ public Action Command_Pause(int client, int args) {
   }
 
   // If the pause will need explicit resuming, we will create a timer to poll the pause status.
-  bool need_resume = Pause(g_FixedPauseTimeCvar.IntValue, MatchTeamToCSTeam(team), pausesLeft);
+  bool need_resume = Pause(g_FixedPauseTimeCvar.IntValue, MatchTeamToCSTeam(team));
+  EventLogger_PauseCommand(team, PauseType_Tactical);
+  LogDebug("Calling Get5_OnMatchPaused(team=%d, pauseReason=%d)", team, PauseType_Tactical);
+  Call_StartForward(g_OnMatchPaused);
+  Call_PushCell(team);
+  Call_PushCell(PauseType_Tactical);
+  Call_Finish();
+
   if (IsPlayer(client)) {
     Get5_MessageToAll("%t", "MatchPausedByTeamMessage", client);
   }
 
   if (IsPlayerTeam(team)) {
     if (need_resume) {
+      g_PauseTimeUsed = g_PauseTimeUsed + g_FixedPauseTimeCvar.IntValue - 1;
       CreateTimer(1.0, Timer_PauseTimeCheck, team, TIMER_REPEAT | TIMER_FLAG_NO_MAPCHANGE);
+      // Keep track of timer, since we don't want several timers created for one pause checking instance.
+      CreateTimer(1.0, Timer_UnpauseEventCheck, team, TIMER_REPEAT | TIMER_FLAG_NO_MAPCHANGE);
     }
 
     g_TeamPausesUsed[team]++;
@@ -96,6 +125,42 @@ public Action Command_Pause(int client, int args) {
   return Plugin_Handled;
 }
 
+public Action Timer_UnpauseEventCheck(Handle timer, int data) {
+  if (!Pauseable()) {
+    g_PauseTimeUsed = 0;
+    return Plugin_Stop;
+  }
+
+  // Unlimited pause time.
+  if (g_MaxPauseTimeCvar.IntValue <= 0) {
+    // Reset state.
+    g_PauseTimeUsed = 0;
+    return Plugin_Stop;
+  }
+
+  if (!InFreezeTime()) {
+    // Someone can call pause during a round and will set this timer.
+    // Keep running timer until we are paused.
+    return Plugin_Continue;
+  } else {
+    if (g_PauseTimeUsed <= 0) {
+      MatchTeam team = view_as<MatchTeam>(data);
+      EventLogger_UnpauseCommand(team);
+      LogDebug("Calling Get5_OnMatchUnpaused(team=%d)", team);
+      Call_StartForward(g_OnMatchUnpaused);
+      Call_PushCell(team);
+      Call_Finish();
+      // Reset state
+      g_PauseTimeUsed = 0;
+      return Plugin_Stop;
+    }
+    g_PauseTimeUsed--;
+    LogDebug("Subtracting time used. Current time = %d", g_PauseTimeUsed);
+  }
+
+  return Plugin_Continue;
+}
+
 public Action Timer_PauseTimeCheck(Handle timer, int data) {
   if (!Pauseable() || !IsPaused() || g_FixedPauseTimeCvar.BoolValue) {
     return Plugin_Stop;
@@ -113,7 +178,6 @@ public Action Timer_PauseTimeCheck(Handle timer, int data) {
 
   MatchTeam team = view_as<MatchTeam>(data);
   int timeLeft = g_MaxPauseTimeCvar.IntValue - g_TeamPauseTimeUsed[team];
-
   // Only count against the team's pause time if we're actually in the freezetime
   // pause and they haven't requested an unpause yet.
   if (InFreezeTime() && !g_TeamReadyForUnpause[team]) {
@@ -126,7 +190,6 @@ public Action Timer_PauseTimeCheck(Handle timer, int data) {
                         timeLeft, pausePeriodString);
     }
   }
-
   if (timeLeft <= 0) {
     Get5_MessageToAll("%t", "PauseRunoutInfoMessage", g_FormattedTeamNames[team]);
     Unpause();
@@ -143,6 +206,11 @@ public Action Command_Unpause(int client, int args) {
   // Let console force unpause
   if (client == 0) {
     Unpause();
+    EventLogger_UnpauseCommand(MatchTeam_TeamNone);
+    LogDebug("Calling Get5_OnMatchUnpaused(team=%d)", MatchTeam_TeamNone);
+    Call_StartForward(g_OnMatchUnpaused);
+    Call_PushCell(MatchTeam_TeamNone);
+    Call_Finish();
     Get5_MessageToAll("%t", "AdminForceUnPauseInfoMessage");
     return Plugin_Handled;
   }
@@ -156,6 +224,11 @@ public Action Command_Unpause(int client, int args) {
 
   if (g_TeamReadyForUnpause[MatchTeam_Team1] && g_TeamReadyForUnpause[MatchTeam_Team2]) {
     Unpause();
+    EventLogger_UnpauseCommand(team);
+    LogDebug("Calling Get5_OnMatchUnpaused(team=%d)", team);
+    Call_StartForward(g_OnMatchUnpaused);
+    Call_PushCell(team);
+    Call_Finish();
     if (IsPlayer(client)) {
       Get5_MessageToAll("%t", "MatchUnpauseInfoMessage", client);
     }

--- a/scripting/get5/util.sp
+++ b/scripting/get5/util.sp
@@ -719,6 +719,15 @@ public bool DeleteFileIfExists(const char[] path) {
   return true;
 }
 
+stock void GetPauseType(PauseType pause, char[] buffer, int len) {
+  if (pause == PauseType_Tech) {
+    Format(buffer, len, "technical");
+  } else if (pause == PauseType_Tactical) {
+    Format(buffer, len, "tactical");
+  } else {
+    Format(buffer, len, "unknown");
+  }
+}
 public bool IsJSONPath(const char[] path) {
   int length = strlen(path);
   if (length >= 5) {

--- a/scripting/include/get5.inc
+++ b/scripting/include/get5.inc
@@ -38,6 +38,11 @@ enum SideChoice {
   SideChoice_KnifeRound,  // There will be a knife round to choose sides
 };
 
+enum PauseType {
+  PauseType_Tech,     // Technical pause
+  PauseType_Tactical,      // Tactical Pause
+};
+
 // Called each get5-event with JSON formatted event text.
 forward void Get5_OnEvent(const char[] eventJson);
 


### PR DESCRIPTION
Hi!

Per the issue #412, this PR creates some forwards and events for pausing and un-pausing in game, so that they can be used in other applications/plugins as well (such as a web-panel notifying if a match is paused).

I saw that PR #386 hasn't been acted upon since I last looked, and I figured I would take a stab at the fixed timeout issue mentioned, as well as provide some context for a pause.

The pause events also take in which team is making the call, and a reason, either tactical or technical, this is to provide some context and help with a forward to determine why a pause was called.

I tested a few of the different possibilities for pausing, including fixed timer and tech pauses, and I think the events successfully pause/unpause under every event. 