### PR TITLE
Use user ID in player object

### DIFF
--- a/documentation/docs/event_schema.yml
+++ b/documentation/docs/event_schema.yml
@@ -1044,11 +1044,19 @@ components:
     Get5Player:
       type: object
       properties:
+        id:
+          type: integer
+          minimum: 0
+          description: |
+            The in-game user ID of the player. This uniquely identifies the player within a server and is
+            auto-incremented for each connecting player. 0 for GOTV/Console but >0 for all players or bots. If the same
+            player reconnects, they will be given a new ID. `steamid` uniquely identifies the player outside the server.
+          example: 4
         steamid:
           type: string
           example: '76561198279375306'
           description: The SteamID64 of the player. `GetSteamId()` and `SetSteamId()`
-            in SourceMod. This will be `BOT-%d` if the player is a bot, where `%d` is the client index. This is required to be able to distinguish bots from each other. The string will be empty for Console and GOTV (although we *should* never see this in practice).
+            in SourceMod. This will be `BOT-%d` if the player is a bot, where `%d` is the user ID (`id`). The string will be empty for Console and GOTV (although we *should* never see this in practice).
         side:
           $ref: "#/components/schemas/Get5Side"
         name:

--- a/scripting/include/get5.inc
+++ b/scripting/include/get5.inc
@@ -355,20 +355,18 @@ methodmap Get5Player < JSON_Object {
       }
     }
 
-    public bool IsEqualToPlayerId(const char[] id) {
-      char ownId[64];
-      this.GetSteamId(ownId, sizeof(ownId));
-      return StrEqual(ownId, id);
+    property int Id {
+      public get() {
+        return this.GetInt("id");
+      }
+      public set(int id) {
+        this.SetInt("id", id);
+      }
     }
 
-    public bool IsEqualToPlayer(const Get5Player player) {
-      char playerId[64];
-      player.GetSteamId(playerId, sizeof(playerId));
-      return this.IsEqualToPlayerId(playerId);
-    }
-
-    public Get5Player(const char[] steamId, const Get5Side side, const char[] name, const bool isBot) {
+    public Get5Player(const int id, const char[] steamId, const Get5Side side, const char[] name, const bool isBot) {
         Get5Player self = view_as<Get5Player>(new JSON_Object());
+        self.Id = id;
         self.SetSteamId(steamId);
         self.Side = side;
         self.SetName(name);


### PR DESCRIPTION
It seems it's smarter to use https://sm.alliedmods.net/new-api/clients/GetClientUserId and store this in grenade victims, than to use steam ID, as it is unique for all intents and purposes within the lifetime of a server (rolling over at 2^16). This means we don't have to allocate a new `JSON_Object` for each time a molotov deals damage, and it also means we don't need to compare players using their steam ID.

Untested, but should work. I'll test it soon and then merge.