### PR TITLE
Fix g_BO2Match never being set to false on match load.

### DIFF
--- a/scripting/get5/matchconfig.sp
+++ b/scripting/get5/matchconfig.sp
@@ -349,6 +349,7 @@ static bool LoadMatchFromKv(KeyValues kv) {
     g_BO2Match = true;
     g_MapsToWin = 2;
   } else {
+    g_BO2Match = false;
     if (mapsToWin >= 1) {
       g_MapsToWin = mapsToWin;
     } else {
@@ -461,6 +462,7 @@ static bool LoadMatchFromJson(JSON_Object json) {
     g_BO2Match = true;
     g_MapsToWin = 2;
   } else {
+    g_BO2Match = false;
     if (mapsToWin >= 1) {
       g_MapsToWin = mapsToWin;
     } else {


### PR DESCRIPTION
Simple fix to clear the BO2Match flag so that vetoes will work properly after a BO2 is played. Closes #708 