### PR TITLE
Adjust EnsurePausedWarmup and renamed it to EnsureIndefiniteWarmup

### DIFF
--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -665,7 +665,7 @@ public void OnClientPutInServer(int client) {
   if (g_GameState <= Get5State_Warmup && g_GameState != Get5State_None) {
     if (GetRealClientCount() <= 1) {
       ExecCfg(g_WarmupCfgCvar);
-      EnsurePausedWarmup();
+      EnsureIndefiniteWarmup();
     }
   }
 
@@ -777,7 +777,7 @@ public void OnMapStart() {
     ExecCfg(g_LiveCfgCvar);
     SetMatchTeamCvars();
     ExecuteMatchConfigCvars();
-    EnsurePausedWarmup();
+    EnsureIndefiniteWarmup();
   }
 }
 
@@ -793,7 +793,7 @@ public void OnConfigsExecuted() {
     ExecCfg(g_WarmupCfgCvar);
     SetMatchTeamCvars();
     ExecuteMatchConfigCvars();
-    EnsurePausedWarmup();
+    EnsureIndefiniteWarmup();
   }
 }
 
@@ -1557,7 +1557,7 @@ public Action Timer_PostKnife(Handle timer) {
   }
 
   ExecCfg(g_WarmupCfgCvar);
-  EnsurePausedWarmup();
+  EnsureIndefiniteWarmup();
 }
 
 public Action StopDemo(Handle timer) {

--- a/scripting/get5/backups.sp
+++ b/scripting/get5/backups.sp
@@ -360,7 +360,7 @@ public void RestoreGet5Backup() {
         CreateTimer(6.0, Timer_SwapCoaches);
       }
     } else {
-      EnsurePausedWarmup();
+      EnsureIndefiniteWarmup();
     }
 
     g_DoingBackupRestoreNow = false;

--- a/scripting/get5/matchconfig.sp
+++ b/scripting/get5/matchconfig.sp
@@ -121,7 +121,7 @@ stock bool LoadMatchConfig(const char[] config, bool restoreBackup = false) {
     ExecCfg(g_WarmupCfgCvar);
     ExecuteMatchConfigCvars();
     LoadPlayerNames();
-    EnsurePausedWarmup();
+    EnsureIndefiniteWarmup();
 
     Stats_InitSeries();
 

--- a/scripting/get5/util.sp
+++ b/scripting/get5/util.sp
@@ -258,7 +258,7 @@ stock bool InFreezeTime() {
   return GameRules_GetProp("m_bFreezePeriod") != 0;
 }
 
-stock void EnsurePausedWarmup() {
+stock void EnsureIndefiniteWarmup() {
   if (!InWarmup()) {
     StartWarmup();
   } else {

--- a/scripting/get5/util.sp
+++ b/scripting/get5/util.sp
@@ -261,11 +261,11 @@ stock bool InFreezeTime() {
 stock void EnsurePausedWarmup() {
   if (!InWarmup()) {
     StartWarmup();
+  } else {
+    ServerCommand("mp_warmup_pausetimer 1");
+    ServerCommand("mp_do_warmup_period 1");
+    ServerCommand("mp_warmup_pausetimer 1");
   }
-
-  ServerCommand("mp_warmup_pausetimer 1");
-  ServerCommand("mp_do_warmup_period 1");
-  ServerCommand("mp_warmup_pausetimer 1");
 }
 
 stock void StartWarmup(bool indefiniteWarmup = true, int warmupTime = 60) {


### PR DESCRIPTION
Looking at the code, the calls to

```c
ServerCommand("mp_warmup_pausetimer 1");
ServerCommand("mp_do_warmup_period 1");
ServerCommand("mp_warmup_pausetimer 1");
```

are already handled by `StartWarmup()`