### PR TITLE
Stats in JSON format

### DIFF
--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -879,7 +879,7 @@ public Action Command_DumpStats(int client, int args) {
     GetCmdArg(1, arg, sizeof(arg));
   }
 
-  if (g_StatsKv.ExportToFile(arg)) {
+  if (DumpToFilePath(arg)) {
     g_StatsKv.Rewind();
     ReplyToCommand(client, "Saved match stats to %s", arg);
   } else {

--- a/scripting/get5/matchconfig.sp
+++ b/scripting/get5/matchconfig.sp
@@ -146,7 +146,7 @@ public bool LoadMatchFile(const char[] config) {
   Call_PushString(config);
   Call_Finish();
 
-  if (StrContains(config, "json") >= 0) {
+  if (IsJSONPath(config)) {
     char configFile[PLATFORM_MAX_PATH];
     strcopy(configFile, sizeof(configFile), config);
     if (!FileExists(configFile)) {

--- a/scripting/get5/stats.sp
+++ b/scripting/get5/stats.sp
@@ -537,7 +537,7 @@ public bool DumpToFilePath(const char[] path) {
     return false;
   }
 
-  char jsonBuffer[32768]; // 32 KiB
+  char jsonBuffer[8192]; // 8 KiB
   stats.Encode(jsonBuffer, sizeof(jsonBuffer));
   json_cleanup_and_delete(stats);
   stats_file.WriteString(jsonBuffer, false);

--- a/scripting/get5/stats.sp
+++ b/scripting/get5/stats.sp
@@ -572,6 +572,8 @@ JSON_Object EncodeKeyValue(KeyValues kv) {
         json_kv.SetInt(keyBuffer, kv.GetNum(NULL_STRING));
       } else if (keyType == KvData_Float) {
         json_kv.SetFloat(keyBuffer, kv.GetFloat(NULL_STRING));
+      } else {
+        LogDebug("Can't JSON encode key '%s' with type %d", keyBuffer, keyType);
       }
     }
   } while (kv.GotoNextKey(false));

--- a/scripting/get5/stats.sp
+++ b/scripting/get5/stats.sp
@@ -527,7 +527,9 @@ public bool DumpToFile() {
 
 public bool DumpToFilePath(const char[] path) {
   g_StatsKv.Rewind();
+  g_StatsKv.GotoFirstSubKey(false);
   JSON_Object stats = EncodeKeyValue(g_StatsKv);
+  g_StatsKv.Rewind();
   
   File stats_file = OpenFile(path, "w");
   if (stats_file == null) {
@@ -555,9 +557,10 @@ JSON_Object EncodeKeyValue(KeyValues kv) {
   do {
     if (kv.GotoFirstSubKey(false)) {
       // Current key is a section. Browse it recursively.
-      kv.GetSectionName(sectionName, sizeof(sectionName));
-      json_kv.SetObject(sectionName, EncodeKeyValue(kv));
+      JSON_Object obj = EncodeKeyValue(kv);
       kv.GoBack();
+      kv.GetSectionName(sectionName, sizeof(sectionName));
+      json_kv.SetObject(sectionName, obj);
     } else {
       // Current key is a regular key, or an empty section.
       KvDataTypes keyType = kv.GetDataType(NULL_STRING);

--- a/scripting/get5/stats.sp
+++ b/scripting/get5/stats.sp
@@ -522,23 +522,7 @@ public void DumpToFile() {
 }
 
 public bool DumpToFilePath(const char[] path) {
-  int path_length = strlen(path);
-  // Check if path ends in ".json"
-  if (path_length >= 5) {
-    char ext[5];
-    ext[0] = path[path_length-5];
-    ext[1] = path[path_length-4];
-    ext[2] = path[path_length-3];
-    ext[3] = path[path_length-2];
-    ext[4] = path[path_length-1];
-    if (StrEqual(".json", ext, false)) {
-      // Dump in json format
-      return DumpToJSONFile(path);
-    }
-  }
-
-  // Does not end with json, default to VKV
-  return g_StatsKv.ExportToFile(path);
+  return IsJSONPath(path) ? DumpToJSONFile(path) : g_StatsKv.ExportToFile(path);
 }
 
 public bool DumpToJSONFile(const char[] path) {

--- a/scripting/get5/util.sp
+++ b/scripting/get5/util.sp
@@ -716,3 +716,12 @@ public bool DeleteFileIfExists(const char[] path) {
 
   return true;
 }
+
+public bool IsJSONPath(const char[] path) {
+  int length = strlen(path);
+  if (length >= 5) {
+    return strcmp(path[length - 5], ".json", false) == 0;
+  } else {
+    return false;
+  }
+}


### PR DESCRIPTION
Add support for writing stats in JSON format.

The feature is enabled by setting the `get5_stats_path_format` cvar to a value ending in `.json`

_The work is paid for in part by [ehub.gg](https://ehub.gg/)_