### PR TITLE
Only print MoveToCoachInfoMessage if the user is a new coach

### DIFF
--- a/scripting/get5/teamlogic.sp
+++ b/scripting/get5/teamlogic.sp
@@ -94,9 +94,15 @@ public Action Command_JoinTeam(int client, const char[] command, int argc) {
       } else {
         // Only attempt to move to coach if we are not full on coaches already.
         if (GetTeamCoaches(correctTeam).Length <= g_CoachesPerTeam) {
+          char auth[AUTH_LENGTH];
           LogDebug("Forcing player %N to coach", client);
+          GetAuth(client, auth, sizeof(auth));
+          // Only output MoveToCoachInfoMessage if we are not
+          // in the coach array already.
+          if (!IsAuthOnTeamCoach(auth, correctTeam)) {
+            Get5_Message(client, "%t", "MoveToCoachInfoMessage");
+          }
           MoveClientToCoach(client);
-          Get5_Message(client, "%t", "MoveToCoachInfoMessage");
         } else {
           KickClient(client, "%t", "TeamIsFullInfoMessage");
         }


### PR DESCRIPTION
This closes #808. All we do is simply check if a user has been previously in the coaching array before placing, and store that in a boolean. After moving the player, just check the boolean and if we were not in the array previously, then inform the user that they are being placed in the coaching slots.

Tested and seems to be working as intended.