### PR TITLE
Fix pausing during match restore when users use a fixed pause timer.

### DIFF
--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -952,7 +952,7 @@ public Action Command_Stop(int client, int args) {
   return Plugin_Handled;
 }
 
-public bool RestoreLastRound(int client) {
+public void RestoreLastRound(int client) {
   LOOP_TEAMS(x) {
     g_TeamGivenStopCommand[x] = false;
   }
@@ -961,12 +961,11 @@ public bool RestoreLastRound(int client) {
   g_LastGet5BackupCvar.GetString(lastBackup, sizeof(lastBackup));
   if (RestoreFromBackup(lastBackup)) {
     Get5_MessageToAll("%t", "BackupLoadedInfoMessage", lastBackup);
+    // Fix the last backup cvar since it gets reset.
+    g_LastGet5BackupCvar.SetString(lastBackup);
   } else {
     ReplyToCommand(client, "Failed to load backup %s - check error logs", lastBackup);
   }
-    // Fix the last backup cvar since it gets reset.
-  g_LastGet5BackupCvar.SetString(lastBackup);
-  return false;
 }
 
 /**

--- a/scripting/get5/backups.sp
+++ b/scripting/get5/backups.sp
@@ -350,7 +350,7 @@ public void RestoreGet5Backup() {
       EndWarmup();
       EndWarmup();
       ServerCommand("mp_restartgame 5");
-      Pause(PauseType_Tactical);
+      Pause(PauseType_Backup);
     } else {
       EnsurePausedWarmup();
     }
@@ -360,7 +360,7 @@ public void RestoreGet5Backup() {
 }
 
 public Action Time_StartRestore(Handle timer) {
-  Pause(PauseType_Tactical);
+  Pause(PauseType_Backup);
 
   char tempValveBackup[PLATFORM_MAX_PATH];
   GetTempFilePath(tempValveBackup, sizeof(tempValveBackup), TEMP_VALVE_BACKUP_PATTERN);

--- a/scripting/get5/get5menu.sp
+++ b/scripting/get5/get5menu.sp
@@ -45,11 +45,7 @@ public int AdminMenuHandler(Menu menu, MenuAction action, int param1, int param2
     } else if (StrEqual(infoString, "ringer")) {
       GiveRingerMenu(client);
     } else if (StrEqual(infoString, "backup")) {
-      if (!RestoreLastRound()) {
-        Get5_Message(
-            client,
-            "Failed to restore backup file. Try manually using get5_listbackups and get5_loadbackup.");
-      }
+      RestoreLastRound(client);
     }
   } else if (action == MenuAction_End) {
     delete menu;

--- a/scripting/get5/pausing.sp
+++ b/scripting/get5/pausing.sp
@@ -310,7 +310,7 @@ public Action Command_Unpause(int client, int args) {
     return Plugin_Handled;
   }
 
-  if (g_FixedPauseTimeCvar.BoolValue && g_PauseType != PauseType_Tech) {
+  if (g_FixedPauseTimeCvar.BoolValue && g_PauseType == PauseType_Tactical) {
     return Plugin_Handled;
   }
 

--- a/scripting/include/get5.inc
+++ b/scripting/include/get5.inc
@@ -42,7 +42,8 @@ enum PauseType {
   PauseType_None,
   PauseType_Tech,      // Technical pause
   PauseType_Tactical,  // Tactical Pause
-  PauseType_Admin      // Admin/RCON Pause
+  PauseType_Admin,      // Admin/RCON Pause
+  PauseType_Backup     // Special type for match pausing during backups.
 };
 
 // Called each get5-event with JSON formatted event text.


### PR DESCRIPTION
Remove the ServerCommand call and use a direct call to function.

Adjust RestoreLastRound to include client to send message to user on backup failure.