### PR TITLE
Match Restore Coach Fix

### DIFF
--- a/configs/get5/example_match.cfg
+++ b/configs/get5/example_match.cfg
@@ -31,6 +31,7 @@
 	}
 
 	"players_per_team"		"5"
+	"coaches_per_team"		"2"
 	"min_players_to_ready"		"1" // Minimum # of players a team must have to ready
 	"min_spectators_to_ready"		"0" // How many spectators must be ready to begin.
 

--- a/configs/get5/example_match.json
+++ b/configs/get5/example_match.json
@@ -1,7 +1,7 @@
 {
 	"matchid": "example_match",
 	"num_maps": 3,
-	"players_per_team": 1,
+	"players_per_team": 5,
 	"coaches_per_team": 2,
 	"min_players_to_ready": 1,
 	"min_spectators_to_ready": 0,

--- a/configs/get5/example_match.json
+++ b/configs/get5/example_match.json
@@ -2,6 +2,7 @@
 	"matchid": "example_match",
 	"num_maps": 3,
 	"players_per_team": 1,
+	"coaches_per_team": 2,
 	"min_players_to_ready": 1,
 	"min_spectators_to_ready": 0,
 	"skip_veto": false,

--- a/configs/get5/scrim_template.cfg
+++ b/configs/get5/scrim_template.cfg
@@ -9,6 +9,7 @@
 	"scrim"		"1"
 	"side_type"		"never_knife"
 	"players_per_team"		"5"
+	"coaches_per_team"		"2"
 	"num_maps"		"1"
 	"skip_veto"		"1"
 

--- a/documentation/docs/match_schema.md
+++ b/documentation/docs/match_schema.md
@@ -26,6 +26,8 @@ match.
   backup method, defaults to `0`.
 - `matchtext`: Wraps `mp_teammatchstat_1`, you probably don't want to set this, in BoX series `mp_teamscore` cvars are
   automatically set and take the place of the `mp_teammatchstat` cvars.
+- `coaches`: Identical to the `players` tag, it's an optional list of Steam ID's for users who wish to coach a team.
+  You may also force player names here. This field is optional.
 
 ## Optional Values
 
@@ -39,6 +41,7 @@ match.
   gets the side choice, "never_knife" means "team1" is always on CT first, and "always_knife" means there is always a
   knife round.
 - `players_per_team`: Maximum players per team (doesn't include a coach spot, default: 5).
+- `coaches_per_team`: Maximum coaches per team (default: 2).
 - `min_players_to_ready`: Minimum players a team needs to be able to ready up (default: 1).
 - `favored_percentage_team1`: Wrapper for the servers `mp_teamprediction_pct`.
 - `favored_percentage_text` Wrapper for the servers `mp_teamprediction_txt`.

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -973,7 +973,6 @@ public void RestoreLastRound(int client) {
     } else {
       ReplyToCommand(client, "Failed to load backup %s - check error logs", lastBackup);
     }
-    //ServerCommand("get5_loadbackup \"%s\"", lastBackup);
   } else {
     ReplyToCommand(client, "Failed to load backup, as previous round backup does not exist.");
   }

--- a/scripting/get5/backups.sp
+++ b/scripting/get5/backups.sp
@@ -351,6 +351,9 @@ public void RestoreGet5Backup() {
       EndWarmup();
       ServerCommand("mp_restartgame 5");
       Pause(PauseType_Backup);
+      if (g_CoachingEnabledCvar.BoolValue) {
+        CreateTimer(6.0, Timer_SwapCoaches);
+      }
     } else {
       EnsurePausedWarmup();
     }
@@ -359,7 +362,25 @@ public void RestoreGet5Backup() {
   }
 }
 
+public Action Timer_SwapCoaches(Handle timer) {
+  for (int i = 1; i <= MaxClients; i++) {
+    if (IsAuthedPlayer(i)) {
+      CheckIfClientCoaching(i, MatchTeam_Team1);
+      CheckIfClientCoaching(i, MatchTeam_Team2);
+    }
+      
+  }
+}
+
 public Action Time_StartRestore(Handle timer) {
+  // If we are coaching, we need to ensure we are in a warmup
+  // per Valve's conditionals set on coaching.
+  // This is only to remove the error message 
+  // You can only change coaching position during warmup.
+  // In the console. We can remove this if we do not care about it?
+  if (g_CoachingEnabledCvar.BoolValue) {
+    EnsurePausedWarmup();
+  }
   Pause(PauseType_Backup);
 
   char tempValveBackup[PLATFORM_MAX_PATH];
@@ -369,6 +390,10 @@ public Action Time_StartRestore(Handle timer) {
 }
 
 public Action Timer_FinishBackup(Handle timer) {
+  if (g_CoachingEnabledCvar.BoolValue) {
+    EndWarmup();
+    EndWarmup();
+  }
   g_DoingBackupRestoreNow = false;
 }
 

--- a/scripting/get5/backups.sp
+++ b/scripting/get5/backups.sp
@@ -373,14 +373,6 @@ public Action Timer_SwapCoaches(Handle timer) {
 }
 
 public Action Time_StartRestore(Handle timer) {
-  // If we are coaching, we need to ensure we are in a warmup
-  // per Valve's conditionals set on coaching.
-  // This is only to remove the error message 
-  // You can only change coaching position during warmup.
-  // In the console. We can remove this if we do not care about it?
-  // if (g_CoachingEnabledCvar.BoolValue) {
-  //   EnsurePausedWarmup();
-  // }
   Pause(PauseType_Backup);
 
   char tempValveBackup[PLATFORM_MAX_PATH];
@@ -391,9 +383,12 @@ public Action Time_StartRestore(Handle timer) {
 
 public Action Timer_FinishBackup(Handle timer) {
   if (g_CoachingEnabledCvar.BoolValue) {
-    // EndWarmup();
-    // EndWarmup();
-    // Do we really need to force this? Will continue testing.
+    // If we are coaching we want to ensure our
+    // coaches get moved back onto the team.
+    // We cannot trust Valve's system as a disconnected
+    // player will count as a "player" and not be placed
+    // in the coach slot. So, we cannot enable warmup during
+    // the round restore process if using a Valve backup.
     CreateTimer(0.5, Timer_SwapCoaches);
   }
   g_DoingBackupRestoreNow = false;

--- a/scripting/get5/backups.sp
+++ b/scripting/get5/backups.sp
@@ -378,9 +378,9 @@ public Action Time_StartRestore(Handle timer) {
   // This is only to remove the error message 
   // You can only change coaching position during warmup.
   // In the console. We can remove this if we do not care about it?
-  if (g_CoachingEnabledCvar.BoolValue) {
-    EnsurePausedWarmup();
-  }
+  // if (g_CoachingEnabledCvar.BoolValue) {
+  //   EnsurePausedWarmup();
+  // }
   Pause(PauseType_Backup);
 
   char tempValveBackup[PLATFORM_MAX_PATH];
@@ -391,8 +391,10 @@ public Action Time_StartRestore(Handle timer) {
 
 public Action Timer_FinishBackup(Handle timer) {
   if (g_CoachingEnabledCvar.BoolValue) {
-    EndWarmup();
-    EndWarmup();
+    // EndWarmup();
+    // EndWarmup();
+    // Do we really need to force this? Will continue testing.
+    CreateTimer(0.5, Timer_SwapCoaches);
   }
   g_DoingBackupRestoreNow = false;
 }

--- a/scripting/get5/debug.sp
+++ b/scripting/get5/debug.sp
@@ -102,6 +102,7 @@ static void AddGlobalStateInfo(File f) {
 
   f.WriteLine("g_MatchTitle = %s", g_MatchTitle);
   f.WriteLine("g_PlayersPerTeam = %d", g_PlayersPerTeam);
+  f.WriteLine("g_CoachesPerTeam = %d", g_CoachesPerTeam);
   f.WriteLine("g_MinPlayersToReady = %d", g_MinPlayersToReady);
   f.WriteLine("g_MinSpectatorsToReady = %d", g_MinSpectatorsToReady);
   f.WriteLine("g_SkipVeto = %d", g_SkipVeto);
@@ -137,6 +138,8 @@ static void AddGlobalStateInfo(File f) {
     f.WriteLine("g_TeamPausesUsed = %d", g_TeamPausesUsed[team]);
     f.WriteLine("g_TeamTechPausesUsed = %d", g_TeamTechPausesUsed[team]);
     f.WriteLine("g_TeamGivenTechPauseCommand = %d", g_TeamGivenTechPauseCommand[team]);
+    f.WriteLine("g_TeamGivenStopCommand = %d", g_TeamGivenStopCommand[team]);
+    WriteArrayList(f, "g_TeamCoaches", g_TeamCoaches[team]);
   }
 }
 
@@ -155,6 +158,7 @@ static void AddInterestingCvars(File f) {
   WriteCvarString(f, "get5_pausing_enabled");
   WriteCvarString(f, "get5_reset_pauses_each_half");
   WriteCvarString(f, "get5_web_api_url");
+  WriteCvarString(f, "get5_last_backup_file");
   WriteCvarString(f, "mp_freezetime");
   WriteCvarString(f, "mp_halftime");
   WriteCvarString(f, "mp_halftime_duration");

--- a/scripting/get5/matchconfig.sp
+++ b/scripting/get5/matchconfig.sp
@@ -879,6 +879,9 @@ public Action Command_AddCoach(int client, int args) {
       if (index >= 0) {
         GetTeamAuths(team).Erase(index);
       }
+      // Update the backup structure as well for round restores, covers edge
+      // case of users joining, coaching, stopping, and getting 16k cash as player.
+      WriteBackup();
       ReplyToCommand(client, "Successfully added player %s to coach team %s", auth, teamString);
     } else {
       ReplyToCommand(client, "Player %s is already in a coaching position on a team.", auth);

--- a/scripting/get5/matchconfig.sp
+++ b/scripting/get5/matchconfig.sp
@@ -622,10 +622,7 @@ static void LoadTeamData(KeyValues kv, MatchTeam matchTeam) {
 
   if (StrEqual(fromfile, "")) {
     AddSubsectionAuthsToList(kv, "players", GetTeamAuths(matchTeam), AUTH_LENGTH);
-    if (kv.JumpToKey("coaches")) {
-      AddSubsectionAuthsToList(kv, "coaches", GetTeamCoaches(matchTeam), AUTH_LENGTH);
-      kv.GoBack();
-    }
+    AddSubsectionAuthsToList(kv, "coaches", GetTeamCoaches(matchTeam), AUTH_LENGTH);
     kv.GetString("name", g_TeamNames[matchTeam], MAX_CVAR_LENGTH, "");
     kv.GetString("tag", g_TeamTags[matchTeam], MAX_CVAR_LENGTH, "");
     kv.GetString("flag", g_TeamFlags[matchTeam], MAX_CVAR_LENGTH, "");

--- a/scripting/get5/matchconfig.sp
+++ b/scripting/get5/matchconfig.sp
@@ -874,6 +874,11 @@ public Action Command_AddCoach(int client, int args) {
     }
 
     if (AddCoachToTeam(auth, team, name)) {
+      // Check if we are in the playerlist already and remove.
+      int index = GetTeamAuths(team).FindString(auth);
+      if (index >= 0) {
+        GetTeamAuths(team).Erase(index);
+      }
       ReplyToCommand(client, "Successfully added player %s to coach team %s", auth, teamString);
     } else {
       ReplyToCommand(client, "Player %s is already in a coaching position on a team.", auth);

--- a/scripting/get5/pausing.sp
+++ b/scripting/get5/pausing.sp
@@ -309,6 +309,8 @@ public Action Command_Unpause(int client, int args) {
     return Plugin_Handled;
   }
 
+  // Check to see if we have a timeout that is timed. Otherwise, we need to
+  // continue for unpausing. New pause type to avoid match restores failing.
   if (g_FixedPauseTimeCvar.BoolValue && g_PauseType == PauseType_Tactical) {
     return Plugin_Handled;
   }

--- a/scripting/get5/teamlogic.sp
+++ b/scripting/get5/teamlogic.sp
@@ -188,6 +188,9 @@ public Action Command_SmCoach(int client, int args) {
   }
 
   MoveClientToCoach(client);
+  // Update the backup structure as well for round restores, covers edge
+  // case of users joining, coaching, stopping, and getting 16k cash as player.
+  WriteBackup();
   return Plugin_Handled;
 }
 
@@ -215,6 +218,9 @@ public Action Command_Coach(int client, const char[] command, int argc) {
   }
 
   MoveClientToCoach(client);
+  // Update the backup structure as well for round restores, covers edge
+  // case of users joining, coaching, stopping, and getting 16k cash as player.
+  WriteBackup();
   return Plugin_Stop;
 }
 

--- a/scripting/get5/teamlogic.sp
+++ b/scripting/get5/teamlogic.sp
@@ -144,6 +144,12 @@ public void MoveClientToCoach(int client) {
   GetAuth(client, clientAuth, AUTH_LENGTH);
   if (!IsAuthOnTeamCoach(clientAuth, matchTeam)) {
     AddCoachToTeam(clientAuth, matchTeam, "");
+    // If we're already on the team, make sure we remove ourselves
+    // to ensure data is correct in the backups.
+    int index = GetTeamAuths(matchTeam).FindString(clientAuth);
+    if (index >= 0) {
+      GetTeamAuths(matchTeam).Erase(index);
+    }
   }
   
   // If we're in warmup we use the in-game

--- a/scripting/get5/teamlogic.sp
+++ b/scripting/get5/teamlogic.sp
@@ -107,15 +107,18 @@ public Action Command_JoinTeam(int client, const char[] command, int argc) {
 }
 
 public bool CheckIfClientCoaching(int client, MatchTeam team) {
-    // Force user to join the coach if specified by config or reconnect.
-    char clientAuth64[AUTH_LENGTH];
-    GetAuth(client, clientAuth64, AUTH_LENGTH);
-    if (g_CoachingEnabledCvar.BoolValue && IsAuthOnTeamCoach(clientAuth64, team)) {
-        LogDebug("Forcing player %N to coach as they were previously.", client);
-        MoveClientToCoach(client);
-        return true;
-    }
+  if (!g_CoachingEnabledCvar.BoolValue) {
     return false;
+  }
+  // Force user to join the coach if specified by config or reconnect.
+  char clientAuth64[AUTH_LENGTH];
+  GetAuth(client, clientAuth64, AUTH_LENGTH);
+  if (IsAuthOnTeamCoach(clientAuth64, team)) {
+      LogDebug("Forcing player %N to coach as they were previously.", client);
+      MoveClientToCoach(client);
+      return true;
+  }
+  return false;
 }
 
 public void MoveClientToCoach(int client) {

--- a/scripting/get5/teamlogic.sp
+++ b/scripting/get5/teamlogic.sp
@@ -14,12 +14,19 @@ public Action Command_JoinGame(int client, const char[] command, int argc) {
 
 public void CheckClientTeam(int client) {
   MatchTeam correctTeam = GetClientMatchTeam(client);
+  char auth[AUTH_LENGTH];
   int csTeam = MatchTeamToCSTeam(correctTeam);
   int currentTeam = GetClientTeam(client);
 
   if (csTeam != currentTeam) {
     if (IsClientCoaching(client)) {
       UpdateCoachTarget(client, csTeam);
+    } else if (GetAuth(client, auth, sizeof(auth))) {
+      char steam64[AUTH_LENGTH];
+      ConvertAuthToSteam64(auth, steam64);
+      if (IsAuthOnTeamCoach(steam64, correctTeam)) {
+        UpdateCoachTarget(client, csTeam);
+      }
     }
 
     SwitchPlayerTeam(client, csTeam);
@@ -63,7 +70,11 @@ public Action Command_JoinTeam(int client, const char[] command, int argc) {
   }
 
   if (csTeam == team_to) {
-    return Plugin_Continue;
+    if(CheckIfClientCoaching(client, correctTeam)) {
+      return Plugin_Stop;
+    } else {
+      return Plugin_Continue;
+    }
   }
 
   if (csTeam != GetClientTeam(client)) {
@@ -74,19 +85,37 @@ public Action Command_JoinTeam(int client, const char[] command, int argc) {
       if (!g_CoachingEnabledCvar.BoolValue) {
         KickClient(client, "%t", "TeamIsFullInfoMessage");
       } else {
-        LogDebug("Forcing player %N to coach", client);
-        MoveClientToCoach(client);
-        Get5_Message(client, "%t", "MoveToCoachInfoMessage");
+        // Only attempt to move to coach if we are not full on coaches already.
+        if (GetTeamCoaches(correctTeam).Length <= g_CoachesPerTeam) {
+          LogDebug("Forcing player %N to coach", client);
+          MoveClientToCoach(client);
+          Get5_Message(client, "%t", "MoveToCoachInfoMessage");
+        } else {
+          KickClient(client, "%t", "TeamIsFullInfoMessage");
+        }
       }
     } else {
       LogDebug("Forcing player %N onto %d", client, csTeam);
       FakeClientCommand(client, "jointeam %d", csTeam);
     }
-
+    
+    CheckIfClientCoaching(client, correctTeam);
     return Plugin_Stop;
   }
 
   return Plugin_Stop;
+}
+
+public bool CheckIfClientCoaching(int client, MatchTeam team) {
+    // Force user to join the coach if specified by config or reconnect.
+    char clientAuth64[AUTH_LENGTH];
+    GetAuth(client, clientAuth64, AUTH_LENGTH);
+    if (g_CoachingEnabledCvar.BoolValue && IsAuthOnTeamCoach(clientAuth64, team)) {
+        LogDebug("Forcing player %N to coach as they were previously.", client);
+        MoveClientToCoach(client);
+        return true;
+    }
+    return false;
 }
 
 public void MoveClientToCoach(int client) {
@@ -110,12 +139,18 @@ public void MoveClientToCoach(int client) {
   }
 
   char teamString[4];
+  char clientAuth[64];
   CSTeamString(csTeam, teamString, sizeof(teamString));
-
-  // If we're in warmup or a freezetime we use the in-game
+  GetAuth(client, clientAuth, AUTH_LENGTH);
+  if (!IsAuthOnTeamCoach(clientAuth, matchTeam)) {
+    AddCoachToTeam(clientAuth, matchTeam, "");
+  }
+  
+  // If we're in warmup we use the in-game
   // coaching command. Otherwise we manually move them to spec
   // and set the coaching target.
-  if (!InWarmup() && !InFreezeTime()) {
+  // If in freeze time, we have to manually move as well.
+  if (!InWarmup() && InFreezeTime()) {
     // TODO: this needs to be tested more thoroughly,
     // it might need to be done in reverse order (?)
     LogDebug("Moving %L directly to coach slot", client);
@@ -130,6 +165,7 @@ public void MoveClientToCoach(int client) {
 }
 
 public Action Command_SmCoach(int client, int args) {
+  char auth[AUTH_LENGTH];
   if (g_GameState == Get5State_None) {
     return Plugin_Continue;
   }
@@ -138,11 +174,19 @@ public Action Command_SmCoach(int client, int args) {
     return Plugin_Handled;
   }
 
+  GetAuth(client, auth, sizeof(auth));
+  MatchTeam matchTeam = GetClientMatchTeam(client);
+  // Don't allow a new coach if spots are full.
+  if (GetTeamCoaches(matchTeam).Length > g_CoachesPerTeam) {
+    return Plugin_Stop;
+  }
+
   MoveClientToCoach(client);
   return Plugin_Handled;
 }
 
 public Action Command_Coach(int client, const char[] command, int argc) {
+
   if (g_GameState == Get5State_None) {
     return Plugin_Continue;
   }
@@ -223,6 +267,24 @@ public MatchTeam GetAuthMatchTeam(const char[] steam64) {
   return MatchTeam_TeamNone;
 }
 
+public MatchTeam GetAuthMatchTeamCoach(const char[] steam64) {
+  if (g_GameState == Get5State_None) {
+    return MatchTeam_TeamNone;
+  }
+
+  if (g_InScrimMode) {
+    return IsAuthOnTeamCoach(steam64, MatchTeam_Team1) ? MatchTeam_Team1 : MatchTeam_Team2;
+  }
+
+  for (int i = 0; i < MATCHTEAM_COUNT; i++) {
+    MatchTeam team = view_as<MatchTeam>(i);
+    if (IsAuthOnTeamCoach(steam64, team)) {
+      return team;
+    }
+  }
+  return MatchTeam_TeamNone;
+}
+
 stock int CountPlayersOnCSTeam(int team, int exclude = -1) {
   int count = 0;
   for (int i = 1; i <= MaxClients; i++) {
@@ -294,8 +356,16 @@ public ArrayList GetTeamAuths(MatchTeam team) {
   return g_TeamAuths[team];
 }
 
+public ArrayList GetTeamCoaches(MatchTeam team) {
+  return g_TeamCoaches[team];
+}
+
 public bool IsAuthOnTeam(const char[] auth, MatchTeam team) {
   return GetTeamAuths(team).FindString(auth) >= 0;
+}
+
+public bool IsAuthOnTeamCoach(const char[] auth, MatchTeam team) {
+  return GetTeamCoaches(team).FindString(auth) >= 0;
 }
 
 public void SetStartingTeams() {
@@ -347,6 +417,23 @@ public bool AddPlayerToTeam(const char[] auth, MatchTeam team, const char[] name
 
   if (GetAuthMatchTeam(steam64) == MatchTeam_TeamNone) {
     GetTeamAuths(team).PushString(steam64);
+    Get5_SetPlayerName(auth, name);
+    return true;
+  } else {
+    return false;
+  }
+}
+
+public bool AddCoachToTeam(const char[] auth, MatchTeam team, const char[] name) {
+  char steam64[AUTH_LENGTH];
+  ConvertAuthToSteam64(auth, steam64);
+
+  if (team == MatchTeam_TeamSpec) {
+    LogDebug("Not allowed to coach a spectator team.");
+    return false;
+  }
+  if (GetAuthMatchTeamCoach(steam64) == MatchTeam_TeamNone) {
+    GetTeamCoaches(team).PushString(steam64);
     Get5_SetPlayerName(auth, name);
     return true;
   } else {

--- a/scripting/include/get5.inc
+++ b/scripting/include/get5.inc
@@ -42,7 +42,7 @@ enum PauseType {
   PauseType_None,
   PauseType_Tech,      // Technical pause
   PauseType_Tactical,  // Tactical Pause
-  PauseType_Admin,      // Admin/RCON Pause
+  PauseType_Admin,     // Admin/RCON Pause
   PauseType_Backup     // Special type for match pausing during backups.
 };
 


### PR DESCRIPTION
Per #699 there is an issue during match restores either using `get5_loadbackup` or `!stop` in chat. Once the match is restored, a coach is dropped onto the team, and unable to `.coach` back. Maybe there was a change to the coaching mechanism in CS:GO, but this fix simply allows users to use `.coach` In freeze time, as was intended by the looks of it from the comments?

Thanks!