### PR TITLE
Prevent suicide increment when restoring backups

### DIFF
--- a/scripting/get5/stats.sp
+++ b/scripting/get5/stats.sp
@@ -182,7 +182,7 @@ public void Stats_SeriesEnd(MatchTeam winner) {
 public Action Stats_PlayerDeathEvent(Event event, const char[] name, bool dontBroadcast) {
   int attacker = GetClientOfUserId(event.GetInt("attacker"));
 
-  if (g_GameState != Get5State_Live) {
+  if (g_GameState != Get5State_Live || g_DoingBackupRestoreNow) {
     if (g_AutoReadyActivePlayers.BoolValue) {
       // HandleReadyCommand checks for game state, so we don't need to do that here as well.
       HandleReadyCommand(attacker, true);


### PR DESCRIPTION
When restoring backups each player gets +1 on the suicides stat which leaves the in-game stats and get5 stats out of sync. This commit prevents that.