### PR TITLE
Doc updates explaining disabling practice mode

### DIFF
--- a/configs/get5/example_match.cfg
+++ b/configs/get5/example_match.cfg
@@ -81,5 +81,6 @@
 	"cvars"
 	{
 		"hostname"		"Match server #1"
+		"sm_practicemode_can_be_started" "0" // Disallow enabling practice mode when a match is loaded.
 	}
 }

--- a/configs/get5/example_match.json
+++ b/configs/get5/example_match.json
@@ -63,6 +63,7 @@
 	},
 
 	"cvars": {
-		"hostname": "Match server #1"
+		"hostname": "Match server #1",
+		"sm_practicemode_can_be_started": "0"
 	}
 }

--- a/configs/get5/scrim_template.cfg
+++ b/configs/get5/scrim_template.cfg
@@ -36,5 +36,6 @@
 		"get5_demo_name_format"		"scrim_{TIME}_{MAPNAME}" // Set to "" to disable recording
 		"get5_kick_when_no_match_loaded"		"0"
 		"get5_print_damage"		"1" // Enabling will print damage on round-end.
+		"sm_practicemode_can_be_started" "0" // Disallow enabling practice mode when a match is loaded.
 	}
 }

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -235,9 +235,8 @@ the [`{MATCHID}`](#tag-matchid) variable, i.e. `backups/{MATCHID}/`. **`Default:
 :   Config file executed when the game goes live. **`Default: get5/live.cfg`**
 
 ####`get5_autoload_config`
-:   A config file to autoload on map starts if no match is loaded, relative to the `csgo` directory. Set to empty
-string
-to disable. **`Default: ""`**
+:  A [match configuration](../match_schema/#schema) file, relative to the `csgo` directory, to autoload when a player joins the server 
+if no match is loaded. Set to empty string to disable. **`Default: ""`**
 
 ####`get5_warmup_cfg`
 :   Config file executed in warmup periods. **`Default: get5/warmup.cfg`**

--- a/documentation/docs/getting_started.md
+++ b/documentation/docs/getting_started.md
@@ -53,7 +53,8 @@ Once you've done this, all that has to happen is teams to [ready up](../commands
 !!! danger "Practice Mode"
 
     If you have [practicemode](https://github.com/splewis/csgo-practice-mode) on your server as well, you may wish to
-    add `sm_practicemode_can_be_started 0` in your [live configuration](../configuration/#phase-configuration-files).
+    add `sm_practicemode_can_be_started 0` in the `cvars` section of your [match configuration](../match_schema/#schema).
+    This will remove the ability to start practice mode until the match is completed or cancelled.
 
 ### Changing Scrim Settings
 

--- a/documentation/docs/gotv.md
+++ b/documentation/docs/gotv.md
@@ -17,6 +17,6 @@ file or upload it somewhere. The filename can also be found in the map-section o
 [KeyValue stats system](../stats_system/#keyvalue).
 
 Get5 will automatically adjust the [`mp_match_restart_delay`](https://totalcsgo.com/command/mpmatchrestartdelay) when a
-map ends if GOTV is enabled to assure that it won't be shorter than what is required for the GOTV broadcast to finish.
+map ends if GOTV is enabled to ensure that it won't be shorter than what is required for the GOTV broadcast to finish.
 Players will also not be [kicked from the server](../configuration/#get5_kick_when_no_match_loaded) before this delay
 has passed.

--- a/documentation/docs/match_schema.md
+++ b/documentation/docs/match_schema.md
@@ -193,7 +193,8 @@ const match_schema: Match = {
         "hostname": "Get5 Match #3123",
         "mp_friendly_fire": "0",
         "get5_end_match_on_empty_server": "0",
-        "get5_stop_command_enabled": "0"
+        "get5_stop_command_enabled": "0",
+        "sm_practicemode_can_be_started": "0"
     }
 }
 


### PR DESCRIPTION
This PR mainly is to update the templates and some minor doc changes. This will close #553 as we are now giving a default way to ensure practice mode cannot be started while a game is live, and give proper warning and knowledge on how to accomplish this through the docs. Here is what was done:

- Update templates to reflect changes.
- Update autoload description.
- Typo fixes in docs, suggested by @nickdnk 