### PR TITLE
Fix suicide logic (again) + self in grenade victim

### DIFF
--- a/documentation/docs/event_schema.yml
+++ b/documentation/docs/event_schema.yml
@@ -589,6 +589,9 @@ paths:
                 event:
                   enum:
                     - player_death
+                bomb:
+                  type: boolean
+                  description: Indicates if the player died from the bomb explosion. `Bomb` in SourceMod.
                 headshot:
                   type: boolean
                   description: Indicates if the player died from a headshot. `Headshot`
@@ -619,7 +622,11 @@ paths:
                   description: Indicates if the player died from friendly fire. `FriendlyFire`
                     in SourceMod.
                 attacker:
-                  "$ref": "#/components/schemas/Get5Player"
+                  allOf:
+                    - type: object
+                      nullable: true
+                      title: Get5Player
+                    - "$ref": "#/components/schemas/Get5Player"
                 assist:
                   "$ref": "#/components/schemas/Get5AssisterObject"
       responses: { }
@@ -995,6 +1002,7 @@ components:
       description: Describes a player. `Player` in SourceMod (or `Attacker` on `Get5PlayerDeathEvent`).
     Get5Weapon:
       type: object
+      nullable: true
       properties:
         name:
           type: string
@@ -1007,7 +1015,7 @@ components:
           example: 27
           description: The weapon ID used. See https://sm.alliedmods.net/new-api/cstrike/CSWeaponID
             `Id` in SourceMod.
-      description: Describes a weapon. `Weapon` in SourceMod.
+      description: Describes a weapon. `Weapon` in SourceMod. Use `HasWeapon()` to determine if `null` on `Get5PlayerDeathEvent`.
     Get5AssisterObject:
       type: object
       nullable: true
@@ -1022,9 +1030,10 @@ components:
           type: boolean
           description: Indicates if the assist was a flash assist. `FlashAssist` in
             SourceMod.
-      description: 'Describes an assist to a kill. `null` if no assister. `Assist`
-        in SourceMod. **Note: Use `HasAssist()` in SourceMod to determine if the property
-        exists before accessing it.**'
+      description: |
+        Describes an assist to a kill. `null` if no assister. `Assist`
+        in SourceMod. Use `HasAssist()` in SourceMod to determine if the property
+        exists before accessing it.
     Get5GrenadeVictim:
       type: object
       properties:

--- a/scripting/include/get5.inc
+++ b/scripting/include/get5.inc
@@ -1196,6 +1196,16 @@ methodmap Get5PlayerWeaponEvent < Get5PlayerTimedRoundEvent {
 
 methodmap Get5PlayerDeathEvent < Get5PlayerWeaponEvent {
 
+  property bool Bomb {
+      public get() {
+        return this.GetBool("bomb");
+      }
+
+      public set(bool bomb) {
+        this.SetBool("bomb", bomb);
+      }
+  }
+
   property bool Headshot {
       public get() {
         return this.GetBool("headshot");
@@ -1291,21 +1301,30 @@ methodmap Get5PlayerDeathEvent < Get5PlayerWeaponEvent {
     return this.GetObject("assist") != null;
   }
 
+  // Use before accessing "Attacker", as its getter will raise an exception if null.
+  public bool HasAttacker() {
+    return this.GetObject("attacker") != null;
+  }
+
+  // Use before accessing "Weapon", as its getter will raise an exception if null.
+  public bool HasWeapon() {
+    return this.GetObject("weapon") != null;
+  }
+
   public Get5PlayerDeathEvent(
     const char[] matchId,
     const int mapNumber,
     const int roundNumber,
     const int roundTime,
-    const Get5Weapon weapon,
     const Get5Player victim,
     const bool headshot,
     const bool friendlyFire,
-    const Get5Player attacker,
     const bool thruSmoke,
     const bool noScope,
     const bool attackerBlind,
     const bool suicide,
-    const int penetrated
+    const int penetrated,
+    const bool bomb
     ) {
 
         Get5PlayerDeathEvent self = view_as<Get5PlayerDeathEvent>(new JSON_Object());
@@ -1314,19 +1333,20 @@ methodmap Get5PlayerDeathEvent < Get5PlayerWeaponEvent {
         self.MapNumber = mapNumber;
         self.RoundNumber = roundNumber;
         self.RoundTime = roundTime;
-        self.Weapon = weapon;
         self.Player = victim;
         self.Headshot = headshot;
         self.FriendlyFire = friendlyFire;
-        self.Attacker = attacker;
         self.ThruSmoke = thruSmoke;
         self.NoScope = noScope;
         self.AttackerBlind = attackerBlind;
         self.Suicide = suicide;
         self.Penetrated = penetrated;
+        self.Bomb = bomb;
 
-        // set assist to null initially
+        // set nullables to null initially
         self.SetObject("assist", null);
+        self.SetObject("attacker", null);
+        self.SetObject("weapon", null);
         return self;
 
     }


### PR DESCRIPTION
There were some problems with the suicide parameter still, because there are so many ways you can kill yourself.

I've narrowed it down to this and added a `bomb` parameter to the player death event to be explicit about it.

This also means that both `weapon` and `attacker` can be `null` on the `player_death` event.

I also let yourself be in the victims array of grenades, as you would expect. This still counts as friendly fire.