### PR TITLE
Move Match Cvars above series init 

### DIFF
--- a/scripting/get5/matchconfig.sp
+++ b/scripting/get5/matchconfig.sp
@@ -116,6 +116,13 @@ stock bool LoadMatchConfig(const char[] config, bool restoreBackup = false) {
     ChangeState(Get5State_PreVeto);
   }
 
+
+  // We need to ensure our match team CVARs are set
+  // before calling the event so we can grab values
+  // that are set in the OnSeriesInit event.
+  // Add to download table after setting.
+  SetMatchTeamCvars();
+
   if (!restoreBackup) {
     SetStartingTeams();
     ExecCfg(g_WarmupCfgCvar);
@@ -152,7 +159,6 @@ stock bool LoadMatchConfig(const char[] config, bool restoreBackup = false) {
   }
 
   AddTeamLogosToDownloadTable();
-  SetMatchTeamCvars();
   ExecuteMatchConfigCvars();
   LoadPlayerNames();
   strcopy(g_LoadedConfigFile, sizeof(g_LoadedConfigFile), config);


### PR DESCRIPTION
This should allow certain vars to be set before the event is called, where users can then take advantage of having the logos set properly or have them be downloaded to the server.

Just looking through the code, I think this may be inconsequential for match loading, but I think more extensive testing needs to be done.

Closes #161 #535 