### PR TITLE
Add Support For Demo Uploads via HTTP & Demo Folder W/ Date Stamps

### DIFF
--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -250,19 +250,15 @@ the [`{MATCHID}`](#tag-matchid) variable, i.e. `backups/{MATCHID}/`.<br>**`Defau
 ####`get5_time_format`
 :   Date and time format string. This determines the [`{TIME}`](#tag-time) tag.<br>**`Default: "%Y-%m-%d_%H-%M-%S"`**
 
+####`get5_date_format`
+:   Date format string. This determines the [`{DATE}`](#tag-date) tag.<br>**`Default: "%Y-%m-%d"`**
+
 !!! danger "Advanced users only"
 
     Do not change the time format unless you know what you are doing. Please always include a component of hours,
     minutes and seconds so that [demo files](#get5_demo_name_format) will not be overwritten. You can find the reference
     for formatting a time string [here](https://cplusplus.com/reference/ctime/strftime/). The default example above
     prints time in this format: `2022-06-12_13-15-45`.
-
-####`get5_demo_name_format`
-:   Format to use for demo files when [recording matches](gotv.md). Do not include a file extension (`.dem` is added
-automatically). If you do not include the [`{TIME}`](#tag-time) tag, you will have
-problems with duplicate files if restoring a game from a backup. Note that the [`{MAPNUMBER}`](#tag-mapnumber)
-variable is not zero-indexed. Set to empty string to disable recording
-demos.<br>**`Default: "{TIME}_{MATCHID}_map{MAPNUMBER}_{MAPNAME}"`**
 
 ####`get5_event_log_format`
 :   Format to write event logs to. Set to empty string to disable writing event logs.<br>**`Default: ""`**
@@ -315,6 +311,41 @@ if [`get5_print_damage`](#get5_print_damage) is disabled.<br>
 ####`get5_knife_cfg`
 :   Config file executed for the knife round, relative to `csgo/cfg`.<br>**`Default: "get5/knife.cfg"`**
 
+## Demos
+
+####`get5_demo_upload_url`
+:   If defined, it is the URL at which a server resides to accept connections to upload demos. Requires
+[SteamWorks](../installation/#steamworks) extension. If no protocol is provided, the plugin will prepend
+`http://` to this value. **`Default: ""`**
+
+####`get5_demo_upload_header_key`
+:   If defined, it is the authorization key that is appended to the HTTP request. Requires
+[SteamWorks](../installation/#steamworks) extension. **`Default: Authorization`**
+
+####`get5_demo_upload_header_value`
+:   If defined, it is the authorization value that is appended to the HTTP request. Requires
+[SteamWorks](../installation/#steamworks) extension. This is where your API *key* would
+be set. **`Default: ""`**
+
+####`get5_demo_delete_after_upload`
+:   Whether or not to delete the demo from the game server after successfully uploading
+it to a web server. Requires [`get5_demo_upload_url`](./#get5_demo_upload_url) to be set.
+**`Default: 0`**
+
+####`get5_demo_path`
+:   The folder of saved [demo files](../gotv), relative to the `csgo` directory. You **can** use
+the [`{MATCHID}`](#tag-matchid) and [`{DATE}`](#tag-date) variable, i.e. `demos/{DATE}/{MATCHID}/`.
+Much like [`get5_backup_path`](./#get5_backup_path), the path must **not** start with a slash, and
+must **end with a slash**.
+**`Default: ""`**
+
+####`get5_demo_name_format`
+:   Format to use for demo files when [recording matches](gotv.md). Do not include a file extension (`.dem` is added
+automatically). If you do not include the [`{TIME}`](#tag-time) tag, you will have
+problems with duplicate files if restoring a game from a backup. Note that the [`{MAPNUMBER}`](#tag-mapnumber)
+variable is not zero-indexed. Set to empty string to disable recording
+demos.<br>**`Default: "{TIME}_{MATCHID}_map{MAPNUMBER}_{MAPNAME}"`**
+
 ## Substitution Variables
 
 ### Match/State Substitutes {: #state-substitutes }
@@ -325,6 +356,9 @@ placeholder strings that will be replaced by meaningful values when printed. Not
 
 ####`{TIME}` {: #tag-time}
 :   The current time, determined by [`get5_time_format`](#get5_time_format).
+
+####`{DATE}` {: #tag-date}
+:   The current date, determined by [`get5_date_format`](#get5_date_format).
 
 ####`{MAPNAME}` {: #tag-mapname}
 :   The pretty-printed name of the map, i.e. **Dust II** for `de_dust2`.

--- a/documentation/docs/gotv.md
+++ b/documentation/docs/gotv.md
@@ -25,3 +25,11 @@ has passed.
     the GOTV bot to join the server. You should enable GOTV in your general server config and refrain from turning it on
     and off with Get5. Note that setting `tv_enable 1` won't allow people to join your server's GOTV. You must also set
     `tv_advertise_watchable 1`, so you don't have to worry about ghosting if this is disabled.
+
+### Automatic Uploads {: #upload }
+If you have configured [`get5_demo_upload_url`](../configuration/#get5_demo_upload_url), 
+[`get5_demo_upload_header_key`](../configuration/#get5_demo_upload_header_key) and
+[`get5_demo_upload_header_value`](../configuration/#get5_demo_upload_header_value), Get5 will
+automatically upload the demo file to the given URL. You can also set
+[`get5_demo_delete_after_upload`](../configuration/#get5_demo_delete_after_upload)
+in order to delete the file from the game server after successful upload.

--- a/documentation/docs/installation.md
+++ b/documentation/docs/installation.md
@@ -36,7 +36,7 @@ so or can live with the potential consequences.
 
 SteamWorks is not required for Get5 to work on your game server, however it is required if you wish to [load match
 configs remotely](../commands#get5_loadmatch_url) or if you want Get5 to [automatically
-check for updates](../configuration#get5_print_update_notice).
+check for updates](../configuration#get5_print_update_notice) or [upload demos](../gotv/#upload) to a remote web server.
 
 [:material-steam: Download SteamWorks](https://github.com/KyleSanderson/SteamWorks/releases/){ .md-button .md-button--primary }
 

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -64,6 +64,7 @@ ConVar g_AutoLoadConfigCvar;
 ConVar g_AutoReadyActivePlayersCvar;
 ConVar g_BackupSystemEnabledCvar;
 ConVar g_CheckAuthsCvar;
+ConVar g_DateFormatCvar;
 ConVar g_DamagePrintCvar;
 ConVar g_DamagePrintExcessCvar;
 ConVar g_DamagePrintFormatCvar;
@@ -108,6 +109,11 @@ ConVar g_VotesRequiredForSurrenderCvar;
 ConVar g_SurrenderVoteTimeLimitCvar;
 ConVar g_SurrenderCooldownCvar;
 ConVar g_SurrenderTimeToRejoinCvar;
+ConVar g_DemoUploadUrlCvar;
+ConVar g_DemoUploadAuthKeyCvar;
+ConVar g_DemoUploadAuthValueCvar;
+ConVar g_DemoUploadDeleteAfterCvar;
+ConVar g_DemoPathCvar;
 
 // Autoset convars (not meant for users to set)
 ConVar g_GameStateCvar;
@@ -239,6 +245,7 @@ ArrayList g_ChatAliasesCommands;
 
 /** Map-game state not related to the actual gameplay. **/
 char g_DemoFileName[PLATFORM_MAX_PATH];
+char g_DemoFileNameLastStartedUpload[PLATFORM_MAX_PATH];
 bool g_MapChangePending = false;
 bool g_PendingSideSwap = false;
 Handle g_PendingMapChangeTimer = INVALID_HANDLE;
@@ -364,12 +371,30 @@ public void OnPluginStart() {
   g_DamagePrintExcessCvar = CreateConVar(
       "get5_print_damage_excess", "0",
       "Prints full damage given in the damage report on round end. With this disabled (default), a player cannot take more than 100 damage.");
+  g_DateFormatCvar = CreateConVar(
+      "get5_date_format", "%Y-%m-%d",
+      "Date format to use when creating file names. Don't tweak this unless you know what you're doing! Avoid using spaces or colons.");
   g_CheckAuthsCvar =
       CreateConVar("get5_check_auths", "1",
                    "If set to 0, get5 will not force players to the correct team based on steamid");
   g_DemoNameFormatCvar = CreateConVar(
       "get5_demo_name_format", "{TIME}_{MATCHID}_map{MAPNUMBER}_{MAPNAME}",
       "Format for demo file names, use \"\" to disable. Do not remove the {TIME} placeholder if you use the backup system.");
+  g_DemoPathCvar = CreateConVar(
+      "get5_demo_path", "",
+      "The folder to save demo files in, relative to the csgo directory. If defined, it must not start with a slash and must end with a slash.");
+  g_DemoUploadAuthKeyCvar = CreateConVar(
+      "get5_demo_upload_header_value", "",
+      "If defined, it is the authorization value that is appended to the HTTP request. Requires SteamWorks.");
+  g_DemoUploadAuthValueCvar = CreateConVar(
+      "get5_demo_upload_header_key", "Authorization",
+      "If defined, it is the authorization key that is appended to the HTTP request. Requires SteamWorks.");
+  g_DemoUploadDeleteAfterCvar = CreateConVar(
+      "get5_demo_delete_after_upload", "0",
+      "Whether to delete the demo from the game server after a successful upload.");
+  g_DemoUploadUrlCvar = CreateConVar(
+      "get5_demo_upload_url", "",
+      "If defined, it is the URL at which a server resides to accept connections to upload demos. Requires SteamWorks extension. If no protocol is provided, the plugin will prepend http:// to this value.");
   g_DisplayGotvVetoCvar =
       CreateConVar("get5_display_gotv_veto", "0",
                    "Whether to wait for map vetos to be printed to GOTV before changing map");
@@ -1883,10 +1908,14 @@ bool FormatCvarString(ConVar cvar, char[] buffer, int len) {
 
   // Get the time, this is {TIME} in the format string.
   char timeFormat[64];
+  char dateFormat[64];
   g_TimeFormatCvar.GetString(timeFormat, sizeof(timeFormat));
+  g_DateFormatCvar.GetString(dateFormat, sizeof(dateFormat));
   int timeStamp = GetTime();
   char formattedTime[64];
+  char formattedDate[64];
   FormatTime(formattedTime, sizeof(formattedTime), timeFormat, timeStamp);
+  FormatTime(formattedDate, sizeof(formattedDate), dateFormat, timeStamp);
 
   // Get team names with spaces removed.
   char team1Str[MAX_CVAR_LENGTH];
@@ -1899,6 +1928,7 @@ bool FormatCvarString(ConVar cvar, char[] buffer, int len) {
 
   // MATCHTITLE must go first as it can contain other placeholders
   ReplaceString(buffer, len, "{MATCHTITLE}", g_MatchTitle);
+  ReplaceString(buffer, len, "{DATE}", formattedDate);
   ReplaceStringWithInt(buffer, len, "{MAPNUMBER}", Get5_GetMapNumber() + 1);
   ReplaceStringWithInt(buffer, len, "{MAXMAPS}", g_NumberOfMapsInSeries);
   ReplaceString(buffer, len, "{MATCHID}", g_MatchID);

--- a/scripting/get5/debug.sp
+++ b/scripting/get5/debug.sp
@@ -128,6 +128,7 @@ static void AddGlobalStateInfo(File f) {
   f.WriteLine("g_PauseType = %d", g_PauseType);
   f.WriteLine("g_LatestPauseDuration = %d", g_LatestPauseDuration);
   f.WriteLine("g_PendingSurrenderTeam = %d", g_PendingSurrenderTeam);
+  f.WriteLine("g_DemoFileNameLastStartedUpload = %s", g_DemoFileNameLastStartedUpload);
 
   LOOP_TEAMS(team) {
     GetTeamString(team, buffer, sizeof(buffer));


### PR DESCRIPTION
This update allows a user to supply a web address and bearer token to authorize against a web server that accepts files from a POST call. This should allow users to setup a simple web server (e.g. using express) to allow a route for demos to be posted to. Docs have been updated to include the new cvars that are available, but some edge case work still needs to be done (such as formatting the address and checking if it contains `https(s)` in the URL already. If no URL is provided, we leave a debug statement to tell that this feature is currently disabled.

This update also includes a new feature of `get5_demo_path` which will allow users to set specific paths for their demos. If the path doesn't exist, get5 will create these paths so users will be able to store demos in a way that can be better sorted. Some logic has been generalized and moved into the util class, as they're being used in more than one place now.

Closes #354 and #485