### PR TITLE
Fix a bunch of problems with GOTV delays

### DIFF
--- a/cfg/get5/live.cfg
+++ b/cfg/get5/live.cfg
@@ -55,6 +55,4 @@ sv_holiday_mode 0
 sv_talk_enemy_dead 0
 sv_talk_enemy_living 0
 sv_voiceenable 1
-tv_delay 105
-tv_delaymapchange 1
 tv_relayvoice 0

--- a/cfg/get5/warmup.cfg
+++ b/cfg/get5/warmup.cfg
@@ -27,8 +27,5 @@ sv_hibernate_when_empty 0
 sv_infinite_ammo 0
 sv_showimpacts 0
 sv_voiceenable 1
-tv_delay 105
-tv_delaymapchange 1
 tv_relayvoice 0
-
 sv_cheats 0

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -49,7 +49,8 @@ cfg/get5/live.cfg # (3)
 :   Whether the [`!stop`](../commands/#stop) command is enabled. **`Default: 1`**
 
 ####`get5_kick_when_no_match_loaded`
-:   Whether to kick all clients if no match is loaded. **`Default: 0`**
+:   Whether to kick all clients if no match is loaded. Players will not be kicked if a match is forcefully ended
+using [`get5_endmatch`](../commands/#get5_endmatch).  **`Default: 0`**
 
 ####`get5_end_match_on_empty_server`
 :   Whether the match is ended with no winner if all players leave (note: this will happen even if all players
@@ -188,7 +189,9 @@ must confirm. **`Default: 0`**
 doing! Avoid using spaces or colons.** **`Default: %Y-%m-%d_%H`**
 
 ####`get5_demo_name_format`
-:   Format to name demo files. Set to empty string to disable. **`Default: {MATCHID}_map{MAPNUMBER}_{MAPNAME}`**
+:   Format to use for demo files when [recording matches](gotv.md). Do not include a file extension (`.dem` is added
+automatically). Set to empty string to disable.<br>Note that the [`{MAPNUMBER}`](#tag-mapnumber) variable is not
+zero-indexed!<br>**`Default: {MATCHID}_map{MAPNUMBER}_{MAPNAME}`**
 
 ####`get5_event_log_format`
 :   Format to write event logs to. Set to empty string to disable. **`Default: ""`**

--- a/documentation/docs/gotv.md
+++ b/documentation/docs/gotv.md
@@ -1,0 +1,22 @@
+# :material-filmstrip: GOTV & Demos {: #gotv }
+
+Get5 can be configured to automatically record matches. This is enabled by default based on the state
+of [`get5_demo_name_format`](../configuration/#get5_demo_name_format) and can be disabled by setting that parameter to
+an empty string.
+
+!!! warning "Don't mess too much with the delay!"
+
+    Changing the `tv_delay` or `tv_enable` in `warmup.cfg`, `live.cfg` etc. is going to cause problems with your demos.
+    We recommend you set this variable either on your server in general or only once in the `cvar` section of your
+    [match configuration](../match_schema). You should also not set `tv_delaymapchange` as Get5 handles this
+    automatically.
+
+Demo recording starts once all teams have readied up and ends shortly following a map result. When a demo file is
+written to disk, the [`Get5_OnDemoFinished`](events_and_forwards.md) forward is called, which you can use to move the
+file or upload it somewhere. The filename can also be found in the map-section of the
+[KeyValue stats system](../stats_system/#keyvalue).
+
+Get5 will automatically adjust the [`mp_match_restart_delay`](https://totalcsgo.com/command/mpmatchrestartdelay) when a
+map ends if GOTV is enabled to assure that it won't be shorter than what is required for the GOTV broadcast to finish.
+Players will also not be [kicked from the server](../configuration/#get5_kick_when_no_match_loaded) before this delay
+has passed.

--- a/documentation/docs/stats_system.md
+++ b/documentation/docs/stats_system.md
@@ -39,6 +39,7 @@ Partial Example:
 	"map0"
 	{
 		"mapname"		"de_mirage"
+		"demo_filename" "304_map1_de_mirage.dem"
 		"winner"		"team1"
 		"team1"
 		{

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -29,10 +29,11 @@ nav:
       - Configuration: configuration.md
   - Basics:
       - Getting Started: getting_started.md
+      - Match Schema: match_schema.md
       - Commands: commands.md
       - Pausing: pausing.md
       - Backup System: backup.md
-      - Match Schema: match_schema.md
+      - GOTV & Demos: gotv.md
   - Advanced:
       - Developer API: developer_api.md
       - Events & Forwards: events_and_forwards.md

--- a/scripting/get5/mapveto.sp
+++ b/scripting/get5/mapveto.sp
@@ -62,14 +62,16 @@ public void VetoFinished() {
     Get5_MessageToAll("%t", "MapIsInfoMessage", i + 1 - seriesScore, map);
   }
 
+  float delay = 10.0;
   g_MapChangePending = true;
   if (!g_SkipVeto && g_DisplayGotvVetoCvar.BoolValue) {
-    float minDelay = float(GetTvDelay()) + MATCH_END_DELAY_AFTER_TV;
-    StopRecording(); // stops recording after GetTvDelay() seconds.
-    CreateTimer(minDelay, Timer_NextMatchMap);
+    // Players must wait for GOTV to end before we can change map, but we don't need to record that.
+    CreateTimer(float(GetTvDelay()) + delay, Timer_NextMatchMap);
   } else {
-    CreateTimer(10.0, Timer_NextMatchMap);
+    CreateTimer(delay, Timer_NextMatchMap);
   }
+  // Always end recording here; ensures that we can successfully start one after veto.
+  StopRecording(delay);
 }
 
 // Main Veto Controller

--- a/scripting/get5/util.sp
+++ b/scripting/get5/util.sp
@@ -731,22 +731,6 @@ stock SideChoice SideTypeFromString(const char[] input) {
   }
 }
 
-typedef VoidFunction = function void();
-
-stock void DelayFunction(float delay, VoidFunction f) {
-  DataPack p = CreateDataPack();
-  p.WriteFunction(f);
-  CreateTimer(delay, _DelayFunctionCallback, p);
-}
-
-public Action _DelayFunctionCallback(Handle timer, DataPack data) {
-  data.Reset();
-  Function func = data.ReadFunction();
-  Call_StartFunction(INVALID_HANDLE, func);
-  Call_Finish();
-  delete data;
-}
-
 // Deletes a file if it exists. Returns true if the
 // file existed AND there was an error deleting it.
 public bool DeleteFileIfExists(const char[] path) {


### PR DESCRIPTION
So it turns out that the GOTV-related stuff I made in https://github.com/splewis/get5/pull/821 caused some problems, as I had slightly misunderstood how the GOTV delay affected recording of demos. This PR fixes all that, and I've tested it **a lot**.

I've taken `tv_delay` parameters out of the sample config files and discouraged people from putting `tv_` in their warmup/live, as changing the delay while changing game states messes with the demos. I took out `tv_delaymapchange` as well, as Get5 automatically makes this adjustment when a map ends. `tv_`-commands should be added to the server permanently (by some other config) or set in the match config `cvar` section, so they don't vary between stages.

Added a separate section on GOTV to the docs also.

This also fixes some race-condition related stuff in the `Get5_OnDemoFinished` event if quickly ending/starting matches, using `DataPack`s