### PR TITLE
Don't allow !ready command when map change is pending

### DIFF
--- a/scripting/get5/matchconfig.sp
+++ b/scripting/get5/matchconfig.sp
@@ -38,7 +38,7 @@ stock bool LoadMatchConfig(const char[] config, bool restoreBackup = false) {
 
   g_ReadyTimeWaitingUsed = 0;
   g_HasKnifeRoundStarted = false;
-
+  g_MapChangePending = false;
   g_MapNumber = 0;
   g_RoundNumber = -1;
   g_LastVetoTeam = Get5Team_2;

--- a/scripting/get5/readysystem.sp
+++ b/scripting/get5/readysystem.sp
@@ -8,7 +8,7 @@ public void ResetReadyStatus() {
 }
 
 public bool IsReadyGameState() {
-  return g_GameState == Get5State_PreVeto || g_GameState == Get5State_Warmup;
+  return (g_GameState == Get5State_PreVeto || g_GameState == Get5State_Warmup) && !g_MapChangePending;
 }
 
 // Client ready status


### PR DESCRIPTION
This prevents players from readying up after the veto has finished but before the map changes. Their ready state is reset on map start anyway, so this just adds a potential for bugs.