### PR TITLE
Init stats to zero

### DIFF
--- a/documentation/docs/commands.md
+++ b/documentation/docs/commands.md
@@ -228,7 +228,8 @@ to [`!ringer`](../commands/#ringer)
 :   Dumps debug info to a file (`addons/sourcemod/logs/get5_debuginfo.txt` if no file parameter is provided).
 
 ####`get5_dumpstats [file]` {: #get5_dumpstats }
-:   Dumps [player stats](../stats_system) to a file (`addons/sourcemod/get5_matchstats.cfg` if no file parameter is provided).
+:   Dumps [player stats](../stats_system/#keyvalue) to a file (`addons/sourcemod/get5_matchstats.cfg` if no file
+parameter is provided).
 
 ####`get5_test`
 :   Runs get5 tests. **This should not be used on a live match server since it will reload a match config to test**.

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -1460,6 +1460,12 @@ public Action Event_RoundEnd(Event event, const char[] name, bool dontBroadcast)
 
     Stats_RoundEnd(csTeamWinner);
 
+    if (g_DamagePrintCvar.BoolValue) {
+      LOOP_CLIENTS(i) {
+        PrintDamageInfo(i); // Checks valid client etc. on its own.
+      }
+    }
+
     Get5RoundStatsUpdatedEvent statsEvent =
         new Get5RoundStatsUpdatedEvent(g_MatchID, g_MapNumber, g_RoundNumber);
 

--- a/scripting/get5/util.sp
+++ b/scripting/get5/util.sp
@@ -16,7 +16,7 @@ static char _colorCodes[][] = {"\x01", "\x02", "\x03", "\x04", "\x05", "\x06",
 
 // Convenience macros.
 #define LOOP_TEAMS(%1) for (Get5Team %1 = Get5Team_1; %1 < Get5Team_Count; %1 ++)
-#define LOOP_CLIENTS(%1) for (int %1 = 0; %1 <= MaxClients; %1 ++)
+#define LOOP_CLIENTS(%1) for (int %1 = 1; %1 <= MaxClients; %1 ++)
 
 // These match CS:GO's m_gamePhase values.
 enum GamePhase {
@@ -31,7 +31,7 @@ enum GamePhase {
  */
 stock int GetNumHumansOnTeam(int team) {
   int count = 0;
-  for (int i = 1; i <= MaxClients; i++) {
+  LOOP_CLIENTS(i) {
     if (IsPlayer(i) && GetClientTeam(i) == team) {
       count++;
     }
@@ -41,7 +41,7 @@ stock int GetNumHumansOnTeam(int team) {
 
 stock int CountAlivePlayersOnTeam(int csTeam) {
   int count = 0;
-  for (int i = 1; i <= MaxClients; i++) {
+  LOOP_CLIENTS(i) {
     if (IsPlayer(i) && IsPlayerAlive(i) && GetClientTeam(i) == csTeam) {
       count++;
     }
@@ -51,7 +51,7 @@ stock int CountAlivePlayersOnTeam(int csTeam) {
 
 stock int SumHealthOfTeam(int team) {
   int sum = 0;
-  for (int i = 1; i <= MaxClients; i++) {
+  LOOP_CLIENTS(i) {
     if (IsPlayer(i) && IsPlayerAlive(i) && GetClientTeam(i) == team) {
       sum += GetClientHealth(i);
     }
@@ -560,7 +560,7 @@ stock bool GetAuth(int client, char[] auth, int size) {
 // TODO: might want a auth->client adt-trie to speed this up, maintained during
 // client auth and disconnect forwards.
 stock int AuthToClient(const char[] auth) {
-  for (int i = 1; i <= MaxClients; i++) {
+  LOOP_CLIENTS(i) {
     if (IsAuthedPlayer(i)) {
       char clientAuth[AUTH_LENGTH];
       if (GetAuth(i, clientAuth, sizeof(clientAuth)) && StrEqual(auth, clientAuth)) {

--- a/scripting/get5_apistats.sp
+++ b/scripting/get5_apistats.sp
@@ -300,7 +300,7 @@ public void UpdatePlayerStats(const char[] matchId, KeyValues kv, Get5Team team)
                                  mapNumber, auth);
       if (req != INVALID_HANDLE) {
         AddStringParam(req, "team", teamString);
-        AddStringParam(req, "name", name);
+        AddStringParam(req, STAT_NAME, name);
         AddIntStat(req, kv, STAT_KILLS);
         AddIntStat(req, kv, STAT_DEATHS);
         AddIntStat(req, kv, STAT_ASSISTS);
@@ -308,6 +308,10 @@ public void UpdatePlayerStats(const char[] matchId, KeyValues kv, Get5Team team)
         AddIntStat(req, kv, STAT_TEAMKILLS);
         AddIntStat(req, kv, STAT_SUICIDES);
         AddIntStat(req, kv, STAT_DAMAGE);
+        AddIntStat(req, kv, STAT_UTILITY_DAMAGE);
+        AddIntStat(req, kv, STAT_ENEMIES_FLASHED);
+        AddIntStat(req, kv, STAT_FRIENDLIES_FLASHED);
+        AddIntStat(req, kv, STAT_KNIFE_KILLS);
         AddIntStat(req, kv, STAT_HEADSHOT_KILLS);
         AddIntStat(req, kv, STAT_ROUNDSPLAYED);
         AddIntStat(req, kv, STAT_BOMBPLANTS);
@@ -329,6 +333,7 @@ public void UpdatePlayerStats(const char[] matchId, KeyValues kv, Get5Team team)
         AddIntStat(req, kv, STAT_TRADEKILL);
         AddIntStat(req, kv, STAT_KAST);
         AddIntStat(req, kv, STAT_CONTRIBUTION_SCORE);
+        AddIntStat(req, kv, STAT_MVP);
         SteamWorks_SendHTTPRequest(req);
       }
 

--- a/scripting/include/get5.inc
+++ b/scripting/include/get5.inc
@@ -1798,6 +1798,8 @@ forward void Get5_OnBackupRestore(const Get5BackupRestoredEvent event);
 #define STAT_TEAMSCORE "score"
 
 // Player stats (under map section, then team section, then player's steam64)
+// If adding stuff here, also add to the InitPlayerStats function!
+#define STAT_INIT "init" // used to zero-fill stats only. Not a real stat.
 #define STAT_NAME "name"
 #define STAT_KILLS "kills"
 #define STAT_DEATHS "deaths"


### PR DESCRIPTION
Replacement for https://github.com/splewis/get5/pull/794 as that was in forked repo, making rebasing annoying.

Something like this should fix https://github.com/splewis/get5/issues/654.

Main points:

We now init all stats to zero at the beginning of each round for all players this has not happened for yet. This allows ringers etc. to come in as replacements and still have a proper stats file.

Used the LOOP_CLIENTS in more places.