### PR TITLE
Add in checks for SVG logos

### DIFF
--- a/scripting/get5/matchconfig.sp
+++ b/scripting/get5/matchconfig.sp
@@ -1230,10 +1230,20 @@ static void AddTeamLogoToDownloadTable(const char[] logoName) {
     return;
 
   char logoPath[PLATFORM_MAX_PATH + 1];
-  Format(logoPath, sizeof(logoPath), "resource/flash/econ/tournaments/teams/%s.png", logoName);
-
-  LogDebug("Adding file %s to download table", logoName);
-  AddFileToDownloadsTable(logoPath);
+  Format(logoPath, sizeof(logoPath), "materials/panorama/images/tournaments/teams/%s.svg", logoName);
+  if (FileExists(logoPath)) {
+    LogDebug("Adding file %s to download table", logoName);
+    AddFileToDownloadsTable(logoPath);
+  } else {
+    Format(logoPath, sizeof(logoPath), "resource/flash/econ/tournaments/teams/%s.png", logoName);
+    if (FileExists(logoPath)) {
+      LogDebug("Adding file %s to download table", logoName);
+      AddFileToDownloadsTable(logoPath);
+    } else {
+      LogError("Error in locating file %s. Please ensure the file exists on your game server.", logoPath);
+    }
+  }
+  
 }
 
 public void CheckTeamNameStatus(Get5Team team) {


### PR DESCRIPTION
Currently the `AddTeamLogoToDownloadTable` does not work as intended since the Panorama update. Currently, it only checks for PNG files located in one specific directory (which was used for ScaleForm UI), and will only show in a few places. The new SVG format has more usage in game, so we need to check if we're using an SVG instead.

This closes #807 