### PR TITLE
Unpause on match end

### DIFF
--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -1135,6 +1135,11 @@ public Action Timer_ReplenishMoney(Handle timer, int client) {
 public Action Event_MatchOver(Event event, const char[] name, bool dontBroadcast) {
   LogDebug("Event_MatchOver");
   if (g_GameState == Get5State_Live) {
+
+    // If someone called for a pause in the last round; cancel it.
+    if (IsPaused()) {
+      UnpauseGame(Get5Team_None);
+    }
     // Figure out who won
     int t1score = CS_GetTeamScore(Get5TeamToCSTeam(Get5Team_1));
     int t2score = CS_GetTeamScore(Get5TeamToCSTeam(Get5Team_2));


### PR DESCRIPTION
If a pause has been called after freezetime on the last round and there is no mapchange to reset the pause state the following round, get5 will leave the server in a paused state after ending the match. This fixes that.