### PR TITLE
Better bot support + rehook SDKHooks on plugin reload

### DIFF
--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -297,6 +297,14 @@ public void OnPluginStart() {
   InitDebugLog(DEBUG_CVAR, "get5");
   LogDebug("OnPluginStart version=%s", PLUGIN_VERSION);
 
+  // Because we use SDKHooks for damage, we need to re-hook clients that are already on the server in case
+  // the plugin is reloaded. This includes bots.
+  LOOP_CLIENTS(i) {
+    if (IsValidClient(i)) {
+      Stats_HookDamageForClient(i);
+    }
+  }
+
   /** Translations **/
   LoadTranslations("get5.phrases");
   LoadTranslations("common.phrases");
@@ -632,16 +640,6 @@ public Action Timer_InfoMessages(Handle timer) {
   return Plugin_Continue;
 }
 
-public void OnEntityCreated(int entity, const char[] name) {
-  // As this function is called *a lot*, we filter to <= MAXPLAYERS to not perform too many string compare operations,
-  // which is a lot more expensive. Player/bot entities always start from 1, as their entity is their client index.
-  // It is necessary to do this, as OnClientPutInServer() cannot figure out how to reliably hook this event to bots.
-  // We also cannot filter to IsPlayer() here, as it returns false for bots at this stage.
-  if (entity > 0 && entity <= MAXPLAYERS && (StrEqual("player", name) || StrEqual("cs_bot", name))) {
-    Stats_HookDamageForClient(entity);
-  }
-}
-
 public void OnClientAuthorized(int client, const char[] auth) {
   SetClientReady(client, false);
   g_MovingClientToCoach[client] = false;
@@ -668,6 +666,7 @@ public void RememberAndKickClient(int client, const char[] format, const char[] 
 }
 
 public void OnClientPutInServer(int client) {
+  Stats_HookDamageForClient(client);
   if (IsFakeClient(client)) {
     return;
   }


### PR DESCRIPTION
This allows bots to be included in the damage report. It also works correctly if a player controls a bot.

I fixed the missing SDKHook on plugin reload, which was the cause of the issues I had with this hook not working.

Also, prevent the spam of auth failure when bots deal damage etc.

Edit: Accidentally had the wrong base. it's good now (on develop). I tested this and it works fine.