### PR TITLE
Disable console "coach" command to make coaching logic easier to handle

### DIFF
--- a/scripting/get5/teamlogic.sp
+++ b/scripting/get5/teamlogic.sp
@@ -176,15 +176,16 @@ public void MoveClientToCoach(int client) {
 }
 
 public Action Command_SmCoach(int client, int args) {
-  char auth[AUTH_LENGTH];
   if (g_GameState == Get5State_None) {
     return Plugin_Continue;
   }
 
   if (!g_CoachingEnabledCvar.BoolValue) {
-    return Plugin_Handled;
+    ReplyToCommand(client, "Cannot set coaches when sv_coaching_enabled is false.");
+    return Plugin_Stop;
   }
 
+  char auth[AUTH_LENGTH];
   GetAuth(client, auth, sizeof(auth));
   Get5Team matchTeam = GetClientMatchTeam(client);
   // Don't allow a new coach if spots are full.
@@ -204,6 +205,7 @@ public Action Command_Coach(int client, const char[] command, int argc) {
     return Plugin_Continue;
   }
   // Don't allow regular "coach" console command. Always force people to use .coach/sm_coach for consistency.
+  Command_SmCoach(client, 0);
   return Plugin_Stop;
 }
 

--- a/scripting/get5/teamlogic.sp
+++ b/scripting/get5/teamlogic.sp
@@ -203,28 +203,7 @@ public Action Command_Coach(int client, const char[] command, int argc) {
   if (g_GameState == Get5State_None) {
     return Plugin_Continue;
   }
-
-  if (!g_CoachingEnabledCvar.BoolValue) {
-    return Plugin_Handled;
-  }
-
-  if (!IsAuthedPlayer(client)) {
-    return Plugin_Stop;
-  }
-
-  if (InHalftimePhase()) {
-    return Plugin_Stop;
-  }
-
-  if (g_MovingClientToCoach[client] || !g_CheckAuthsCvar.BoolValue) {
-    LogDebug("Command_Coach: %L, letting pass-through", client);
-    return Plugin_Continue;
-  }
-
-  MoveClientToCoach(client);
-  // Update the backup structure as well for round restores, covers edge
-  // case of users joining, coaching, stopping, and getting 16k cash as player.
-  WriteBackup();
+  // Don't allow regular "coach" console command. Always force people to use .coach/sm_coach for consistency.
   return Plugin_Stop;
 }
 


### PR DESCRIPTION
I'm pretty sure we better do this. There is no reason to let the ingame coach command mess around with the `.coach/sm_coach` logic we already have.

@PhlexPlexico  ?