### PR TITLE
Added Ready Team Tag CVAR to Enable or Disable it

### DIFF
--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -71,6 +71,7 @@ ConVar g_MaxPauseTimeCvar;
 ConVar g_MessagePrefixCvar;
 ConVar g_PausingEnabledCvar;
 ConVar g_PrettyPrintJsonCvar;
+ConVar g_ReadyTeamTagCvar;
 ConVar g_ResetPausesEachHalfCvar;
 ConVar g_ServerIdCvar;
 ConVar g_SetClientClanTagCvar;
@@ -314,6 +315,8 @@ public void OnPluginStart() {
   g_PausingEnabledCvar = CreateConVar("get5_pausing_enabled", "1", "Whether pausing is allowed.");
   g_PrettyPrintJsonCvar = CreateConVar("get5_pretty_print_json", "1",
                                        "Whether all JSON output is in pretty-print format.");
+  g_ReadyTeamTagCvar = CreateConVar("get5_ready_team_tag" , "1",
+                                    "Adds [READY] [NOT READY] Tags before Team Names. 0 to disable it.");
   g_ServerIdCvar = CreateConVar(
       "get5_server_id", "0",
       "Integer that identifies your server. This is used in temp files to prevent collisions.");

--- a/scripting/get5/util.sp
+++ b/scripting/get5/util.sp
@@ -260,13 +260,17 @@ stock void SetTeamInfo(int csTeam, const char[] name, const char[] flag = "",
 
   // Add Ready/Not ready tags to team name if in warmup.
   char taggedName[MAX_CVAR_LENGTH];
-  if ((g_GameState == Get5State_Warmup || g_GameState == Get5State_PreVeto) &&
-      !g_DoingBackupRestoreNow) {
-    MatchTeam matchTeam = CSTeamToMatchTeam(csTeam);
-    if (IsTeamReady(matchTeam)) {
-      Format(taggedName, sizeof(taggedName), "%T %s", "ReadyTag", LANG_SERVER, name);
+  if(g_ReadyTeamTagCvar.bool) {                   
+    if ((g_GameState == Get5State_Warmup || g_GameState == Get5State_PreVeto) &&
+        !g_DoingBackupRestoreNow) {
+      MatchTeam matchTeam = CSTeamToMatchTeam(csTeam);
+      if (IsTeamReady(matchTeam)) {
+        Format(taggedName, sizeof(taggedName), "%T %s", "ReadyTag", LANG_SERVER, name);
+      } else {
+        Format(taggedName, sizeof(taggedName), "%T %s", "NotReadyTag", LANG_SERVER, name);
+      }
     } else {
-      Format(taggedName, sizeof(taggedName), "%T %s", "NotReadyTag", LANG_SERVER, name);
+      strcopy(taggedName, sizeof(taggedName), name);
     }
   } else {
     strcopy(taggedName, sizeof(taggedName), name);

--- a/scripting/get5/util.sp
+++ b/scripting/get5/util.sp
@@ -260,7 +260,7 @@ stock void SetTeamInfo(int csTeam, const char[] name, const char[] flag = "",
 
   // Add Ready/Not ready tags to team name if in warmup.
   char taggedName[MAX_CVAR_LENGTH];
-  if(g_ReadyTeamTagCvar.bool) {                   
+  if(g_ReadyTeamTagCvar.BoolValue) {                   
     if ((g_GameState == Get5State_Warmup || g_GameState == Get5State_PreVeto) &&
         !g_DoingBackupRestoreNow) {
       MatchTeam matchTeam = CSTeamToMatchTeam(csTeam);


### PR DESCRIPTION
This was old request which i deleted before due to some reason. @splewis  If possible check it again and update it. 

It just add CVAR to enable or disable Team Ready Tag. 

Workaround works fine for Match Restoration Backup having [NOT READY] [READY] Tags. 

