### PR TITLE
Fix knife fun fact reason

### DIFF
--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -1567,8 +1567,27 @@ public Action Event_RoundWinPanel(Event event, const char[] name, bool dontBroad
     }
 
     // This ensures that the correct graphic is displayed in-game for the winning team, as CTs will always win if the
-    // clock runs out. It also ensures that the reason displayed is correct, i.e. just "win" and no "won because clock
+    // clock runs out. It also ensures that the fun fact displayed is correct; overriding to number of players killed
+    // by knife and no "CT won by running down the clock". MVP can still be on the losing team though.
     // ran down".
+    int maxFrags = 0;
+    int topFragClient = 0;
+    int frags;
+    LOOP_CLIENTS(i) {
+      if (IsValidClient(i)) {
+        frags = GetClientFrags(i);
+        if (frags >= maxFrags) {
+          maxFrags = frags;
+          topFragClient = i;
+        }
+      }
+    }
+    if (topFragClient > 0) {
+      // Found here: https://github.com/SteamDatabase/GameTracking-CSGO/blob/master/csgo/bin/server_client_strings.txt
+      event.SetString("funfact_token", "#funfact_knife_kills");
+      event.SetInt("funfact_player", topFragClient);
+      event.SetInt("funfact_data1", maxFrags);
+    }
     event.SetInt("final_event", ConvertCSTeamToDefaultWinReason(winningCSTeam));
   }
   return Plugin_Continue;


### PR DESCRIPTION
This makes sure that no "fun fact" is displayed on the graphic for the wrong team in the knife round. Without this, you could have Ts win and "Counter Terrorists won by running down the clock" in the same graphic, which makes no sense. This fixes the fun fact to number of knife kills, which always makes sense. Tested, also with bots.