### PR TITLE
Include Pause Forwards in get5.inc

### DIFF
--- a/scripting/include/get5.inc
+++ b/scripting/include/get5.inc
@@ -87,6 +87,12 @@ forward void Get5_OnSidePicked(MatchTeam team, const char[] map, int side);
 // Called when a demo finishes recording.
 forward void Get5_OnDemoFinished(const char[] filename);
 
+// Called when a match is paused.
+forward void Get5_OnMatchPaused(MatchTeam team, PauseType pauseReason);
+
+// Called when a match is unpaused.
+forward void Get5_OnMatchUnpaused(MatchTeam team);
+
 // Called when a match backup is restored.
 forward void Get5_OnBackupRestore();
 


### PR DESCRIPTION
Wow, my bad. I completely forgot to include the forwards in get5.inc. This PR should fix this, apologies! I think this should now be inline with all other events that are called and should make it public to API calls so long as it's included in those projects now as well.