### PR TITLE
Set scrim matchid back to "scrim"

### DIFF
--- a/documentation/docs/commands.md
+++ b/documentation/docs/commands.md
@@ -97,7 +97,7 @@ You should put the `url` argument inside quotation marks (`""`).
 ####`get5_endmatch`
 :   Force ends the current match. No winner is set (draw).
 
-####`get5_creatematch [map name] [matchid]`
+####`get5_creatematch [map name] [matchid]` {: #get5_creatematch }
 :   Creates a BO1 match with the current players on the server. `map name` defaults to the current map and `matchid`
     defaults to `manual`. You should **not** provide a match ID if you use the [MySQL extension](../stats_system/#mysql).
 

--- a/documentation/docs/stats_system.md
+++ b/documentation/docs/stats_system.md
@@ -71,8 +71,9 @@ functionality, but can also be used as-is.
 !!! danger "Fixed Match IDs"
 
     If you use the MySQL extension, you should **not** set the `matchid` in your
-    [match configuration](../match_schema/#schema) (just leave it empty) or when creating scrims using the
-    [`get5_scrim`](../commands/#get5_scrim) command. The match ID will be set to the
+    [match configuration](../match_schema/#schema) (just leave it empty) or when creating scrims or matches using the
+    [`get5_scrim`](../commands/#get5_scrim) or [`get5_creatematch`](../commands/#get5_creatematch) commands. The match
+    ID will be set to the
     [auto-incrementing integer](https://dev.mysql.com/doc/refman/8.0/en/example-auto-increment.html) (cast to a string)
     returned by inserting into the `get5_stats_matches` table.
 

--- a/scripting/get5/matchconfig.sp
+++ b/scripting/get5/matchconfig.sp
@@ -1081,7 +1081,7 @@ public Action Command_CreateScrim(int client, int args) {
     return Plugin_Handled;
   }
 
-  char matchid[MATCH_ID_LENGTH] = "";
+  char matchid[MATCH_ID_LENGTH] = "scrim";
   char matchMap[PLATFORM_MAX_PATH];
   GetCleanMapName(matchMap, sizeof(matchMap));
   char otherTeamName[MAX_CVAR_LENGTH] = "Away";


### PR DESCRIPTION
This was fixed in mysql extension instead and was not supposed to have been changed to an empty string.