### PR TITLE
version 0.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.zip
 *.tar.gz
 builds
+.idea

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -112,6 +112,10 @@ char g_FavoredTeamText[MAX_CVAR_LENGTH];
 int g_PlayersPerTeam = 5;
 int g_MinPlayersToReady = 1;
 int g_MinSpectatorsToReady = 0;
+int g_RoundNumber = 0;
+float g_RoundStartedTime = 0.0;
+float g_BombPlantedTime = 0.0;
+
 bool g_SkipVeto = false;
 float g_VetoMenuTime = 0.0;
 MatchSideType g_MatchSideType = MatchSideType_Standard;
@@ -199,21 +203,28 @@ Handle g_MatchConfigChangedCvars = INVALID_HANDLE;
 
 /** Forwards **/
 Handle g_OnBackupRestore = INVALID_HANDLE;
+Handle g_OnBombDefused = INVALID_HANDLE;
+Handle g_OnBombPlanted = INVALID_HANDLE;
 Handle g_OnDemoFinished = INVALID_HANDLE;
 Handle g_OnEvent = INVALID_HANDLE;
 Handle g_OnGameStateChanged = INVALID_HANDLE;
 Handle g_OnGoingLive = INVALID_HANDLE;
+Handle g_OnGrenadeThrown = INVALID_HANDLE;
 Handle g_OnLoadMatchConfigFailed = INVALID_HANDLE;
 Handle g_OnMapPicked = INVALID_HANDLE;
 Handle g_OnMapResult = INVALID_HANDLE;
 Handle g_OnMapVetoed = INVALID_HANDLE;
-Handle g_OnSidePicked = INVALID_HANDLE;
+Handle g_OnMatchPaused = INVALID_HANDLE;
+Handle g_OnMatchUnpaused = INVALID_HANDLE;
+Handle g_OnPlayerDied = INVALID_HANDLE;
+Handle g_OnPlayerBecameMVP = INVALID_HANDLE;
+Handle g_OnRoundEnd = INVALID_HANDLE;
+Handle g_OnRoundStart = INVALID_HANDLE;
 Handle g_OnPreLoadMatchConfig = INVALID_HANDLE;
 Handle g_OnRoundStatsUpdated = INVALID_HANDLE;
 Handle g_OnSeriesInit = INVALID_HANDLE;
 Handle g_OnSeriesResult = INVALID_HANDLE;
-Handle g_OnMatchPaused = INVALID_HANDLE;
-Handle g_OnMatchUnpaused = INVALID_HANDLE;
+Handle g_OnSidePicked = INVALID_HANDLE;
 
 #include "get5/util.sp"
 #include "get5/version.sp"
@@ -443,15 +454,17 @@ public void OnPluginStart() {
       "Runs get5 tests - should not be used on a live match server since it will reload a match config to test");
 
   /** Hooks **/
-  HookEvent("player_spawn", Event_PlayerSpawn);
   HookEvent("cs_win_panel_match", Event_MatchOver);
-  HookEvent("round_prestart", Event_RoundPreStart);
-  HookEvent("round_freeze_end", Event_FreezeEnd);
-  HookEvent("round_end", Event_RoundEnd);
-  HookEvent("server_cvar", Event_CvarChanged, EventHookMode_Pre);
   HookEvent("player_connect_full", Event_PlayerConnectFull);
   HookEvent("player_disconnect", Event_PlayerDisconnect);
+  HookEvent("player_spawn", Event_PlayerSpawn);
   HookEvent("player_team", Event_OnPlayerTeam, EventHookMode_Pre);
+  HookEvent("round_end", Event_RoundEnd);
+  HookEvent("round_freeze_end", Event_FreezeEnd);
+  HookEvent("round_prestart", Event_RoundPreStart);
+  HookEvent("round_start", Event_RoundStart);
+  HookEvent("server_cvar", Event_CvarChanged, EventHookMode_Pre);
+
   Stats_PluginStart();
   Stats_InitSeries();
 
@@ -480,8 +493,22 @@ public void OnPluginStart() {
   g_OnGameStateChanged =
       CreateGlobalForward("Get5_OnGameStateChanged", ET_Ignore, Param_Cell, Param_Cell);
   g_OnGoingLive = CreateGlobalForward("Get5_OnGoingLive", ET_Ignore, Param_Cell);
+  g_OnGrenadeThrown = CreateGlobalForward("Get5_OnGrenadeThrown", ET_Ignore, Param_Cell, Param_String, Param_Cell, Param_Cell,
+    Param_Cell, Param_Cell);
   g_OnMapResult = CreateGlobalForward("Get5_OnMapResult", ET_Ignore, Param_String, Param_Cell,
                                       Param_Cell, Param_Cell, Param_Cell);
+  g_OnPlayerDied = CreateGlobalForward("Get5_OnPlayerDied", ET_Ignore, Param_String, Param_Cell,
+  Param_Cell, Param_Cell, Param_Cell, Param_Cell, Param_Cell, Param_Cell, Param_Cell, Param_Cell, Param_Cell,
+  Param_Cell, Param_Cell, Param_Cell, Param_Cell, Param_Cell);
+  g_OnPlayerBecameMVP = CreateGlobalForward("Get5_OnPlayerBecameMVP", ET_Ignore, Param_Cell, Param_Cell, Param_Cell,
+    Param_Cell, Param_Cell);
+  g_OnBombDefused = CreateGlobalForward("Get5_OnBombDefused", ET_Ignore, Param_Cell, Param_Cell, Param_Cell, Param_Cell,
+    Param_Cell, Param_Cell);
+  g_OnBombPlanted = CreateGlobalForward("Get5_OnBombPlanted", ET_Ignore, Param_Cell, Param_Cell, Param_Cell, Param_Cell,
+      Param_Cell);
+  g_OnRoundStart = CreateGlobalForward("Get5_OnRoundStart", ET_Ignore, Param_Cell, Param_Cell);
+  g_OnRoundEnd = CreateGlobalForward("Get5_OnRoundEnd", ET_Ignore, Param_Cell, Param_String, Param_Cell, Param_Cell,
+    Param_Cell, Param_Cell);
   g_OnLoadMatchConfigFailed =
       CreateGlobalForward("Get5_OnLoadMatchConfigFailed", ET_Ignore, Param_String);
   g_OnMapPicked = CreateGlobalForward("Get5_OnMapPicked", ET_Ignore, Param_Cell, Param_String);
@@ -1102,6 +1129,10 @@ public void KickClientsOnEnd() {
   }
 }
 
+public int GetMilliSecondsPassedSince(float timestamp) {
+  return RoundToFloor((GetEngineTime() - timestamp) * 1000);
+}
+
 public void EndSeries() {
   DelayFunction(10.0, KickClientsOnEnd);
   StopRecording();
@@ -1155,8 +1186,10 @@ public Action Event_RoundPreStart(Event event, const char[] name, bool dontBroad
 }
 
 public Action Event_FreezeEnd(Event event, const char[] name, bool dontBroadcast) {
+  LogDebug("Event_FreezeEnd");
   if (g_GameState == Get5State_Live) {
     Stats_RoundStart();
+    g_RoundStartedTime = GetEngineTime();
   }
 }
 
@@ -1179,6 +1212,22 @@ public void WriteBackup() {
     LogDebug("writing to %s", path);
     WriteBackStructure(path);
     g_LastGet5BackupCvar.SetString(path);
+  }
+}
+
+public Action Event_RoundStart(Event event, const char[] name, bool dontBroadcast) {
+  LogDebug("Event_RoundStart");
+  if (g_GameState == Get5State_Live) {
+    g_RoundNumber = GameRules_GetProp("m_totalRoundsPlayed") + 1;
+    int mapNumber = GetMapNumber();
+
+    EventLogger_RoundStart(g_RoundNumber);
+
+    LogDebug("Calling Get5_OnRoundStart(mapNumber=%d, roundNumber=%d)", mapNumber, g_RoundNumber);
+    Call_StartForward(g_OnRoundStart);
+    Call_PushCell(mapNumber);
+    Call_PushCell(g_RoundNumber);
+    Call_Finish();
   }
 }
 
@@ -1227,7 +1276,10 @@ public Action Event_RoundEnd(Event event, const char[] name, bool dontBroadcast)
 
   if (g_GameState == Get5State_Live) {
     int csTeamWinner = event.GetInt("winner");
-    int csReason = event.GetInt("reason");
+    // Reason is incorrect in CSGO compared to the enumerations defined here:
+    // https://github.com/alliedmodders/sourcemod/blob/master/plugins/include/cstrike.inc#L53-L77
+    // - which is why we subtract one.
+    int csReason = event.GetInt("reason") - 1;
 
     Get5_MessageToAll("%t", "CurrentScoreInfoMessage", g_TeamNames[MatchTeam_Team1],
                       CS_GetTeamScore(MatchTeamToCSTeam(MatchTeam_Team1)),
@@ -1239,8 +1291,6 @@ public Action Event_RoundEnd(Event event, const char[] name, bool dontBroadcast)
     LogDebug("Calling Get5_OnRoundStatsUpdated");
     Call_StartForward(g_OnRoundStatsUpdated);
     Call_Finish();
-
-    EventLogger_RoundEnd(csTeamWinner, csReason);
 
     int roundsPlayed = GameRules_GetProp("m_totalRoundsPlayed");
     LogDebug("m_totalRoundsPlayed = %d", roundsPlayed);
@@ -1269,6 +1319,27 @@ public Action Event_RoundEnd(Event event, const char[] name, bool dontBroadcast)
         }
       }
     }
+
+    char winnerString[16];
+    GetTeamString(CSTeamToMatchTeam(csTeamWinner), winnerString, sizeof(winnerString));
+
+    int mapNumber = GetMapNumber();
+    int roundDuration = GetMilliSecondsPassedSince(g_RoundStartedTime);
+
+    EventLogger_RoundEnd(g_RoundNumber, csTeamWinner, csReason, roundDuration);
+
+    LogDebug("Calling Get5_OnRoundEnd(winnerSide=%d, winnerTeam=%s, mapNumber=%d, roundNumber=%d, roundDuration=%d, winReason=%d)",
+        csTeamWinner, winnerString, mapNumber, g_RoundNumber, roundDuration, csReason);
+
+    Call_StartForward(g_OnRoundEnd);
+    Call_PushCell(csTeamWinner);
+    Call_PushString(winnerString);
+    Call_PushCell(mapNumber);
+    Call_PushCell(g_RoundNumber);
+    Call_PushCell(roundDuration);
+    Call_PushCell(csReason);
+    Call_Finish();
+
   }
 }
 
@@ -1383,6 +1454,8 @@ public Action Command_Status(int client, int args) {
     json.SetString("matchid", g_MatchID);
     json.SetString("loaded_config_file", g_LoadedConfigFile);
     json.SetInt("map_number", GetMapNumber());
+    json.SetInt("round_number", g_RoundNumber);
+    json.SetInt("round_time", GetMilliSecondsPassedSince(g_RoundStartedTime));
 
     JSON_Object team1 = new JSON_Object();
     AddTeamInfo(team1, MatchTeam_Team1);

--- a/scripting/get5/debug.sp
+++ b/scripting/get5/debug.sp
@@ -92,6 +92,7 @@ static void AddGlobalStateInfo(File f) {
   f.WriteLine("g_GameState = %d (%s)", g_GameState, buffer);
 
   f.WriteLine("g_MatchID = %s", g_MatchID);
+  f.WriteLine("g_RoundNumber = %d", g_RoundNumber);
   f.WriteLine("g_MapsToWin = %d", g_MapsToWin);
   f.WriteLine("g_BO2Match = %d", g_BO2Match);
   f.WriteLine("g_LastVetoTeam = %d", g_LastVetoTeam);
@@ -141,13 +142,13 @@ static void AddInterestingCvars(File f) {
   f.WriteLine("Interesting cvars:");
   WriteCvarString(f, "get5_allow_technical_pause");
   WriteCvarString(f, "get5_autoload_config");
+  WriteCvarString(f, "get5_auto_ready_active_players");
   WriteCvarString(f, "get5_check_auths");
   WriteCvarString(f, "get5_fixed_pause_time");
   WriteCvarString(f, "get5_kick_when_no_match_loaded");
   WriteCvarString(f, "get5_live_cfg");
   WriteCvarString(f, "get5_max_pause_time");
   WriteCvarString(f, "get5_max_pauses");
-  WriteCvarString(f, "get5_mysql_force_matchid");
   WriteCvarString(f, "get5_pausing_enabled");
   WriteCvarString(f, "get5_reset_pauses_each_half");
   WriteCvarString(f, "get5_web_api_url");

--- a/scripting/get5/eventlogger.sp
+++ b/scripting/get5/eventlogger.sp
@@ -9,8 +9,8 @@ static void EventLogger_LogEvent(const char[] eventName, JSON_Object params) {
   json.SetString("matchid", g_MatchID);
   json.SetObject("params", params);
 
-  const int kMaxCharacters = 1000;
-  char buffer[2048];
+  const int kMaxCharacters = 4096;
+  char buffer[8192];
 
   json.Encode(buffer, sizeof(buffer), g_PrettyPrintJsonCvar.BoolValue);
   if (strlen(buffer) > kMaxCharacters) {
@@ -139,6 +139,160 @@ public void EventLogger_GoingLive() {
   EventLogger_StartEvent();
   AddMapData(params);
   EventLogger_EndEvent("going_live");
+}
+
+public void EventLogger_SmokeGrenadeDetonated(int roundNumber, int roundTime, bool extinguishedMolotov, int attacker) {
+  EventLogger_StartEvent();
+  AddMapData(params);
+  AddPlayer(params, "attacker", attacker);
+  params.SetInt("round_number", roundNumber);
+  params.SetInt("round_time", roundTime);
+  params.SetBool("extinguished_molotov", extinguishedMolotov);
+  EventLogger_EndEvent("smokegrenade_detonated");
+}
+
+public void EventLogger_FlashbangDetonated(int roundNumber, int roundTime, int attacker, const ArrayList victims) {
+  EventLogger_StartEvent();
+  AddMapData(params);
+  AddPlayer(params, "attacker", attacker);
+  params.SetInt("round_number", roundNumber);
+  params.SetInt("round_time", roundTime);
+
+  JSON_Array victimsArray = new JSON_Array();
+
+  for(int i = 0; i < victims.Length; i++)
+  {
+      StringMap victim = victims.Get(i);
+
+      JSON_Object victimJson = new JSON_Object();
+
+      int victimId;
+      victim.GetValue("victim", victimId);
+      AddPlayer(victimJson, "victim", victimId);
+
+      float blindDuration;
+      victim.GetValue("blind_duration", blindDuration);
+      victimJson.SetFloat("blind_duration", blindDuration);
+
+      bool friendlyFire;
+      victim.GetValue("friendly_fire", friendlyFire);
+      victimJson.SetBool("friendly_fire", friendlyFire);
+
+      victimsArray.PushObject(victimJson);
+  }
+
+  params.SetObject("victims", victimsArray);
+  
+  EventLogger_EndEvent("flashbang_detonated");
+}
+
+public void EventLogger_DecoyEnded(int roundNumber, int roundTime, int attacker, const ArrayList victims) {
+  EventLogger_StartEvent();
+  AddMapData(params);
+  AddPlayer(params, "attacker", attacker);
+  params.SetInt("round_number", roundNumber);
+  params.SetInt("round_time", roundTime);
+
+  JSON_Array victimsArray = new JSON_Array();
+
+  for(int i = 0; i < victims.Length; i++)
+  {
+      StringMap victim = victims.Get(i);
+
+      JSON_Object victimJson = new JSON_Object();
+
+      int victimId;
+      victim.GetValue("victim", victimId);
+      AddPlayer(victimJson, "victim", victimId);
+
+      int damage;
+      victim.GetValue("damage", damage);
+      victimJson.SetInt("damage", damage);
+
+      bool friendlyFire;
+      victim.GetValue("friendly_fire", friendlyFire);
+      victimJson.SetBool("friendly_fire", friendlyFire);
+
+      victimsArray.PushObject(victimJson);
+
+  }
+
+  params.SetObject("victims", victimsArray);
+
+  EventLogger_EndEvent("decoy_ended");
+}
+
+public void EventLogger_MolotovGrenadeEnded(int roundNumber, int roundTime, int extinguishedTime, int attacker, const ArrayList victims) {
+  EventLogger_StartEvent();
+  AddMapData(params);
+  AddPlayer(params, "attacker", attacker);
+  params.SetInt("round_number", roundNumber);
+  params.SetInt("round_time", roundTime);
+  params.SetInt("extinguished_time", extinguishedTime);
+
+  JSON_Array victimsArray = new JSON_Array();
+
+  for(int i = 0; i < victims.Length; i++)
+  {
+      StringMap victim = victims.Get(i);
+
+      JSON_Object victimJson = new JSON_Object();
+
+      int victimId;
+      victim.GetValue("victim", victimId);
+      AddPlayer(victimJson, "victim", victimId);
+
+      int damage;
+      victim.GetValue("damage", damage);
+      victimJson.SetInt("damage", damage);
+
+      bool friendlyFire;
+      victim.GetValue("friendly_fire", friendlyFire);
+      victimJson.SetBool("friendly_fire", friendlyFire);
+
+      victimsArray.PushObject(victimJson);
+
+  }
+
+  params.SetObject("victims", victimsArray);
+  
+  EventLogger_EndEvent("molotov_ended");
+}
+
+public void EventLogger_HEGrenadeDetonated(int roundNumber, int roundTime, int attacker, const ArrayList victims) {
+  EventLogger_StartEvent();
+  AddMapData(params);
+  AddPlayer(params, "attacker", attacker);
+  params.SetInt("round_number", roundNumber);
+  params.SetInt("round_time", roundTime);
+
+  JSON_Array victimsArray = new JSON_Array();
+
+  for(int i = 0; i < victims.Length; i++)
+  {
+      StringMap victim = victims.Get(i);
+
+      JSON_Object victimJson = new JSON_Object();
+
+      int victimId;
+      victim.GetValue("victim", victimId);
+      AddPlayer(victimJson, "victim", victimId);
+
+      int damage;
+      victim.GetValue("damage", damage);
+      victimJson.SetInt("damage", damage);
+
+      bool friendlyFire;
+      victim.GetValue("friendly_fire", friendlyFire);
+      victimJson.SetBool("friendly_fire", friendlyFire);
+
+      victimsArray.PushObject(victimJson);
+
+  }
+
+  params.SetObject("victims", victimsArray);
+  
+  EventLogger_EndEvent("hegrenade_detonated");
 }
 
 public void EventLogger_GrenadeThrown(int roundNumber, int roundTime, int attacker, const char[] weapon) {

--- a/scripting/get5/eventlogger.sp
+++ b/scripting/get5/eventlogger.sp
@@ -37,6 +37,8 @@ static void EventLogger_LogEvent(const char[] eventName, JSON_Object params) {
     Call_PushString(buffer);
     Call_Finish();
   }
+
+  json_cleanup_and_delete(json);
 }
 
 static void AddMapData(JSON_Object params) {
@@ -139,25 +141,27 @@ public void EventLogger_GoingLive() {
   EventLogger_EndEvent("going_live");
 }
 
-public void EventLogger_GrenadeThrown(int attacker, const char[] weapon) {
+public void EventLogger_GrenadeThrown(int roundNumber, int roundTime, int attacker, const char[] weapon) {
   EventLogger_StartEvent();
   AddMapData(params);
   AddPlayer(params, "attacker", attacker);
+  params.SetInt("round_number", roundNumber);
+  params.SetInt("round_time", roundTime);
   params.SetString("weapon", weapon);
   EventLogger_EndEvent("grenade_thrown");
 }
 
-public void EventLogger_PlayerDeath(int roundNumber, int roundTime, int killer, int victim, bool headshot, int assister,
-                             bool flashAssist, const char[] weapon, bool friendlyFire,
+public void EventLogger_PlayerDeath(int roundNumber, int roundTime, int attacker, int victim, bool suicide,
+                             bool headshot, int assister, bool flashAssist, const char[] weapon, bool friendlyFire,
                              bool assistFriendlyFire, int penetrated, bool thruSmoke,
                              bool noScope, bool attackerBlind) {
   EventLogger_StartEvent();
   AddMapData(params);
 
-  if (killer > 0) {
-    AddPlayer(params, "attacker", killer);
+  if (attacker > 0) {
+    AddPlayer(params, "attacker", attacker);
   } else {
-    params.SetObject("attacker", null); // In case of non-player killer, such as fall damage.
+    params.SetObject("attacker", null); // In case of non-player attacker, such as fall damage.
   }
 
   AddPlayer(params, "victim", victim);
@@ -165,6 +169,7 @@ public void EventLogger_PlayerDeath(int roundNumber, int roundTime, int killer, 
   params.SetInt("round_time", roundTime);
   params.SetInt("headshot", headshot);
   params.SetInt("penetrated", penetrated);
+  params.SetBool("suicide", suicide);
   params.SetBool("thru_smoke", thruSmoke);
   params.SetBool("no_scope", noScope);
   params.SetBool("attacker_blind", attackerBlind);
@@ -194,11 +199,11 @@ public void EventLogger_RoundStart(int roundNumber) {
   EventLogger_EndEvent("round_start");
 }
 
-public void EventLogger_RoundEnd(int roundNumber, int csTeamWinner, int csReason, int roundDuration) {
+public void EventLogger_RoundEnd(int roundNumber, int csTeamWinner, int csReason, int roundTime) {
   EventLogger_StartEvent();
   AddMapData(params);
   params.SetInt("round_number", roundNumber);
-  params.SetInt("round_duration", roundDuration);
+  params.SetInt("round_time", roundTime);
   AddCSTeam(params, "winner_side", csTeamWinner);
   AddTeam(params, "winner", CSTeamToMatchTeam(csTeamWinner));
   params.SetInt("reason", csReason);
@@ -261,36 +266,43 @@ public void EventLogger_ClientSay(int client, const char[] message) {
   EventLogger_EndEvent("client_say");
 }
 
-public void EventLogger_BombPlanted(int client, int site) {
+public void EventLogger_BombPlanted(int client, int roundNumber, int roundTime, int site) {
   EventLogger_StartEvent();
   AddMapData(params);
   AddPlayer(params, "client", client);
   params.SetInt("site", site);
+  params.SetInt("round_number", roundNumber);
+  params.SetInt("round_time", roundTime);
   EventLogger_EndEvent("bomb_planted");
 }
 
-public void EventLogger_BombDefused(int client, int site, int bombTimeRemaining) {
+public void EventLogger_BombDefused(int client, int roundNumber, int roundTime, int site, int bombTimeRemaining) {
   EventLogger_StartEvent();
   AddMapData(params);
   AddPlayer(params, "client", client);
   params.SetInt("site", site);
   params.SetInt("bomb_time_remaining", bombTimeRemaining);
+  params.SetInt("round_number", roundNumber);
+  params.SetInt("round_time", roundTime);
   EventLogger_EndEvent("bomb_defused");
 }
 
-public void EventLogger_MVP(int client, int reason) {
+public void EventLogger_MVP(int client, int roundNumber, int reason) {
   EventLogger_StartEvent();
   AddMapData(params);
   AddPlayer(params, "client", client);
   params.SetInt("reason", reason);
-  EventLogger_EndEvent("mvp");
+  params.SetInt("round_number", roundNumber);
+  EventLogger_EndEvent("round_mvp");
 }
 
-public void EventLogger_BombExploded(int client, int site) {
+public void EventLogger_BombExploded(int client, int roundNumber, int roundTime, int site) {
   EventLogger_StartEvent();
   AddMapData(params);
   AddPlayer(params, "client", client);
   params.SetInt("site", site);
+  params.SetInt("round_number", roundNumber);
+  params.SetInt("round_time", roundTime);
   EventLogger_EndEvent("bomb_exploded");
 }
 

--- a/scripting/get5/goinglive.sp
+++ b/scripting/get5/goinglive.sp
@@ -23,9 +23,12 @@ public Action StartGoingLive(Handle timer) {
 
   EventLogger_GoingLive();
 
-  LogDebug("Calling Get5_OnGoingLive(mapnum=%d)", GetMapNumber());
+  int mapNumber = GetMapNumber();
+
+  LogDebug("Calling Get5_OnGoingLive(matchId=%s, mapnum=%d)", g_MatchID, mapNumber);
   Call_StartForward(g_OnGoingLive);
-  Call_PushCell(GetMapNumber());
+  Call_PushString(g_MatchID);
+  Call_PushCell(mapNumber);
   Call_Finish();
 
   return Plugin_Handled;

--- a/scripting/get5/mapveto.sp
+++ b/scripting/get5/mapveto.sp
@@ -158,8 +158,9 @@ public void VetoController(int client) {
 
     EventLogger_MapPicked(MatchTeam_TeamNone, mapName, g_MapsToPlay.Length - 1);
 
-    LogDebug("Calling Get5_OnMapPicked(team=%d, map=%s)", MatchTeam_TeamNone, mapName);
+    LogDebug("Calling Get5_OnMapPicked(matchId=%s, team=%d, map=%s)", g_MatchID, MatchTeam_TeamNone, mapName);
     Call_StartForward(g_OnMapPicked);
+    Call_PushString(g_MatchID);
     Call_PushCell(MatchTeam_TeamNone);
     Call_PushString(mapName);
     Call_Finish();
@@ -276,8 +277,9 @@ public int MapVetoMenuHandler(Menu menu, MenuAction action, int param1, int para
 
     EventLogger_MapVetoed(team, mapName);
 
-    LogDebug("Calling Get5_OnMapVetoed(team=%d, map=%s)", team, mapName);
+    LogDebug("Calling Get5_OnMapVetoed(matchId=%s, team=%d, map=%s)", g_MatchID, team, mapName);
     Call_StartForward(g_OnMapVetoed);
+    Call_PushString(g_MatchID);
     Call_PushCell(team);
     Call_PushString(mapName);
     Call_Finish();
@@ -344,8 +346,9 @@ public int MapPickMenuHandler(Menu menu, MenuAction action, int param1, int para
 
     EventLogger_MapPicked(team, mapName, g_MapsToPlay.Length - 1);
 
-    LogDebug("Calling Get5_OnMapPicked(team=%d, map=%s)", team, mapName);
+    LogDebug("Calling Get5_OnMapPicked(matchId=%s, team=%d, map=%s)", g_MatchID, team, mapName);
     Call_StartForward(g_OnMapPicked);
+    Call_PushString(g_MatchID);
     Call_PushCell(team);
     Call_PushString(mapName);
     Call_Finish();
@@ -418,8 +421,9 @@ public int SidePickMenuHandler(Menu menu, MenuAction action, int param1, int par
 
     EventLogger_SidePicked(team, mapName, g_MapsToPlay.Length - 1, selectedSide);
 
-    LogDebug("Calling Get5_OnSidePicked(team=%d, map=%s, side=%d)", team, mapName, selectedSide);
+    LogDebug("Calling Get5_OnSidePicked(matchId=%s, team=%d, map=%s, side=%d)", g_MatchID, team, mapName, selectedSide);
     Call_StartForward(g_OnSidePicked);
+    Call_PushString(g_MatchID);
     Call_PushCell(team);
     Call_PushString(mapName);
     Call_PushCell(selectedSide);

--- a/scripting/get5/matchconfig.sp
+++ b/scripting/get5/matchconfig.sp
@@ -1,7 +1,7 @@
 #include <string>
 
 #define REMOTE_CONFIG_PATTERN "remote_config%d.json"
-#define CONFIG_MATCHID_DEFAULT "matchid"
+#define CONFIG_MATCHID_DEFAULT "" // empty string if no match ID defined in config.
 #define CONFIG_MATCHTITLE_DEFAULT "Map {MAPNUMBER} of {MAXMAPS}"
 #define CONFIG_PLAYERSPERTEAM_DEFAULT 5
 #define CONFIG_MINPLAYERSTOREADY_DEFAULT 0
@@ -118,6 +118,7 @@ stock bool LoadMatchConfig(const char[] config, bool restoreBackup = false) {
 
     LogDebug("Calling Get5_OnSeriesInit");
     Call_StartForward(g_OnSeriesInit);
+    Call_PushString(g_MatchID);
     Call_Finish();
   }
 

--- a/scripting/get5/pausing.sp
+++ b/scripting/get5/pausing.sp
@@ -12,9 +12,10 @@ public Action Command_TechPause(int client, int args) {
   if (client == 0) {
     Pause();
     EventLogger_PauseCommand(MatchTeam_TeamNone, PauseType_Tech);
-    LogDebug("Calling Get5_OnMatchPaused(team=%d, pauseReason=%d)", MatchTeam_TeamNone,
+    LogDebug("Calling Get5_OnMatchPaused(matchId=%s, team=%d, pauseReason=%d)", g_MatchID, MatchTeam_TeamNone,
              PauseType_Tech);
     Call_StartForward(g_OnMatchPaused);
+    Call_PushString(g_MatchID);
     Call_PushCell(MatchTeam_TeamNone);
     Call_PushCell(PauseType_Tech);
     Call_Finish();
@@ -25,8 +26,9 @@ public Action Command_TechPause(int client, int args) {
   MatchTeam team = GetClientMatchTeam(client);
   Pause();
   EventLogger_PauseCommand(team, PauseType_Tech);
-  LogDebug("Calling Get5_OnMatchPaused(team=%d, pauseReason=%d)", team, PauseType_Tech);
+  LogDebug("Calling Get5_OnMatchPaused(matchId=%s, team=%d, pauseReason=%d)", g_MatchID, team, PauseType_Tech);
   Call_StartForward(g_OnMatchPaused);
+  Call_PushString(g_MatchID);
   Call_PushCell(team);
   Call_PushCell(PauseType_Tech);
   Call_Finish();
@@ -47,9 +49,10 @@ public Action Command_Pause(int client, int args) {
 
     Pause();
     EventLogger_PauseCommand(MatchTeam_TeamNone, PauseType_Tactical);
-    LogDebug("Calling Get5_OnMatchPaused(team=%d, pauseReason=%d)", MatchTeam_TeamNone,
+    LogDebug("Calling Get5_OnMatchPaused(matchId=%s, team=%d, pauseReason=%d)", g_MatchID, MatchTeam_TeamNone,
              PauseType_Tactical);
     Call_StartForward(g_OnMatchPaused);
+    Call_PushString(g_MatchID);
     Call_PushCell(MatchTeam_TeamNone);
     Call_PushCell(PauseType_Tactical);
     Call_Finish();
@@ -88,8 +91,9 @@ public Action Command_Pause(int client, int args) {
   // If the pause will need explicit resuming, we will create a timer to poll the pause status.
   bool need_resume = Pause(g_FixedPauseTimeCvar.IntValue, MatchTeamToCSTeam(team));
   EventLogger_PauseCommand(team, PauseType_Tactical);
-  LogDebug("Calling Get5_OnMatchPaused(team=%d, pauseReason=%d)", team, PauseType_Tactical);
+  LogDebug("Calling Get5_OnMatchPaused(matchId=%s, team=%d, pauseReason=%d)", g_MatchID, team, PauseType_Tactical);
   Call_StartForward(g_OnMatchPaused);
+  Call_PushString(g_MatchID);
   Call_PushCell(team);
   Call_PushCell(PauseType_Tactical);
   Call_Finish();
@@ -149,8 +153,9 @@ public Action Timer_UnpauseEventCheck(Handle timer, int data) {
     if (g_PauseTimeUsed <= 0) {
       MatchTeam team = view_as<MatchTeam>(data);
       EventLogger_UnpauseCommand(team);
-      LogDebug("Calling Get5_OnMatchUnpaused(team=%d)", team);
+      LogDebug("Calling Get5_OnMatchUnpaused(matchId=%s, team=%d)", g_MatchID, team);
       Call_StartForward(g_OnMatchUnpaused);
+      Call_PushString(g_MatchID);
       Call_PushCell(team);
       Call_Finish();
       // Reset state
@@ -210,8 +215,9 @@ public Action Command_Unpause(int client, int args) {
   if (client == 0) {
     Unpause();
     EventLogger_UnpauseCommand(MatchTeam_TeamNone);
-    LogDebug("Calling Get5_OnMatchUnpaused(team=%d)", MatchTeam_TeamNone);
+    LogDebug("Calling Get5_OnMatchUnpaused(matchId=%s, team=%d)", g_MatchID, MatchTeam_TeamNone);
     Call_StartForward(g_OnMatchUnpaused);
+    Call_PushString(g_MatchID);
     Call_PushCell(MatchTeam_TeamNone);
     Call_Finish();
     Get5_MessageToAll("%t", "AdminForceUnPauseInfoMessage");
@@ -228,8 +234,9 @@ public Action Command_Unpause(int client, int args) {
   if (g_TeamReadyForUnpause[MatchTeam_Team1] && g_TeamReadyForUnpause[MatchTeam_Team2]) {
     Unpause();
     EventLogger_UnpauseCommand(team);
-    LogDebug("Calling Get5_OnMatchUnpaused(team=%d)", team);
+    LogDebug("Calling Get5_OnMatchUnpaused(matchId=%s, team=%d)", g_MatchID, team);
     Call_StartForward(g_OnMatchUnpaused);
+    Call_PushString(g_MatchID);
     Call_PushCell(team);
     Call_Finish();
     if (IsPlayer(client)) {

--- a/scripting/get5/teamlogic.sp
+++ b/scripting/get5/teamlogic.sp
@@ -243,10 +243,6 @@ stock int CountPlayersOnMatchTeam(MatchTeam team, int exclude = -1) {
   return count;
 }
 
-public Action Event_OnPlayerTeam(Event event, const char[] name, bool dontBroadcast) {
-  return Plugin_Continue;
-}
-
 // Returns the match team a client is the captain of, or MatchTeam_None.
 public MatchTeam GetCaptainTeam(int client) {
   if (client == GetTeamCaptain(MatchTeam_Team1)) {

--- a/scripting/get5/util.sp
+++ b/scripting/get5/util.sp
@@ -155,8 +155,9 @@ stock bool Record(const char[] demoName) {
 
 stock void StopRecording() {
   ServerCommand("tv_stoprecord");
-  LogDebug("Calling Get5_OnDemoFinished(file=%s)", g_DemoFileName);
+  LogDebug("Calling Get5_OnDemoFinished(matchId=%s, file=%s)", g_MatchID, g_DemoFileName);
   Call_StartForward(g_OnDemoFinished);
+  Call_PushString(g_MatchID);
   Call_PushString(g_DemoFileName);
   Call_Finish();
 }
@@ -665,12 +666,8 @@ stock bool ConvertAuthToSteam64(const char[] inputId, char outputId[AUTH_LENGTH]
 }
 
 stock bool HelpfulAttack(int attacker, int victim) {
-  if (!IsValidClient(attacker) || !IsValidClient(victim)) {
-    return false;
-  }
-  int attackerTeam = GetClientTeam(attacker);
-  int victimTeam = GetClientTeam(victim);
-  return attackerTeam != victimTeam && attacker != victim;
+  // Assumes both attacker and victim are valid clients; check this before calling this function.
+  return attacker != victim && GetClientTeam(attacker) != GetClientTeam(victim);
 }
 
 stock SideChoice SideTypeFromString(const char[] input) {
@@ -735,4 +732,8 @@ public bool IsJSONPath(const char[] path) {
   } else {
     return false;
   }
+}
+
+public int GetMilliSecondsPassedSince(float timestamp) {
+  return RoundToFloor((GetEngineTime() - timestamp) * 1000);
 }

--- a/scripting/get5/util.sp
+++ b/scripting/get5/util.sp
@@ -4,7 +4,7 @@
 #define MAX_FLOAT_STRING_LENGTH 32
 #define AUTH_LENGTH 64
 
-// Dummy value for when we need to write a keyvalue string, but we don't care about he value.
+// Dummy value for when we need to write a keyvalue string, but we don't care about the value.
 // Trying to write an empty string often results in the keyvalue not being written, so we use this.
 #define KEYVALUE_STRING_PLACEHOLDER "__placeholder"
 

--- a/scripting/get5/util.sp
+++ b/scripting/get5/util.sp
@@ -138,6 +138,16 @@ stock int GetTvDelay() {
   return 0;
 }
 
+stock void EmptyArrayList(const ArrayList array) {
+  LogDebug("Emptying victim array of length %d", array.Length);
+  while (array.Length > 0) {
+    Handle obj = array.Get(0);
+    array.Erase(0);
+    delete obj;
+  }
+  delete array;
+}
+
 stock bool Record(const char[] demoName) {
   char szDemoName[256];
   strcopy(szDemoName, sizeof(szDemoName), demoName);

--- a/scripting/get5_mysqlstats.sp
+++ b/scripting/get5_mysqlstats.sp
@@ -33,9 +33,6 @@
 Database db = null;
 char queryBuffer[2048];
 
-int g_MatchID = -1;
-
-ConVar g_ForceMatchIDCvar;
 bool g_DisableStats = false;
 
 // clang-format off
@@ -51,28 +48,20 @@ public Plugin myinfo = {
 public void OnPluginStart() {
   InitDebugLog("get5_debug", "get5_mysql");
 
-  g_ForceMatchIDCvar = CreateConVar(
-      "get5_mysql_force_matchid", "0",
-      "If set to a positive integer, this will force get5 to use the matchid in this convar");
-
   char error[255];
   db = SQL_Connect("get5", true, error, sizeof(error));
   if (db == null) {
     SetFailState("Could not connect to get5 database: %s", error);
+    g_DisableStats = true;
   } else {
-    g_DisableStats = false;
     db.SetCharset("utf8mb4");
   }
 }
 
-public void Get5_OnBackupRestore() {
-  char matchid[64];
-  Get5_GetMatchID(matchid, sizeof(matchid));
-  g_MatchID = StringToInt(matchid);
-}
-
-public void Get5_OnSeriesInit() {
-  g_MatchID = -1;
+public void Get5_OnSeriesInit(const char[] matchId) {
+  if (g_DisableStats) {
+    return;
+  }
 
   char seriesType[64];
   char team1Name[64];
@@ -98,21 +87,19 @@ public void Get5_OnSeriesInit() {
 
   delete tmpStats;
 
-  g_DisableStats = false;
-  LogDebug("Setting up series stats, get5_mysql_force_matchid = %d", g_ForceMatchIDCvar.IntValue);
+  // Match ID defaults to an empty string, so if it's empty we use auto-increment from MySQL.
+  if (strlen(matchId) > 0) {
 
-  if (g_ForceMatchIDCvar.IntValue > 0) {
-    SetMatchID(g_ForceMatchIDCvar.IntValue);
-    g_ForceMatchIDCvar.IntValue = 0;
+    char matchIdSz[64];
+    db.Escape(matchId, matchIdSz, sizeof(matchIdSz));
+
     Format(queryBuffer, sizeof(queryBuffer), "INSERT INTO `get5_stats_matches` \
             (matchid, series_type, team1_name, team2_name, start_time, server_id) VALUES \
-            (%d, '%s', '%s', '%s', NOW(), %d)",
-           g_MatchID, seriesTypeSz, team1NameSz, team2NameSz, serverId);
+            ('%s', '%s', '%s', '%s', NOW(), %d)",
+           matchIdSz, seriesTypeSz, team1NameSz, team2NameSz, serverId);
     LogDebug(queryBuffer);
     db.Query(SQLErrorCheckCallback, queryBuffer);
-
-    LogMessage("Starting match id %d", g_MatchID);
-
+    LogMessage("Starting match with preset ID: %s", matchId);
   } else {
     Format(queryBuffer, sizeof(queryBuffer), "INSERT INTO `get5_stats_matches` \
             (series_type, team1_name, team2_name, start_time, server_id) VALUES \
@@ -125,26 +112,23 @@ public void Get5_OnSeriesInit() {
 
 public void MatchInitCallback(Database dbObj, DBResultSet results, const char[] error, any data) {
   if (results == null) {
-    LogError("Failed to get matchid from match init query");
+    LogError("Failed to get Match ID from match init query: %s.", error);
+    g_DisableStats = true;
+  } else if (results.InsertId < 1) {
+    LogError("Match ID init query succeeded but did not return a match ID integer. Perhaps the column does not have AUTO_INCREMENT?");
     g_DisableStats = true;
   } else {
-    if (results.InsertId > 0) {
-      SetMatchID(results.InsertId);
-    }
-    LogMessage("Starting match id %d", g_MatchID);
+    char matchId[64];
+    IntToString(results.InsertId, matchId, sizeof(matchId));
+    Get5_SetMatchID(matchId);
+    LogMessage("Starting match ID: %d", results.InsertId);
   }
 }
 
-static void SetMatchID(int matchid) {
-  g_MatchID = matchid;
-  char idStr[32];
-  IntToString(g_MatchID, idStr, sizeof(idStr));
-  Get5_SetMatchID(idStr);
-}
-
-public void Get5_OnGoingLive(int mapNumber) {
-  if (g_DisableStats)
+public void Get5_OnGoingLive(const char[] matchId, int mapNumber) {
+  if (g_DisableStats) {
     return;
+  }
 
   char mapName[255];
   GetCurrentMap(mapName, sizeof(mapName));
@@ -152,23 +136,29 @@ public void Get5_OnGoingLive(int mapNumber) {
   char mapNameSz[sizeof(mapName) * 2 + 1];
   db.Escape(mapName, mapNameSz, sizeof(mapNameSz));
 
+  char matchIdSz[64];
+  db.Escape(matchId, matchIdSz, sizeof(matchIdSz));
+
   Format(queryBuffer, sizeof(queryBuffer), "INSERT IGNORE INTO `get5_stats_maps` \
         (matchid, mapnumber, mapname, start_time) VALUES \
-        (%d, %d, '%s', NOW())",
-         g_MatchID, mapNumber, mapNameSz);
+        ('%s', %d, '%s', NOW())",
+         matchIdSz, mapNumber, mapNameSz);
   LogDebug(queryBuffer);
 
   db.Query(SQLErrorCheckCallback, queryBuffer);
 }
 
-public void UpdateRoundStats(int mapNumber) {
+public void UpdateRoundStats(const char[] matchId, int mapNumber) {
   // Update team scores
   int t1score = CS_GetTeamScore(Get5_MatchTeamToCSTeam(MatchTeam_Team1));
   int t2score = CS_GetTeamScore(Get5_MatchTeamToCSTeam(MatchTeam_Team2));
 
+  char matchIdSz[64];
+  db.Escape(matchId, matchIdSz, sizeof(matchIdSz));
+
   Format(queryBuffer, sizeof(queryBuffer), "UPDATE `get5_stats_maps` \
-        SET team1_score = %d, team2_score = %d WHERE matchid = %d and mapnumber = %d",
-         t1score, t2score, g_MatchID, mapNumber);
+        SET team1_score = %d, team2_score = %d WHERE matchid = '%s' and mapnumber = %d",
+         t1score, t2score, matchIdSz, mapNumber);
   LogDebug(queryBuffer);
   db.Query(SQLErrorCheckCallback, queryBuffer);
 
@@ -179,11 +169,11 @@ public void UpdateRoundStats(int mapNumber) {
   Format(mapKey, sizeof(mapKey), "map%d", mapNumber);
   if (kv.JumpToKey(mapKey)) {
     if (kv.JumpToKey("team1")) {
-      AddPlayerStats(kv, MatchTeam_Team1);
+      AddPlayerStats(matchId, kv, MatchTeam_Team1);
       kv.GoBack();
     }
     if (kv.JumpToKey("team2")) {
-      AddPlayerStats(kv, MatchTeam_Team2);
+      AddPlayerStats(matchId, kv, MatchTeam_Team2);
       kv.GoBack();
     }
     kv.GoBack();
@@ -191,18 +181,22 @@ public void UpdateRoundStats(int mapNumber) {
   delete kv;
 }
 
-public void Get5_OnMapResult(const char[] map, MatchTeam mapWinner, int team1Score, int team2Score,
+public void Get5_OnMapResult(const char[] matchId, const char[] map, MatchTeam mapWinner, int team1Score, int team2Score,
                       int mapNumber) {
-  if (g_DisableStats)
+  if (g_DisableStats) {
     return;
+  }
+
+  char matchIdSz[64];
+  db.Escape(matchId, matchIdSz, sizeof(matchIdSz));
 
   // Update the map winner
   char winnerString[64];
   GetTeamString(mapWinner, winnerString, sizeof(winnerString));
   Format(queryBuffer, sizeof(queryBuffer),
          "UPDATE `get5_stats_maps` SET winner = '%s', end_time = NOW() \
-        WHERE matchid = %d and mapnumber = %d",
-         winnerString, g_MatchID, mapNumber);
+        WHERE matchid = '%s' and mapnumber = %d",
+         winnerString, matchIdSz, mapNumber);
   LogDebug(queryBuffer);
   db.Query(SQLErrorCheckCallback, queryBuffer);
 
@@ -212,18 +206,21 @@ public void Get5_OnMapResult(const char[] map, MatchTeam mapWinner, int team1Sco
   Get5_GetTeamScores(MatchTeam_Team2, t2_seriesscore, tmp);
 
   Format(queryBuffer, sizeof(queryBuffer), "UPDATE `get5_stats_matches` \
-        SET team1_score = %d, team2_score = %d WHERE matchid = %d",
-         t1_seriesscore, t2_seriesscore, g_MatchID);
+        SET team1_score = %d, team2_score = %d WHERE matchid = '%s'",
+         t1_seriesscore, t2_seriesscore, matchIdSz);
   LogDebug(queryBuffer);
   db.Query(SQLErrorCheckCallback, queryBuffer);
 }
 
-public void AddPlayerStats(KeyValues kv, MatchTeam team) {
+public void AddPlayerStats(const char[] matchId, KeyValues kv, MatchTeam team) {
   char name[MAX_NAME_LENGTH];
   char auth[AUTH_LENGTH];
   char nameSz[MAX_NAME_LENGTH * 2 + 1];
   char authSz[AUTH_LENGTH * 2 + 1];
   int mapNumber = MapNumber();
+
+  char matchIdSz[64];
+  db.Escape(matchId, matchIdSz, sizeof(matchIdSz));
 
   if (kv.GotoFirstSubKey()) {
     do {
@@ -282,7 +279,7 @@ public void AddPlayerStats(KeyValues kv, MatchTeam team) {
                 `firstkill_t`, `firstkill_ct`, `firstdeath_t`, `firstdeath_ct`, \
                 `tradekill`, `kast`, `contribution_score`, `mvp` \
                 ) VALUES \
-                (%d, %d, '%s', '%s', \
+                ('%s', %d, '%s', '%s', \
                 %d, '%s', %d, %d, %d, \
                 %d, %d, %d, %d, \
                 %d, %d, %d, %d, %d, %d, \
@@ -322,7 +319,7 @@ public void AddPlayerStats(KeyValues kv, MatchTeam team) {
                 `kast` = VALUES(`kast`), \
                 `contribution_score` = VALUES(`contribution_score`), \
                 `mvp` = VALUES(`mvp`)",
-             g_MatchID, mapNumber, authSz, teamString, 
+             matchIdSz, mapNumber, authSz, teamString,
              roundsplayed, nameSz, kills, deaths, flashbang_assists, 
              assists, teamkills, knife_kills, headshot_kills, damage, utility_damage,
              enemies_flashed, friendlies_flashed,
@@ -341,17 +338,21 @@ public void AddPlayerStats(KeyValues kv, MatchTeam team) {
   }
 }
 
-public void Get5_OnSeriesResult(MatchTeam seriesWinner, int team1MapScore, int team2MapScore) {
-  if (g_DisableStats)
+public void Get5_OnSeriesResult(const char[] matchId, MatchTeam seriesWinner, int team1MapScore, int team2MapScore) {
+  if (g_DisableStats) {
     return;
+  }
 
   char winnerString[64];
   GetTeamString(seriesWinner, winnerString, sizeof(winnerString));
 
+  char matchIdSz[64];
+  db.Escape(matchId, matchIdSz, sizeof(matchIdSz));
+
   Format(queryBuffer, sizeof(queryBuffer), "UPDATE `get5_stats_matches` \
         SET winner = '%s', team1_score = %d, team2_score = %d, end_time = NOW() \
-        WHERE matchid = %d",
-         winnerString, team1MapScore, team2MapScore, g_MatchID);
+        WHERE matchid = '%s'",
+         winnerString, team1MapScore, team2MapScore, matchIdSz);
   LogDebug(queryBuffer);
   db.Query(SQLErrorCheckCallback, queryBuffer);
 }
@@ -362,9 +363,9 @@ public int SQLErrorCheckCallback(Handle owner, Handle hndl, const char[] error, 
   }
 }
 
-public void Get5_OnRoundStatsUpdated() {
+public void Get5_OnRoundStatsUpdated(const char[] matchId) {
   if (Get5_GetGameState() == Get5State_Live && !g_DisableStats) {
-    UpdateRoundStats(MapNumber());
+    UpdateRoundStats(matchId, MapNumber());
   }
 }
 

--- a/scripting/include/get5.inc
+++ b/scripting/include/get5.inc
@@ -81,6 +81,26 @@ forward void Get5_OnMapVetoed(MatchTeam team, const char[] map);
 // and not by one of the teams specifically.
 forward void Get5_OnMapPicked(MatchTeam team, const char[] map);
 
+// Called when a player is elected the MVP of the round.
+forward void Get5_OnPlayerBecameMVP(int mapNumber, int roundNumber, int client, int clientSide, int reason);
+
+// Called when a player is killed in a live match. Used by MySQL stats. roundTime is milliseconds.
+forward void Get5_OnPlayerDied(char[] weapon, bool headshot, int mapNumber, int roundNumber, int roundTime,
+    int attacker, int victim, int assister, bool flashAssist, int penetratedObjects, bool thruSmoke, bool noScope,
+    bool attackerBlind, int attackerSide, int assisterSide, int victimSide);
+
+// Called when a round starts. Used by MySQL stats.
+forward void Get5_OnRoundStart(int mapNumber, int roundNumber);
+
+// Called when the round ends. Used by MySQL stats. roundLength is milliseconds.
+forward void Get5_OnRoundEnd(int winnerSide, char[] winningTeam, int mapNumber, int roundNumber, int roundLength, int reason);
+
+// Called when the bomb is defused. Used by MySQL stats. roundTime is milliseconds.
+forward void Get5_OnBombDefused(int client, int site, int mapNumber, int roundNumber, int roundTime, int milliSecondsRemaining);
+
+// Called when the bomb is planted. Used by MySQL stats. roundTime is milliseconds.
+forward void Get5_OnBombPlanted(int client, int site, int mapNumber, int roundNumber, int roundTime);
+
 // Called when a team selects a side.
 forward void Get5_OnSidePicked(MatchTeam team, const char[] map, int side);
 

--- a/scripting/include/get5.inc
+++ b/scripting/include/get5.inc
@@ -96,6 +96,48 @@ forward void Get5_OnPlayerDeath(const char[] matchId, int mapNumber, int roundNu
 // Called when a round starts.
 forward void Get5_OnRoundStart(const char[] matchId, int mapNumber, int roundNumber);
 
+// Called when a flashbang detonates (after collecting victim info)
+// victims is an array of StringMaps with these properties:
+// - victim - integer with client id
+// - blind_duration - float with duration victim was blinded
+// - friendly_fire - bool indicating if the victim was flashed by a friendly
+forward void Get5_OnFlashBangDetonated(const char[] matchId, int mapNumber, int roundNumber, int roundTime,
+  const ArrayList victims, int attacker, int attackerSide);
+
+// Called when a decoy grenade detonates - or if the round ends (after collecting victim info)
+// victims is an array of StringMaps with these properties:
+// - victim - integer with client id
+// - damage - integer with damage taken (excess damage removed)
+// - friendly_fire - bool indicating if the grenade was thrown by a friendly
+forward void Get5_OnDecoyEnded(const char[] matchId, int mapNumber, int roundNumber, int roundTime,
+  const ArrayList victims, int attacker, int attackerSide);
+
+// Called when an HE grenade goes off (after collecting victim info)
+// victims is an array of StringMaps with these properties:
+// - victim - integer with client id
+// - damage - integer with damage taken (excess damage removed)
+// - friendly_fire - bool indicating if the grenade was thrown by a friendly
+forward void Get5_OnHEGrenadeDetonated(const char[] matchId, int mapNumber, int roundNumber, int roundTime,
+  const ArrayList victims, int attacker, int attackerSide);
+
+// Called when a smoke grenade detonates.
+// extinguishedMolotov becomes true if the smoke extinguishes a molotov grenade on detonation.
+// Throwing a molotov into an active smoke does not cause the boolean for that smoke to be true. The smoke must be
+// thrown at the molotov for this to trigger.
+forward void Get5_OnSmokeGrenadeDetonated(const char[] matchId, int mapNumber, int roundNumber, int roundTime,
+  bool extinguishedMolotov, int attacker, int attackerSide);
+
+// Called when a molotov grenade expires - or if the round ends (after collecting victim info)
+// victims is an array of StringMaps with these properties:
+// - victim - integer with client id
+// - damage - integer with damage taken (excess damage removed)
+// - friendly_fire - bool indicating if the molotov was thrown by a friendly
+// Note that roundTime is the time the molotov exploded; not when it expired. The event does not fire until then, as
+// it would otherwise be impossible to gather victim data.
+// extinguishedTime is roundTime at which the molotov was extinguished by a smoke, if that happened. Otherwise this value is 0.
+forward void Get5_OnMolotovEnded(const char[] matchId, int mapNumber, int roundNumber, int roundTime, int extinguishedTime,
+  const ArrayList victims, int attacker, int attackerSide);
+
 // Called when the round ends. roundTime is milliseconds.
 forward void Get5_OnRoundEnd(const char[] matchId, int mapNumber, int roundNumber, int roundTime, int winnerSide, char[] winningTeam, int reason);
 

--- a/scripting/include/get5.inc
+++ b/scripting/include/get5.inc
@@ -34,7 +34,7 @@ enum MatchSideType {
 
 enum SideChoice {
   SideChoice_Team1CT,     // Team 1 will start on CT
-  SideChoice_Team1T,      // Team 2 will start on T
+  SideChoice_Team1T,      // Team 1 will start on T
   SideChoice_KnifeRound,  // There will be a knife round to choose sides
 };
 
@@ -47,26 +47,30 @@ enum PauseType {
 forward void Get5_OnEvent(const char[] eventJson);
 
 // Called when a series is first setup.
-// Note: do not rely on the state of any cvars at this point.
-forward void Get5_OnSeriesInit();
+// Note: Do not rely on the state of any cvars at this point.
+// Also: matchId is an empty string at this stage if not defined in the match config.
+forward void Get5_OnSeriesInit(const char[] matchId);
 
 // Called each time in a match when a map is going live.
 // The mapNumber parameter starts at 0.
-forward void Get5_OnGoingLive(int mapNumber);
+forward void Get5_OnGoingLive(const char[] matchId, int mapNumber);
 
 // Called whenever the gamestate phase is changed.
 forward void Get5_OnGameStateChanged(Get5State oldState, Get5State newState);
 
+forward void Get5_OnGrenadeThrown(const char[] matchId, int mapNumber, int roundNumber, int roundTime, int attacker,
+  int attackerTeam, const char[] weapon);
+
 // Called when the stats for the last round have been updated.
-forward void Get5_OnRoundStatsUpdated();
+forward void Get5_OnRoundStatsUpdated(const char[] matchId);
 
 // Called at the end of a map in a series.
-forward void Get5_OnMapResult(const char[] map, MatchTeam mapWinner, int team1Score, int team2Score,
+forward void Get5_OnMapResult(const char[] matchId, const char[] map, MatchTeam mapWinner, int team1Score, int team2Score,
                               int mapNumber);
 
 // Called at the end of a full match.
 // Note: both Get5_OnMapResult and Get5_OnSeriesResult are called on the last map of a series.
-forward void Get5_OnSeriesResult(MatchTeam seriesWinner, int team1MapScore, int team2MapScore);
+forward void Get5_OnSeriesResult(const char[] matchId, MatchTeam seriesWinner, int team1MapScore, int team2MapScore);
 
 forward void Get5_OnPreLoadMatchConfig(const char[] filePath);
 
@@ -74,44 +78,44 @@ forward void Get5_OnPreLoadMatchConfig(const char[] filePath);
 forward void Get5_OnLoadMatchConfigFailed(const char[] reason);
 
 // Called when a team vetoes a map.
-forward void Get5_OnMapVetoed(MatchTeam team, const char[] map);
+forward void Get5_OnMapVetoed(const char[] matchId, MatchTeam team, const char[] map);
 
 // Called when a team selects a map.
 // The team parameter will be MatchTeam_TeamNone if the map was selected as the last remaining map
 // and not by one of the teams specifically.
-forward void Get5_OnMapPicked(MatchTeam team, const char[] map);
+forward void Get5_OnMapPicked(const char[] matchId, MatchTeam team, const char[] map);
 
 // Called when a player is elected the MVP of the round.
-forward void Get5_OnPlayerBecameMVP(int mapNumber, int roundNumber, int client, int clientSide, int reason);
+forward void Get5_OnPlayerBecameMVP(const char[] matchId, int mapNumber, int roundNumber, int client, int clientSide, int reason);
 
-// Called when a player is killed in a live match. Used by MySQL stats. roundTime is milliseconds.
-forward void Get5_OnPlayerDied(char[] weapon, bool headshot, int mapNumber, int roundNumber, int roundTime,
-    int attacker, int victim, int assister, bool flashAssist, int penetratedObjects, bool thruSmoke, bool noScope,
-    bool attackerBlind, int attackerSide, int assisterSide, int victimSide);
+// Called when a player dies in a match, including from suicide and team kills. roundTime is milliseconds.
+forward void Get5_OnPlayerDeath(const char[] matchId, int mapNumber, int roundNumber, int roundTime, const char[] weapon,
+  bool headshot, int attacker, int victim, bool suicide, int assister, bool flashAssist, int penetratedObjects, bool thruSmoke,
+  bool noScope, bool attackerBlind, int attackerSide, int assisterSide, int victimSide);
 
-// Called when a round starts. Used by MySQL stats.
-forward void Get5_OnRoundStart(int mapNumber, int roundNumber);
+// Called when a round starts.
+forward void Get5_OnRoundStart(const char[] matchId, int mapNumber, int roundNumber);
 
-// Called when the round ends. Used by MySQL stats. roundLength is milliseconds.
-forward void Get5_OnRoundEnd(int winnerSide, char[] winningTeam, int mapNumber, int roundNumber, int roundLength, int reason);
+// Called when the round ends. roundTime is milliseconds.
+forward void Get5_OnRoundEnd(const char[] matchId, int mapNumber, int roundNumber, int roundTime, int winnerSide, char[] winningTeam, int reason);
 
-// Called when the bomb is defused. Used by MySQL stats. roundTime is milliseconds.
-forward void Get5_OnBombDefused(int client, int site, int mapNumber, int roundNumber, int roundTime, int milliSecondsRemaining);
+// Called when the bomb is defused. roundTime is milliseconds.
+forward void Get5_OnBombDefused(const char[] matchId, int mapNumber, int roundNumber, int roundTime, int client, int site, int milliSecondsRemaining);
 
-// Called when the bomb is planted. Used by MySQL stats. roundTime is milliseconds.
-forward void Get5_OnBombPlanted(int client, int site, int mapNumber, int roundNumber, int roundTime);
+// Called when the bomb is planted. roundTime is milliseconds.
+forward void Get5_OnBombPlanted(const char[] matchId, int mapNumber, int roundNumber, int roundTime, int client, int site);
 
 // Called when a team selects a side.
-forward void Get5_OnSidePicked(MatchTeam team, const char[] map, int side);
+forward void Get5_OnSidePicked(const char[] matchId, MatchTeam team, const char[] map, int side);
 
 // Called when a demo finishes recording.
-forward void Get5_OnDemoFinished(const char[] filename);
+forward void Get5_OnDemoFinished(const char[] matchId, const char[] filename);
 
 // Called when a match is paused.
-forward void Get5_OnMatchPaused(MatchTeam team, PauseType pauseReason);
+forward void Get5_OnMatchPaused(const char[] matchId, MatchTeam team, PauseType pauseReason);
 
 // Called when a match is unpaused.
-forward void Get5_OnMatchUnpaused(MatchTeam team);
+forward void Get5_OnMatchUnpaused(const char[] matchId, MatchTeam team);
 
 // Called when a match backup is restored.
 forward void Get5_OnBackupRestore();

--- a/translations/get5.phrases.txt
+++ b/translations/get5.phrases.txt
@@ -48,7 +48,7 @@
     }
     "NoMatchSetupInfoMessage"
     {
-        "en"			"There is no match setup"
+        "en"            "No match was set up"
     }
     "YourAreNotAPlayerInfoMessage"
     {
@@ -56,7 +56,7 @@
     }
     "TeamIsFullInfoMessage"
     {
-        "en"            "Your team is full"
+        "en"            "Your team is full."
     }
     "TeamForfeitInfoMessage"
     {
@@ -179,7 +179,7 @@
     "TeammateForceReadied"
     {
         "#format"       "{1:N}"
-        "en"            "Your team was force-readied by {GREEN}{1}"
+        "en"            "Your team was force-readied by {GREEN}{1}{NORMAL}."
     }
     "AdminForceReadyInfoMessage"
     {
@@ -205,17 +205,17 @@
     "TeamWinningSeriesInfoMessage"
     {
         "#format"       "{1:s},{2:d},{3:d}"
-        "en"            "{1}{NORMAL} is winning the series {2}-{3}"
+        "en"            "{1}{NORMAL} is winning the series {2}-{3}."
     }
     "SeriesTiedInfoMessage"
     {
         "#format"       "{1:d},{2:d}"
-        "en"            "The series is tied at {1}-{2}"
+        "en"            "The series is tied at {1}-{2}."
     }
     "NextSeriesMapInfoMessage"
     {
         "#format"       "{1:s}"
-        "en"            "The next map in the series is {GREEN}{1}"
+        "en"            "The next map in the series is {GREEN}{1}{NORMAL}."
     }
     "TeamWonMatchInfoMessage"
     {
@@ -239,7 +239,7 @@
     }
     "MatchFinishedInfoMessage"
     {
-        "en"            "The match has been finished"
+        "en"            "The match is over"
     }
     "CurrentScoreInfoMessage"
     {
@@ -249,7 +249,7 @@
     "BackupLoadedInfoMessage"
     {
         "#format"       "{1:s}"
-        "en"            "Successfully loaded backup {1}"
+        "en"            "Successfully loaded backup {1}."
     }
     "MatchBeginInSecondsInfoMessage"
     {
@@ -295,22 +295,22 @@
     "MapIsInfoMessage"
     {
         "#format"       "{1:d},{2:s}"
-        "en"            "Map {1}: {GREEN}{2}"
+        "en"            "Map {1}: {GREEN}{2}{NORMAL}."
     }
     "TeamPickedMapInfoMessage"
     {
         "#format"       "{1:s},{2:s},{3:d}"
-        "en"            "{1} picked {GREEN}{2} {NORMAL}as map {3}"
+        "en"            "{1} picked {GREEN}{2} {NORMAL}as map {3}."
     }
     "TeamSelectSideInfoMessage"
     {
         "#format"       "{1:s},{2:s},{3:s}"
-        "en"            "{1} has selected to start on {GREEN}{2} {NORMAL}on {3}"
+        "en"            "{1} has selected to start on {GREEN}{2} {NORMAL}on {3}."
     }
     "TeamVetoedMapInfoMessage"
     {
         "#format"       "{1:s},{2:s}"
-        "en"            "{1} vetoed {LIGHT_RED}{2}"
+        "en"            "{1} vetoed {LIGHT_RED}{2}{NORMAL}."
     }
     "CaptainLeftOnVetoInfoMessage"
     {
@@ -326,7 +326,7 @@
     }
     "MoveToCoachInfoMessage"
     {
-        "en"            "Because your team is full, you were moved to the coach position."
+        "en"            "You were moved to the coach position because your team is full."
     }
     "ReadyTag"
     {
@@ -361,7 +361,7 @@
     "MapVetoSidePickMenuText"
     {
         "#format"       "{1:s}"
-        "en"        "Select a side for {1}"
+        "en"        "Select a side for {1}:"
     }
     "MapVetoSidePickConfirmMenuText"
     {


### PR DESCRIPTION
1. Added new forwards for player killed, round end, round started (freeze time ends), grenade thrown and MVP election.
2. Added bomb plant and defuse forwards, including time remaining (milliseconds) for defuse.
3. Cleaned up some suicide logic, should fix https://github.com/splewis/get5/issues/453
4. Add a few missing LogDebug calls.
5. Changed some properties and hooks to alphabetical order.
6. Removed unused `player_team` event hook.
7. Made MatchID a string everywhere (no redeclaration in apistats or mysqlstats). It now defaults to an empty string and not "matchid".
8. Removed the `get5_mysql_force_matchid` Cvar and fixed the code that sets it from the match config. Should resolve https://github.com/splewis/get5/issues/685

**Breaking changes:**

I plan on this being a breaking change release, so I made these adjustments. I track all the breaking changes here and I suggest we add a changelog.

1. Changed winReason to match the enumerations (CSGO added 1 to these values for some reason). See https://github.com/saul/demofile/issues/38#issuecomment-330068048
2. Changed event data structure for `player_death`, adding the entire `assist` as an object that can be null if there was no assist. It's cleaner this way, JSON-wise.
3. Player death event now fires for friendly fire and suicides and includes assist-friendly fire as well. If you don't want this data you have to now check for these booleans.
4. Removed `get5_web_avaliable` legacy spelling-mistake command alias.
5. stock `HelpfulAttack` no longer checks for `isValidClient` - you should do this before using the method. This because it caused duplicate calls to `isValidClient` in most use-cases.
6. `matchId` is now passed as the first `char[]` argument to most forwards where it makes sense to have it, instead of those forwards having to call `GetMatchID` immediately after. The order is now always `matchId`, `mapNumber`, `roundNumber` and `roundTime` for all forward events where these are applicable. Please check your argument order in forwards!
7. Added `round_time` and `round_number` to applicable events and forwards. `round_time` is milliseconds and `round_number` is zero-indexed like map number.

If anyone has any feedback please comment. I did not test this code yet so there may be errors.