### PR TITLE
Fix coach game prop when reconnect or calling !stop from match.

### DIFF
--- a/scripting/get5/teamlogic.sp
+++ b/scripting/get5/teamlogic.sp
@@ -167,6 +167,8 @@ public void MoveClientToCoach(int client) {
     LogDebug("Moving %L directly to coach slot", client);
     SwitchPlayerTeam(client, CS_TEAM_SPECTATOR);
     UpdateCoachTarget(client, csTeam);
+    // Need to set to avoid third person view bug.
+    SetEntProp(client, Prop_Send, "m_iObserverMode", 4);
   } else {
     LogDebug("Moving %L indirectly to coach slot via coach cmd", client);
     g_MovingClientToCoach[client] = true;


### PR DESCRIPTION
Previously in development, if a coach left and rejoined, they would enter this third person view for a player. This game prop apparently fixes that issue, and now coaches are forced back into their first person perspective. Only needed when we're not using the default coach pass through.