### PR TITLE
Maintain Pause Count On Match Restore

### DIFF
--- a/scripting/get5/matchconfig.sp
+++ b/scripting/get5/matchconfig.sp
@@ -23,8 +23,13 @@ stock bool LoadMatchConfig(const char[] config, bool restoreBackup = false) {
     g_TeamReadyForUnpause[team] = false;
     g_TeamGivenStopCommand[team] = false;
     g_TeamPauseTimeUsed[team] = 0;
-    g_TeamPausesUsed[team] = 0;
-    g_TeamTechPausesUsed[team] = 0;
+    // We only reset these on a new game.
+    // During restore we want to keep our 
+    // current pauses used.
+    if (!restoreBackup) {
+      g_TeamPausesUsed[team] = 0;
+      g_TeamTechPausesUsed[team] = 0;
+    }
     g_TechPausedTimeOverride[team] = 0;
     g_TeamGivenTechPauseCommand[team] = false;
     ClearArray(GetTeamAuths(team));

--- a/scripting/get5/pausing.sp
+++ b/scripting/get5/pausing.sp
@@ -129,8 +129,7 @@ public Action Command_Pause(int client, int args) {
     if (need_resume) {
       g_PauseTimeUsed = g_PauseTimeUsed + g_FixedPauseTimeCvar.IntValue - 1;
       CreateTimer(1.0, Timer_PauseTimeCheck, team, TIMER_REPEAT | TIMER_FLAG_NO_MAPCHANGE);
-      // Keep track of timer, since we don't want several timers created for one pause checking
-      // instance.
+      // This timer is used to only fire off the Unpause event.
       CreateTimer(1.0, Timer_UnpauseEventCheck, team, TIMER_REPEAT | TIMER_FLAG_NO_MAPCHANGE);
     }
 


### PR DESCRIPTION
As per discussed in Discord with a few users, during the `Command_Stop` or restoring using `LoadBackup`, the current amount of pauses should be left as they are per game. This is a small fix in the LOOP_TEAM Macro to make sure we don't reset it if we're currently restoring from a backup.