### PR TITLE
Live Coach Fix

### DIFF
--- a/scripting/get5/teamlogic.sp
+++ b/scripting/get5/teamlogic.sp
@@ -162,18 +162,19 @@ public void MoveClientToCoach(int client) {
   // If we're in warmup we use the in-game
   // coaching command. Otherwise we manually move them to spec
   // and set the coaching target.
-  // If in freeze time, we have to manually move as well.
-  if (!InWarmup() && InFreezeTime()) {
+  // If in freeze time, or any other state like a live round,
+  // we have to manually move as well.
+  if (InWarmup()) {
+    LogDebug("Moving %L indirectly to coach slot via coach cmd", client);
+    g_MovingClientToCoach[client] = true;
+    FakeClientCommand(client, "coach %s", teamString);
+    g_MovingClientToCoach[client] = false;
+  } else {
     LogDebug("Moving %L directly to coach slot", client);
     SwitchPlayerTeam(client, CS_TEAM_SPECTATOR);
     UpdateCoachTarget(client, csTeam);
     // Need to set to avoid third person view bug.
     SetEntProp(client, Prop_Send, "m_iObserverMode", 4);
-  } else {
-    LogDebug("Moving %L indirectly to coach slot via coach cmd", client);
-    g_MovingClientToCoach[client] = true;
-    FakeClientCommand(client, "coach %s", teamString);
-    g_MovingClientToCoach[client] = false;
   }
 }
 


### PR DESCRIPTION
Swap coaching logic to use in-game coaching feature only in warmup (as provided by valve), since that is what the error message provides.

This update now moves coaches in all cases, since when a player joins and if they exist in the coach array, we will move them to the coach slot no matter the case.

Backups are also working as intended, where the coach is moved back into the slot with no changes to money.

Attempting to join during a live scrim, a user must call .coach if get5_check_auths is 0, but the player will still reliably be placed on the coach slot, with the proper camera.

Putting this one in draft as I would like to test a few more things before having it marked as ready.

Closes #811 