### PR TITLE
More fixed pause timer fixes.

### DIFF
--- a/scripting/get5/matchconfig.sp
+++ b/scripting/get5/matchconfig.sp
@@ -22,11 +22,11 @@ stock bool LoadMatchConfig(const char[] config, bool restoreBackup = false) {
     g_TeamSeriesScores[team] = 0;
     g_TeamReadyForUnpause[team] = false;
     g_TeamGivenStopCommand[team] = false;
-    g_TeamPauseTimeUsed[team] = 0;
     // We only reset these on a new game.
     // During restore we want to keep our 
     // current pauses used.
     if (!restoreBackup) {
+      g_TeamPauseTimeUsed[team] = 0;
       g_TeamPausesUsed[team] = 0;
       g_TeamTechPausesUsed[team] = 0;
     }

--- a/scripting/get5/pausing.sp
+++ b/scripting/get5/pausing.sp
@@ -113,7 +113,7 @@ public Action Command_Pause(int client, int args) {
   }
 
   // If the pause will need explicit resuming, we will create a timer to poll the pause status.
-  bool need_resume = Pause(PauseType_Tactical, g_FixedPauseTimeCvar.IntValue, MatchTeamToCSTeam(team));
+  bool need_resume = Pause(PauseType_Tactical, g_FixedPauseTimeCvar.IntValue, MatchTeamToCSTeam(team), pausesLeft);
   EventLogger_PauseCommand(team, PauseType_Tactical);
   LogDebug("Calling Get5_OnMatchPaused(team=%d, pauseReason=%d)", team, PauseType_Tactical);
   Call_StartForward(g_OnMatchPaused);


### PR DESCRIPTION
Updates pausesLeft in Pause call for UI.

Do not update pause time used on round restore as well.

Confirmed working by Kancha in the Discord as well.

This was reported after testing the coaches branch with a few test cases. Pauses were still restoring after the first fix, so this now fixes any remaining fixed timeout pause issues.