### PR TITLE
Remove Weapon nullability because of molotovs being ID 0.

### DIFF
--- a/documentation/docs/event_schema.yml
+++ b/documentation/docs/event_schema.yml
@@ -1007,7 +1007,6 @@ components:
       description: Describes a player. `Player` in SourceMod (or `Attacker` on `Get5PlayerDeathEvent`).
     Get5Weapon:
       type: object
-      nullable: true
       properties:
         name:
           type: string
@@ -1019,8 +1018,8 @@ components:
           minimum: 0
           example: 27
           description: The weapon ID used. See https://sm.alliedmods.net/new-api/cstrike/CSWeaponID
-            `Id` in SourceMod.
-      description: Describes a weapon. `Weapon` in SourceMod. Use `HasWeapon()` to determine if `null` on `Get5PlayerDeathEvent`.
+            `Id` in SourceMod. Some weapons are ID 0, such as the C4 bomb explosion or molotov/incendiary fire.
+      description: Describes a weapon. `Weapon` in SourceMod.
     Get5AssisterObject:
       type: object
       nullable: true

--- a/scripting/get5/stats.sp
+++ b/scripting/get5/stats.sp
@@ -763,16 +763,12 @@ public Action Stats_PlayerDeathEvent(Event event, const char[] name, bool dontBr
 
   Get5PlayerDeathEvent playerDeathEvent = new Get5PlayerDeathEvent(
       g_MatchID, g_MapNumber, g_RoundNumber, GetRoundTime(),
-      GetPlayerObject(victim), headshot, validAttacker ? attackerTeam == victimTeam : false,
+      GetPlayerObject(victim), new Get5Weapon(weapon, weaponId), headshot, validAttacker ? attackerTeam == victimTeam : false,
       event.GetBool("thrusmoke"), event.GetBool("noscope"), event.GetBool("attackerblind"),
       isSuicide, event.GetInt("penetrated"), killedByBomb);
 
   if (validAttacker) {
     playerDeathEvent.Attacker = GetPlayerObject(attacker);
-  }
-
-  if (view_as<int>(weaponId) > 0) {
-    playerDeathEvent.Weapon = new Get5Weapon(weapon, weaponId);
   }
 
   if (validAssister) {

--- a/scripting/include/get5.inc
+++ b/scripting/include/get5.inc
@@ -1309,17 +1309,13 @@ methodmap Get5PlayerDeathEvent < Get5PlayerWeaponEvent {
     return this.GetObject("attacker") != null;
   }
 
-  // Use before accessing "Weapon", as its getter will raise an exception if null.
-  public bool HasWeapon() {
-    return this.GetObject("weapon") != null;
-  }
-
   public Get5PlayerDeathEvent(
     const char[] matchId,
     const int mapNumber,
     const int roundNumber,
     const int roundTime,
     const Get5Player victim,
+    const Get5Weapon weapon,
     const bool headshot,
     const bool friendlyFire,
     const bool thruSmoke,
@@ -1337,6 +1333,7 @@ methodmap Get5PlayerDeathEvent < Get5PlayerWeaponEvent {
         self.RoundNumber = roundNumber;
         self.RoundTime = roundTime;
         self.Player = victim;
+        self.Weapon = weapon;
         self.Headshot = headshot;
         self.FriendlyFire = friendlyFire;
         self.ThruSmoke = thruSmoke;
@@ -1349,7 +1346,6 @@ methodmap Get5PlayerDeathEvent < Get5PlayerWeaponEvent {
         // set nullables to null initially
         self.SetObject("assist", null);
         self.SetObject("attacker", null);
-        self.SetObject("weapon", null);
         return self;
 
     }


### PR DESCRIPTION
Weapon can't be made nullable because some weapons have ID 0. Regression after adjusting suicide logic.