### PR TITLE
Error log instead of exceptions when logging fails

### DIFF
--- a/scripting/get5/eventlogger.sp
+++ b/scripting/get5/eventlogger.sp
@@ -27,6 +27,8 @@ static void EventLogger_LogEvent(const char[] eventName, JSON_Object params) {
       if (hLogFile) {
         LogToOpenFileEx(hLogFile, buffer);
         CloseHandle(hLogFile);
+      } else {
+        LogError("Could not open file \"%s\"", logPath);
       }
     }
 

--- a/scripting/get5/eventlogger.sp
+++ b/scripting/get5/eventlogger.sp
@@ -22,7 +22,12 @@ static void EventLogger_LogEvent(const char[] eventName, JSON_Object params) {
 
     char logPath[PLATFORM_MAX_PATH];
     if (FormatCvarString(g_EventLogFormatCvar, logPath, sizeof(logPath))) {
-      LogToFileEx(logPath, buffer);
+      File hLogFile = OpenFile(logPath, "a+");
+
+      if (hLogFile) {
+        LogToOpenFileEx(hLogFile, buffer);
+        CloseHandle(hLogFile);
+      }
     }
 
     LogDebug("Calling Get5_OnEvent(event name = %s)", eventName);


### PR DESCRIPTION
Fix #618

Should get rid of exceptions when logging tries to write in a missing file by doing what is said in https://github.com/splewis/get5/issues/618#issuecomment-766273068.

The function [OpenFile()](https://sm.alliedmods.net/new-api/files/OpenFile) doesn't throw when the file could not be opened, but it returns `null`. We then use [LogToOpenFileEx()](https://sm.alliedmods.net/new-api/files/LogToOpenFileEx), only if the file **could** be opened.