### PR TITLE
Improved damage report to include kills, assists and flash assists.

### DIFF
--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -144,6 +144,9 @@ int g_PlayerKilledBy[MAXPLAYERS + 1];
 float g_PlayerKilledByTime[MAXPLAYERS + 1];
 int g_DamageDone[MAXPLAYERS + 1][MAXPLAYERS + 1];
 int g_DamageDoneHits[MAXPLAYERS + 1][MAXPLAYERS + 1];
+bool g_DamageDoneKill[MAXPLAYERS + 1][MAXPLAYERS + 1];
+bool g_DamageDoneAssist[MAXPLAYERS + 1][MAXPLAYERS + 1];
+bool g_DamageDoneFlashAssist[MAXPLAYERS + 1][MAXPLAYERS + 1];
 bool g_PlayerRoundKillOrAssistOrTradedDeath[MAXPLAYERS + 1];
 bool g_PlayerSurvived[MAXPLAYERS + 1];
 KeyValues g_StatsKv;
@@ -270,8 +273,8 @@ public void OnPluginStart() {
       CreateConVar("get5_print_damage", "0", "Whether damage reports are printed on round end.");
   g_DamagePrintFormat = CreateConVar(
       "get5_damageprint_format",
-      "--> ({DMG_TO} dmg / {HITS_TO} hits) to ({DMG_FROM} dmg / {HITS_FROM} hits) from {NAME} ({HEALTH} HP)",
-      "Format of the damage output string. Avaliable tags are in the default, color tags such as {LIGHT_RED} and {GREEN} also work.");
+      "- [{KILL_TO}] ({DMG_TO} in {HITS_TO}) to [{KILL_FROM}] ({DMG_FROM} in {HITS_FROM}) from {NAME} ({HEALTH} HP)",
+      "Format of the damage output string. Available tags are in the default, color tags such as {LIGHT_RED} and {GREEN} also work. {KILL_TO} and {KILL_FROM} indicate kills, assists and flash assists as booleans, all of which are mutually exclusive.");
   g_CheckAuthsCvar =
       CreateConVar("get5_check_auths", "1",
                    "If set to 0, get5 will not force players to the correct team based on steamid");


### PR DESCRIPTION
Hello

This improves a little on the damage report printed after each round, adding boolean swithes (X, A and F, respectively) as indicators of kills, assists and flashes and removing the (kind of) redundant `dmg` and `hits` strings to compact the info a bit.

It looks something like this ingame, where X indicates a kill and is written in green if it's you who killed someone and in red if you were killed, A indicates an assist and F indicates a flash assists, both always written in yellow. No kills or assists become a white dash.

This change is backwards compatible and existing users would just have to replace their `g_DamagePrintFormat` convar with the example to achieve this behavior instead.

```
[Get5] Team A 1 - 0 Team B
- [X] (100 in 3) to [A] (44 in 1) from Player1 (0 HP)  - killed this player, they assisted in killing you
- [F] (0 in 0) to [X] (56 in 2) from Player2 (0 HP)  - killed by this player, flash assisted in killing them
- [-] (0 in 0) to [-] (0 in 0) from Player3 (84 HP)  - no interaction, this player survived
- [A] (73 in 2) to [-] (0 in 0) from Player4 (0 HP)  - assisted in killing this player
- [-] (30 in 1) to [-] (0 in 0) from Player5 (0 HP)  - dealt damage to this player, not enough for assist
```

You can see how it looks ingame in this video at 3:15: https://www.youtube.com/watch?v=poQVX9eCptA (not me playing, just someone using this version). Note this was video was from before I added assists, which is why it did not trigger on the last player. It does work and I tested the code from this PR in several games.