### PR TITLE
Only extend mp_match_restart_delay if required - never shorten it

### DIFF
--- a/scripting/get5/goinglive.sp
+++ b/scripting/get5/goinglive.sp
@@ -77,7 +77,12 @@ public Action MatchLive(Handle timer) {
 }
 
 public void SetMatchRestartDelay() {
+  // This ensures that the mp_match_restart_delay is not shorter than what
+  // is required for the GOTV recording to finish.
   ConVar mp_match_restart_delay = FindConVar("mp_match_restart_delay");
-  int delay = GetTvDelay() + MATCH_END_DELAY_AFTER_TV + 5;
-  SetConVarInt(mp_match_restart_delay, delay);
+  int requiredDelay = GetTvDelay() + MATCH_END_DELAY_AFTER_TV + 5;
+  if (requiredDelay > mp_match_restart_delay.IntValue) {
+    LogDebug("Extended mp_match_restart_delay from %d to %d to ensure GOTV can finish recording.", mp_match_restart_delay.IntValue, requiredDelay);
+    mp_match_restart_delay.IntValue = requiredDelay;
+  }
 }


### PR DESCRIPTION
The fact that I cannot set a longer `mp_match_restart_delay` for a bo1 is a little annoying, as the servers I run are containerized and shut down after the series ends, so they should just hang around on the "match has ended" screen practically forever when the match ends, just like FaceIT does. This change makes that possible and only ensure that the restart delay is not too short; it does not shorten it if not required. 

This would also allow a tournament admin to set a 5-10 minute break between maps, or whatever they want. Edit: This requires some more changes to the `Timer_NextMatchMap` logic, which requires https://github.com/splewis/get5/pull/821 to be merged first.