### PR TITLE
Fix damage hook for bots

### DIFF
--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -658,6 +658,9 @@ public void RememberAndKickClient(int client, const char[] format, const char[] 
 }
 
 public void OnClientPutInServer(int client) {
+  if (!IsClientSourceTV(client)) {
+    Stats_HookDamageForClient(client);
+  }
   if (IsFakeClient(client)) {
     return;
   }
@@ -671,7 +674,6 @@ public void OnClientPutInServer(int client) {
   }
 
   Stats_ResetClientRoundValues(client);
-  Stats_HookDamageForClient(client);
 }
 
 public void OnClientPostAdminCheck(int client) {


### PR DESCRIPTION
Noticed that bot grenade damage attribution etc. does not work for bots, because we're not hooking the call to bots.

Bots still kind of broken, but this is a step in the right direction.