### PR TITLE
Change gMapSides when knife round swaps.

### DIFF
--- a/scripting/get5/kniferounds.sp
+++ b/scripting/get5/kniferounds.sp
@@ -42,6 +42,13 @@ static void PerformSideSwap(bool swap) {
         }
       }
     }
+    // Make sure g_MapSides has the correct values as well,
+    // that way set starting teams won't swap on round 0,
+    // since a temp valve backup does not exist.
+    if (g_TeamSide[MatchTeam_Team1] == CS_TEAM_CT)
+      g_MapSides.Set(GetMapNumber(), SideChoice_Team1CT);
+    else
+      g_MapSides.Set(GetMapNumber(), SideChoice_Team1T);
   } else {
     g_TeamSide[MatchTeam_Team1] = TEAM1_STARTING_SIDE;
     g_TeamSide[MatchTeam_Team2] = TEAM2_STARTING_SIDE;


### PR DESCRIPTION
This should fix Side Restore Issues in #699.

Currently on round 0, it appears that the temp valve backup is not created, which causes us to hit the conditional in `RestoreGet5Backup()` and calls `SetStartingTeams()` in `teamlogic.sp` on Line 301. So instead of rewriting a bunch of logic, we just set the current `g_MapSides` value to be whichever side choice is selected by the `!swap` command.