### PR TITLE
Add in bug label for bug fixes on release note generation.

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -9,6 +9,9 @@ changelog:
     - title: Exciting New Features 🎉
       labels:
         - enhancement
+    - title: Bug Fixes 🐞
+      labels:
+        - "bug"
     - title: Other Changes
       labels:
         - "*"


### PR DESCRIPTION
During the generate release this will add in a new section called "Bug Fixes" where any PR marked with "bug" will appear in that section. Figured it's easier than having those fall under "Other" fixes.