### PR TITLE
Clean up Native_Message logic to reduce code repetition

### DIFF
--- a/scripting/get5/natives.sp
+++ b/scripting/get5/natives.sp
@@ -31,86 +31,60 @@ public int Native_GetGameState(Handle plugin, int numParams) {
 
 public int Native_Message(Handle plugin, int numParams) {
   int client = GetNativeCell(1);
-  if (client != 0 && (!IsClientConnected(client) || !IsClientInGame(client)))
-    return;
-
   char buffer[1024];
-  int bytesWritten = 0;
-  SetGlobalTransTarget(client);
-  FormatNativeString(0, 2, 3, sizeof(buffer), bytesWritten, buffer);
-
-  char prefix[64];
-  g_MessagePrefixCvar.GetString(prefix, sizeof(prefix));
-
-  char finalMsg[1024];
-  if (StrEqual(prefix, ""))
-    Format(finalMsg, sizeof(finalMsg), " %s", buffer);
-  else
-    Format(finalMsg, sizeof(finalMsg), "%s %s", prefix, buffer);
-
-  if (client == 0) {
-    Colorize(finalMsg, sizeof(finalMsg), false);
-    PrintToConsole(client, finalMsg);
-  } else if (IsClientInGame(client)) {
-    Colorize(finalMsg, sizeof(finalMsg));
-    PrintToChat(client, finalMsg);
-  }
+  FormatNativeString(0, 2, 3, sizeof(buffer), _, buffer);
+  PrintMessage(buffer, Get5Team_None, client);
 }
 
 public int Native_MessageToTeam(Handle plugin, int numParams) {
   Get5Team team = view_as<Get5Team>(GetNativeCell(1));
-  char prefix[64];
-  g_MessagePrefixCvar.GetString(prefix, sizeof(prefix));
-
   char buffer[1024];
-  int bytesWritten = 0;
-
-  LOOP_CLIENTS(i) {
-    if (!IsPlayer(i) || GetClientMatchTeam(i) != team) {
-      continue;
-    }
-
-    SetGlobalTransTarget(i);
-    FormatNativeString(0, 2, 3, sizeof(buffer), bytesWritten, buffer);
-
-    char finalMsg[1024];
-    if (StrEqual(prefix, ""))
-      Format(finalMsg, sizeof(finalMsg), " %s", buffer);
-    else
-      Format(finalMsg, sizeof(finalMsg), "%s %s", prefix, buffer);
-
-    Colorize(finalMsg, sizeof(finalMsg));
-    PrintToChat(i, finalMsg);
-  }
+  FormatNativeString(0, 2, 3, sizeof(buffer), _, buffer);
+  PrintMessage(buffer, team, 0);
 }
 
 public int Native_MessageToAll(Handle plugin, int numParams) {
+  char buffer[1024];
+  FormatNativeString(0, 1, 2, sizeof(buffer), _, buffer);
+  PrintMessage(buffer, Get5Team_None, 0);
+}
+
+static void PrintMessage(const char[] message, const Get5Team onlyForTeam, const int onlyForClient) {
   char prefix[64];
   g_MessagePrefixCvar.GetString(prefix, sizeof(prefix));
-  char buffer[1024];
-  int bytesWritten = 0;
+  char prefixedMsg[1024];
+  if (StrEqual(prefix, "")) {
+    Format(prefixedMsg, sizeof(prefixedMsg), " %s", message);
+  } else {
+    Format(prefixedMsg, sizeof(prefixedMsg), "%s %s", prefix, message);
+  }
 
-  // Don't use LOOP_CLIENTS(i) because we need client 0 here.
-  for (int i = 0; i <= MaxClients; i++) {
-    if (i != 0 && (!IsClientConnected(i) || !IsClientInGame(i))) {
+  if (onlyForClient == 0) {
+    // Copy the string and strip color tags for console output, if the message is not only for one client.
+    char consoleMessage[1024];
+    strcopy(consoleMessage, sizeof(consoleMessage), prefixedMsg);
+    Colorize(consoleMessage, sizeof(consoleMessage), true);
+    PrintToConsole(0, consoleMessage);
+  }
+
+  // Replace color tags with colors for client output
+  Colorize(prefixedMsg, sizeof(prefixedMsg), false);
+
+  if (onlyForClient > 0) {
+    if (IsClientConnected(onlyForClient) && IsClientInGame(onlyForClient)) {
+      SetGlobalTransTarget(onlyForClient);
+      PrintToChat(onlyForClient, prefixedMsg);
+    }
+    return;
+  }
+
+  LOOP_CLIENTS(i) {
+    if (!IsClientConnected(i) || !IsClientInGame(i)) {
       continue;
     }
-
-    SetGlobalTransTarget(i);
-    FormatNativeString(0, 1, 2, sizeof(buffer), bytesWritten, buffer);
-
-    char finalMsg[1024];
-    if (StrEqual(prefix, ""))
-      Format(finalMsg, sizeof(finalMsg), " %s", buffer);
-    else
-      Format(finalMsg, sizeof(finalMsg), "%s %s", prefix, buffer);
-
-    if (i != 0) {
-      Colorize(finalMsg, sizeof(finalMsg));
-      PrintToChat(i, finalMsg);
-    } else {
-      Colorize(finalMsg, sizeof(finalMsg), false);
-      PrintToConsole(i, finalMsg);
+    if (onlyForTeam == Get5Team_None || GetClientMatchTeam(i) == onlyForTeam) {
+      SetGlobalTransTarget(i);
+      PrintToChat(i, prefixedMsg);
     }
   }
 }


### PR DESCRIPTION
This takes the three different `Native_MessageToXX` functions and reduces them down to one, also cutting down a lot on calls for `Format`. No changes in functionality; just less repetition and string copy code, which can grow exponentially when the MessageToAll is used in a loop.