### PR TITLE
Fixed Ready Tag not resetting properly on end match.

### DIFF
--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -775,8 +775,8 @@ public Action Command_EndMatch(int client, int args) {
   Call_PushCell(g_TeamSeriesScores[MatchTeam_Team2]);
   Call_Finish();
 
-  UpdateClanTags();
   ChangeState(Get5State_None);
+  UpdateClanTags();
 
   Get5_MessageToAll("%t", "AdminForceEndInfoMessage");
   RestoreCvars(g_MatchConfigChangedCvars);


### PR DESCRIPTION
I fixed the phenomenon that the ready tag is not reset correctly and remains when the match is end.

----------------------
Reproduction method
----------------------
!scrim
!ready
get5_endmatch