### PR TITLE
Match restore issues

### DIFF
--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -670,6 +670,12 @@ public Action Timer_CheckReady(Handle timer) {
   if (g_GameState == Get5State_None) {
     return Plugin_Continue;
   }
+  
+  if (g_DoingBackupRestoreNow) {
+    LogDebug("Timer_CheckReady: Waiting for restore");
+    return Plugin_Continue;
+  }
+
 
   CheckTeamNameStatus(MatchTeam_Team1);
   CheckTeamNameStatus(MatchTeam_Team2);

--- a/scripting/get5/backups.sp
+++ b/scripting/get5/backups.sp
@@ -336,7 +336,7 @@ public void RestoreGet5Backup() {
 
     // There are some timing issues leading to incorrect score when restoring matches in second half.
     // Doing the restore on a timer    
-    CreateTimer(0.1, Time_StartRestore);   
+    CreateTimer(1.0, Time_StartRestore);   
   } else {
     SetStartingTeams();
     SetMatchTeamCvars();
@@ -360,11 +360,12 @@ public void RestoreGet5Backup() {
 }
 
 public Action Time_StartRestore(Handle timer) {
+  Pause();
+
   char tempValveBackup[PLATFORM_MAX_PATH];
   GetTempFilePath(tempValveBackup, sizeof(tempValveBackup), TEMP_VALVE_BACKUP_PATTERN);
   ServerCommand("mp_backup_restore_load_file \"%s\"", tempValveBackup);
   CreateTimer(0.1, Timer_FinishBackup);
-  Pause();
 }
 
 public Action Timer_FinishBackup(Handle timer) {

--- a/scripting/get5/backups.sp
+++ b/scripting/get5/backups.sp
@@ -334,8 +334,6 @@ public void RestoreGet5Backup() {
     ExecuteMatchConfigCvars();
     SetMatchRestartDelay();
 
-    Pause();
-
     // There are some timing issues leading to incorrect score when restoring matches in second half.
     // Doing the restore on a timer    
     CreateTimer(0.1, Time_StartRestore);   

--- a/scripting/get5/goinglive.sp
+++ b/scripting/get5/goinglive.sp
@@ -46,8 +46,7 @@ public Action MatchLive(Handle timer) {
 
   // We force the match end-delay to extend for the duration of the GOTV broadcast here.
   g_PendingSideSwap = false;
-  ConVar mp_match_restart_delay = FindConVar("mp_match_restart_delay");
-  SetConVarInt(mp_match_restart_delay, GetTvDelay() + MATCH_END_DELAY_AFTER_TV + 5);
+  SetMatchRestartDelay();
 
   for (int i = 0; i < 5; i++) {
     Get5_MessageToAll("%t", "MatchIsLiveInfoMessage");
@@ -60,4 +59,10 @@ public Action MatchLive(Handle timer) {
   }
 
   return Plugin_Handled;
+}
+
+public void SetMatchRestartDelay() {
+  ConVar mp_match_restart_delay = FindConVar("mp_match_restart_delay");
+  int delay = GetTvDelay() + MATCH_END_DELAY_AFTER_TV + 5;
+  SetConVarInt(mp_match_restart_delay, delay);
 }


### PR DESCRIPTION
While testing the restore functionality I ran into 3 separate issues:

1. Restoring to another map than the current map results in the match starting Warmup or Knife depending on the current map number.
2. Restoring to second half on an another map than the current map results in the "end of first half screen" and incorrect match scores. Also the teams may be spawned on incorrect sides.
3. mp_match_restart_delay was not set

Any feedback is much appreciated!