### PR TITLE
Add function to check for latest version of get5

### DIFF
--- a/documentation/docs/commands.md
+++ b/documentation/docs/commands.md
@@ -83,7 +83,7 @@ directory.
 
 ####`get5_loadmatch_url <url>` {: #get5_loadmatch_url }
 :   Loads a remote (JSON-formatted) match config by sending an HTTP(S) GET to the given URL. This requires the
-[Steamworks](../installation/#installing-steamworks-optional) extension. When specifying a URL with http:// or
+[SteamWorks](../installation/#steamworks) extension. When specifying a URL with http:// or
 https:// in front, you have to put it in quotation (`""`) marks.
 
 ####`get5_endmatch`

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -61,6 +61,10 @@ disconnect even in warmup with the intention to reconnect!). **`Default: 0`**
 :   Whether the Steam IDs from a "players" section are used to force players onto teams, and will kick
 users if they are not in the auth list. **`Default: 1`**
 
+####`get5_print_update_notice`
+:   Whether to print to chat when the game goes live if a new version of Get5 is available. This only works if
+    [SteamWorks](../installation/#steamworks) has been installed. **`Default: 1`**
+
 ## Match Setup
 
 **These options will generally be represented by changes to the clients.**

--- a/documentation/docs/installation.md
+++ b/documentation/docs/installation.md
@@ -3,7 +3,8 @@
 ## SourceMod & MetaMod
 
 You must have [SourceMod](https://www.sourcemod.net/) installed on your server. Please note that Get5
-requires **SourceMod version 1.10** or higher. You can get the latest versions here:
+requires **SourceMod version 1.10** or higher. SourceMod requires MetaMod, so you must install both plugins.
+You can get the latest versions here:
 
 [:material-download: Download MetaMod](https://www.sourcemm.net/downloads.php?branch=stable){ .md-button .md-button--primary } [:material-download: Download SourceMod](https://www.sourcemod.net/downloads.php?branch=stable){ .md-button .md-button--primary }
 
@@ -23,12 +24,18 @@ pre-releases found at the same link above that are marked in the title with "Nig
 
     Get5 itself is OS-agnostic, meaning the same file works on any OS.
 
-## Download SteamWorks (Optional)
+## Download SteamWorks (Recommended) {: #steamworks }
 
 SteamWorks is not required for Get5 to work on your game server, however it is required if you wish to [load match
-configs remotely](../commands#get5_loadmatch_url). You can download the latest binaries for
-SteamWorks [here](https://github.com/KyleSanderson/SteamWorks/releases/). If you require a Windows build of the
-extension, that can also be found [here](https://github.com/hexa-core-eu/SteamWorks/releases) instead.
+configs remotely](../commands#get5_loadmatch_url) or if you want Get5 to [automatically
+check for updates](../configuration#get5_print_update_notice).
+
+[:material-steam: Download SteamWorks](https://github.com/KyleSanderson/SteamWorks/releases/){ .md-button .md-button--primary }
+
+!!! tip "SteamWorks for Windows"
+
+    Similarly to SourceMod and MetaMod, SteamWorks is OS-specific. If you run Windows, you can get a Windows-version of
+    SteamWorks [here](https://github.com/hexa-core-eu/SteamWorks/releases).
 
 ## Putting it all together
 
@@ -41,7 +48,7 @@ is just to indicate what the correct structure looks like.
 
     If you already have Get5 installed and wish to upgrade to a newer version, simply copying the entire `get5.zip` folder
     structure will override your configuration files, so when updating, you should only add `get5.smx` (and
-    optionally `get5_mysqlstats.smx`) to `addons/sourcemod/plugins` as well as merge the entire `translations` folder with
+    optionally `get5_mysqlstats.smx`) to `addons/sourcemod/plugins` and merge the entire `translations` folder with
     `addons/sourcemod/translations`. In updated versions we might add or remove translation strings, and Get5 will error if
     it cannot find the strings it expects in these folders. The folder only contains Get5's translations, so it won't
     override translations for any other plugins.

--- a/scripting/get5/goinglive.sp
+++ b/scripting/get5/goinglive.sp
@@ -61,6 +61,18 @@ public Action MatchLive(Handle timer) {
     Get5_MessageToAll("%t", "MatchPoweredBy");
   }
 
+  if (!g_PrintUpdateNoticeCvar.BoolValue) {
+    return Plugin_Handled;
+  }
+
+  if (g_RunningPrereleaseVersion) {
+    char conVarName[64];
+    g_PrintUpdateNoticeCvar.GetName(conVarName, sizeof(conVarName));
+    Get5_MessageToAll("%t", "PrereleaseVersionWarning", PLUGIN_VERSION, conVarName);
+  } else if (g_NewerVersionAvailable) {
+    Get5_MessageToAll("%t", "NewVersionAvailable", GET5_GITHUB_PAGE);
+  }
+
   return Plugin_Handled;
 }
 

--- a/scripting/get5/version.sp
+++ b/scripting/get5/version.sp
@@ -2,3 +2,8 @@
 #if !defined PLUGIN_VERSION
 #define PLUGIN_VERSION "0.9.0-dev"
 #endif
+
+// This MUST be the latest version in x.y.z semver format followed by -dev.
+// If this is not consistently applied, the update-checker might malfunction.
+// In official releases, the CI flow will remove the -dev suffix when compiling the plugin.
+// In development pre-releases, dev is replaced with the first 6 characters of the commit hash.

--- a/translations/get5.phrases.txt
+++ b/translations/get5.phrases.txt
@@ -181,6 +181,16 @@
         "#format"       "{1:s},{2:d}"
         "en"            "Tactical pauses remaining for {1}: {2}"
     }
+    "PrereleaseVersionWarning"
+    {
+        "#format"       "{1:s},{2:s}"
+        "en"            "You are running an unofficial version of Get5 ({1}) intended for development and testing only. This message can be disabled with {2}."
+    }
+    "NewVersionAvailable"
+    {
+        "#format"       "{1:s}"
+        "en"            "A newer version of Get5 is available. Please visit {1} to update."
+    }
     "TeamFailToReadyMinPlayerCheck"
     {
         "#format"       "{1:d}"


### PR DESCRIPTION
This allows get5 to check if its version is the same one as the one on the master branch.

~~We need to do some regex stuff after the CI stuff has been merged to make this work. Currently it matches against the `PLUGIN_VERSION` 1:1 on master which would also be incorrect as it includes `-dev`.~~ Edit: I fixed this.

I tested this and it works. It also correctly doesn't load if SteamWorks is not installed.

What I don't know is if I need to `delete` the `request` handle in the callback function.

Output example would be, with `0.9.0-dev` in the `version.sp` file on master and `0.8.0` in the official version used:

`[get5.smx] A newer version of Get5 is available. You are running 0.8.0 while the latest version is 0.9.0.`