### PR TITLE
Refactor coach and team-assignment logic

### DIFF
--- a/cfg/get5/warmup.cfg
+++ b/cfg/get5/warmup.cfg
@@ -15,7 +15,6 @@ mp_solid_teammates 0
 mp_spectators_max 20
 mp_startmoney 16000
 mp_timelimit 0
-mp_warmuptime_all_players_connected 0
 sv_alltalk 1
 sv_auto_full_alltalk_during_warmup_half_end 1
 sv_coaching_enabled 1

--- a/documentation/docs/backup.md
+++ b/documentation/docs/backup.md
@@ -10,14 +10,15 @@ the entire [match configuration](../match_schema) and the match series score for
 
 The backup system must be [enabled](../configuration/#get5_backup_system_enabled) for this to work.
 
-## How does it work?
+### How does it work?
 
 Every time a round starts, CS:GO automatically writes a round backup file into the root of the `csgo` directory based on
 the value of `mp_backup_round_file`. The default value for this is `backup`. Get5 reads this file and copies it into its
-own file called `get5_backup_match%s_map%d_round%d.cfg`, where the arguments are `matchid`, `mapnumber` and `roundnumber`,
-respectively. A special backup called `get5_backup_match%s_map%d_prelive.cfg` is created for the knife round.
+own file called `get5_backup_match%s_map%d_round%d.cfg`, where the arguments are `matchid`, `mapnumber`
+and `roundnumber`, respectively. A special backup called `get5_backup_match%s_map%d_prelive.cfg` is created and should
+be used if you want to restore to the beginning of the map, before the knife round.
 
-## Example
+### Example
 
 When in a match, you can call [`get5_listbackups`](../commands/#get5_listbackups) to view all backups for the current
 match. Note that all rounds and map numbers start at 0.
@@ -39,6 +40,14 @@ get5_backup_match1844_map0_round17.cfg 2022-07-26 19:03:39 "Team A" "Team B" de_
 To load at the beginning of round 13 of the first map of match ID 1844, all players should be connected to the server,
 and you use the [`get5_loadbackup`](../commands/#get5_loadbackup) command:
 
-`get5_loadbackup get5_backup_match1844_map0_round12.cfg`. 
+`get5_loadbackup get5_backup_match1844_map0_round12.cfg`.
 
 The game should restore in a paused state and both teams must [`!unpause`](../commands/#unpause) to continue.
+
+### Pauses in backups
+
+When restoring from a backup, the [consumed pauses](pausing.md) are reset to the state they were in at the beginning
+of the round you restore to, but only if the game state is not currently live. This means that using
+the [`!stop`](../commands/#stop) command or the [`get5_loadbackup`](../commands/#get5_loadbackup) command **for the same
+match and map** would retain the currently used pauses. If restarting the server or loading the backup from scratch, the
+pauses from the backup file will be used.

--- a/documentation/docs/coaching.md
+++ b/documentation/docs/coaching.md
@@ -1,0 +1,64 @@
+# :material-headset: Coaching
+
+Get5 ships with mechanics to manage coaches, but the behavior differs _slightly_ from the built-in coaching
+system found in the game, which avoids a
+few ["minor" bugs](https://en.wikipedia.org/wiki/Counter-Strike_coaching_bug_scandal).
+
+### Server requirements {: #requirements }
+
+1. [`sv_coaching_enabled`](https://totalcsgo.com/command/svcoachingenabled) must be set.
+2. [`coaches_per_team`](../match_schema/#schema) in your match configuration
+   or [scrim template](../getting_started/#scrims) must be larger than 0.
+3. The [`-maxplayers_override`](https://developer.valvesoftware.com/wiki/Maxplayers)
+   launch parameter must be defined on your server to allow for the number of connected clients you expect, including
+   all players, spectators and coaches.
+
+### Becoming a coach {: #howto }
+
+Due to internal conflicts with how [backups](backup.md) and auto-assignment to teams works in Get5, the default
+[`coach`](https://counterstrike.fandom.com/wiki/Coaching) console command is disabled. You can become a coach in one of
+three ways:
+
+1. Use the [`!coach`](../commands/#coach) chat command during freezetime or warmup.
+2. Be defined as a coach in the [match configuration](../match_schema/#schema) or
+   via [`get5_addcoach`](../commands/#get5_addcoach).
+3. Join a game where the team is already full (determined by [`players_per_team`](../match_schema/#schema)) and where a
+   coach slot is available.
+
+!!! warning "Coaching is permanent"
+
+    Once you are assigned as a coach in a non-scrim game, you cannot leave the coach slot unless you are removed from
+    coaching using [`get5_removeplayer`](../commands/#get5_removeplayer).
+
+If the current number of coaches exceeds or equals [`coaches_per_team`](../match_schema/#schema), including if it is
+zero, additional players will be kicked from the match. However, if a connecting player is defined
+in [`players`](../match_schema/#schema), the team is full and a coach slot is open, they will be permanently moved to
+coaching for the series.
+
+This behavior allows you to define as many coaches and players in the match configuration as you want: As long as the
+number of players and coaches on the server don't exceed [`players_per_team`](../match_schema/#schema)
+and [`coaches_per_team`](../match_schema/#schema), respectively, Get5 will fill the
+game slots with the appropriate number of players and coaches and kick the rest. Being in
+the [`coaches`](../match_schema/#schema) section takes precedence over [`players`](../match_schema/#schema).
+
+!!! note "Decreasing the number of players"
+
+    If a match configuration with [`players_per_team`](../match_schema/#schema) or
+    [`coaches_per_team`](../match_schema/#schema) set to a number *lower* than the number of players **already connected
+    to the server**, the entire team will be kicked and must reconnect.
+
+### Coaching in Scrims {: #scrims }
+
+When in [scrim-mode](../getting_started/#scrims), you cannot set the [`coaches`](../match_schema/#schema) key, and
+players are never locked to the coaching slot. This means that to become a coach in a scrim, you must always
+call [`!coach`](../commands/#coach) or join a team that already has [`players_per_team`](../match_schema/#schema)
+players (i.e. is full). Contrary
+to games with a complete [match configuration](../match_schema/#schema), you can also exit the coaching slot if the team
+is not full by simply selecting any team using the team-join menu, which will respawn you as a player in the next
+round (or immediately if still in freezetime), similarly to if you were to reconnect to the server.
+
+!!! danger "`players_per_team` matters in scrims!"
+
+    Do not set [`players_per_team`](../match_schema/#schema) to a value larger than the number of players you expect.
+    If you do this, a player could go back and forth between coaching and playing during freezetime, potentially
+    dropping items for their team. If you play 5v5, don't set it to 6 to allow "anyone to join to coach".

--- a/documentation/docs/coaching.md
+++ b/documentation/docs/coaching.md
@@ -6,9 +6,9 @@ few ["minor" bugs](https://en.wikipedia.org/wiki/Counter-Strike_coaching_bug_sca
 
 ### Server requirements {: #requirements }
 
-1. [`sv_coaching_enabled`](https://totalcsgo.com/command/svcoachingenabled) must be set.
+1. [`sv_coaching_enabled`](https://totalcsgo.com/command/svcoachingenabled) must be set to 1.
 2. [`coaches_per_team`](../match_schema/#schema) in your match configuration
-   or [scrim template](../getting_started/#scrims) must be larger than 0.
+   or [scrim](../getting_started/#scrims) template must be larger than 0.
 3. The [`-maxplayers_override`](https://developer.valvesoftware.com/wiki/Maxplayers)
    launch parameter must be defined on your server to allow for the number of connected clients you expect, including
    all players, spectators and coaches.
@@ -19,46 +19,43 @@ Due to internal conflicts with how [backups](backup.md) and auto-assignment to t
 [`coach`](https://counterstrike.fandom.com/wiki/Coaching) console command is disabled. You can become a coach in one of
 three ways:
 
-1. Use the [`!coach`](../commands/#coach) chat command during freezetime or warmup.
+1. Use the [`!coach`](../commands/#coach) chat command during warmup.
 2. Be defined as a coach in the [match configuration](../match_schema/#schema) or
    via [`get5_addcoach`](../commands/#get5_addcoach).
 3. Join a game where the team is already full (determined by [`players_per_team`](../match_schema/#schema)) and where a
    coach slot is available.
 
-!!! warning "Coaching is permanent"
+!!! warning "Coaching is permanent after warmup"
 
-    Once you are assigned as a coach in a non-scrim game, you cannot leave the coach slot unless you are removed from
-    coaching using [`get5_removeplayer`](../commands/#get5_removeplayer).
+    Once a game begins (goes past the warmup-phase), you cannot enter or leave the coach slot unless you are removed
+    from coaching using [`get5_removeplayer`](../commands/#get5_removeplayer).
 
 If the current number of coaches exceeds or equals [`coaches_per_team`](../match_schema/#schema), including if it is
 zero, additional players will be kicked from the match. However, if a connecting player is defined
-in [`players`](../match_schema/#schema), the team is full and a coach slot is open, they will be permanently moved to
-coaching for the series.
+in [`players`](../match_schema/#schema), the team is full and a coach slot is open, they will be moved to coaching for
+the series and can only stop coaching if the game is still in warmup.
 
 This behavior allows you to define as many coaches and players in the match configuration as you want: As long as the
 number of players and coaches on the server don't exceed [`players_per_team`](../match_schema/#schema)
 and [`coaches_per_team`](../match_schema/#schema), respectively, Get5 will fill the
-game slots with the appropriate number of players and coaches and kick the rest. Being in
+game's slots with the appropriate number of players and coaches and kick the rest. Being in
 the [`coaches`](../match_schema/#schema) section takes precedence over [`players`](../match_schema/#schema).
 
 !!! note "Decreasing the number of players"
 
     If a match configuration with [`players_per_team`](../match_schema/#schema) or
     [`coaches_per_team`](../match_schema/#schema) set to a number *lower* than the number of players **already connected
-    to the server**, the entire team will be kicked and must reconnect.
+    to the server**, the entire team's players or coaches (whichever is exceeded) will be kicked and must reconnect.
 
-### Coaching in Scrims {: #scrims }
+### Coaching in scrims {: #scrims }
 
-When in [scrim-mode](../getting_started/#scrims), you cannot set the [`coaches`](../match_schema/#schema) key, and
-players are never locked to the coaching slot. This means that to become a coach in a scrim, you must always
+When in [scrim mode](../getting_started/#scrims), you cannot set the [`coaches`](../match_schema/#schema) key, and
+players are never _locked_ to the coaching slot. This means that to become a coach in a scrim, you must always
 call [`!coach`](../commands/#coach) or join a team that already has [`players_per_team`](../match_schema/#schema)
-players (i.e. is full). Contrary
-to games with a complete [match configuration](../match_schema/#schema), you can also exit the coaching slot if the team
-is not full by simply selecting any team using the team-join menu, which will respawn you as a player in the next
-round (or immediately if still in freezetime), similarly to if you were to reconnect to the server.
+players (i.e. is full).
 
-!!! danger "`players_per_team` matters in scrims!"
+!!! danger "`players_per_team` matters!"
 
-    Do not set [`players_per_team`](../match_schema/#schema) to a value larger than the number of players you expect.
-    If you do this, a player could go back and forth between coaching and playing during freezetime, potentially
-    dropping items for their team. If you play 5v5, don't set it to 6 to allow "anyone to join to coach".
+    Do not set [`players_per_team`](../match_schema/#schema) in your scrim template to a value larger than the number of
+    players you expect. If you do this, a coach - or any player defined in your scrim template - (re)connecting after
+    warmup will be put on the team and won't be able to become a coach.

--- a/documentation/docs/commands.md
+++ b/documentation/docs/commands.md
@@ -30,8 +30,7 @@ Please note that these can be typed by *all players* in chat.
 
 ####`!coach`
 
-:   Moves a client to coach for their team. Requires that
-the [`sv_coaching_enabled`](https://totalcsgo.com/command/svcoachingenabled) variable is set to `1`.
+:   Moves a client to [coach for their team](coaching.md).
 
 ####`!stay`
 
@@ -51,13 +50,13 @@ the [get5_stop_command_enabled](../configuration/#get5_stop_command_enabled) is 
 
 :   Force-readies your team, marking all players on your team as ready.
 
-####`!ringer`
+####`!ringer <target>` {: #ringer }
 
-:   Adds/removes a ringer to/from the home scrim team.
+:   Alias for [`get5_ringer`](#get5_ringer).
 
 ####`!scrim`
 
-:   Shortcut for [`get5_scrim`](#get5_scrim).
+:   Alias for [`get5_scrim`](#get5_scrim).
 
 ####`!get5`
 
@@ -100,12 +99,12 @@ to that team. Omitting the team argument sets no winner (tie).
 
 ####`get5_creatematch [map name] [matchid]` {: #get5_creatematch }
 :   Creates a BO1 match with the current players on the server. `map name` defaults to the current map and `matchid`
-    defaults to `manual`. You should **not** provide a match ID if you use the [MySQL extension](../stats_system/#mysql).
+defaults to `manual`. You should **not** provide a match ID if you use the [MySQL extension](../stats_system/#mysql).
 
 ####`get5_scrim [opposing team name] [map name] [matchid]` {: #get5_scrim }
 :   Creates a [scrim](../getting_started/#scrims) on the current map. The opposing team name defaults to `Away`
-    and the map defaults to the current map. `matchid` defaults to `scrim`. You should **not** provide a match ID if
-    you use the [MySQL extension](../stats_system/#mysql).
+and the map defaults to the current map. `matchid` defaults to `scrim`. You should **not** provide a match ID if
+you use the [MySQL extension](../stats_system/#mysql).
 
 ####`get5_addplayer <auth> <team1|team2|spec> [name]` {: #get5_addplayer }
 :   Adds a Steam ID to a team (can be any format for the Steam ID). The name parameter optionally locks the player's
@@ -115,8 +114,10 @@ name.
 :   Adds a Steam ID to a team as a coach. The name parameter optionally locks the player's
 name.
 
-####`get5_removeplayer <auth>`
-:   Removes a steam ID from all teams (can be any format for the Steam ID).
+####`get5_removeplayer <auth>` {: #get5_removeplayer}
+:   Removes a steam ID from all teams (can be any format for the Steam ID). This also removes the player as
+a [coach](coaching.md). If [`get5_check_auths`](../configuration/#get5_check_auths) is set, the player will be removed
+from the server immediately.
 
 ####`get5_addkickedplayer <team1|team2|spec> [name]` {: #get5_addkickedplayer }
 :   Adds the last kicked Steam ID to a team. The name parameter optionally locks the player's name.
@@ -223,9 +224,17 @@ name.
 :   Lists backup files for the current match or a given match ID if provided. If you define
 [`get5_backup_path`](../configuration/#get5_backup_path), it will only list backups found under that prefix.
 
-####`get5_ringer <player>`
-:   Adds/removes a ringer to/from the home scrim team. `player` is the name of the player. Similar
-to [`!ringer`](../commands/#ringer)
+####`get5_ringer <target>` {: #get5_ringer }
+:   Adds/removes a ringer to/from the home scrim team. `target` is the name of the player, their user ID or their Steam
+ID. Similar to [`!ringer`](../commands/#ringer) in chat.
+
+!!! example "User ID vs client index"
+
+    To view user IDs, type `users` in console. In this example, `3` is the user ID and `1` is the client index:
+    ```
+    > users
+    1:3:"Quinn"
+    ```
 
 ####`get5_debuginfo [file]` {: #get5_debuginfo }
 :   Dumps debug info to a file (`addons/sourcemod/logs/get5_debuginfo.txt` if no file parameter is provided).

--- a/documentation/docs/commands.md
+++ b/documentation/docs/commands.md
@@ -30,7 +30,8 @@ Please note that these can be typed by *all players* in chat.
 
 ####`!coach`
 
-:   Moves a client to [coach for their team](coaching.md).
+:   Requests to become a [coach](coaching.md) for your team. If already coaching, this will move you back as a player
+if possible. Can only be used during warmup.
 
 ####`!stay`
 

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -59,8 +59,9 @@ disconnect even in warmup with the intention to reconnect!). **`Default: 0`**
 :   Whether to wait for map vetoes to be printed to GOTV before changing map. **`Default: 0`**
 
 ####`get5_check_auths`
-:   Whether the Steam IDs from a `players` of a [match configuration](../match_schema/#schema) section are used to
-force players onto teams, kicking everyone else. **`Default: 1`**
+:   Whether the Steam IDs from the `players` and `coaches` sections of a [match configuration](../match_schema/#schema)
+are used to force players onto teams. Anyone not defined will be removed from the game, or if
+in [scrim mode](../getting_started/#scrims), put on `team2`. **`Default: 1`**
 
 ####`get5_print_update_notice`
 :   Whether to print to chat when the game goes live if a new version of Get5 is available. This only works if

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -32,6 +32,27 @@ cfg/get5/live.cfg # (3)
 2. Executed when the knife-round starts.
 3. Executed when the game goes live.
 
+!!! danger "Prohibited options"
+
+    You should avoid these commands in your live, knife and warmup configuration files, as all of these are handled by
+    Get5 automatically. Introducing restarts, warmup changes or [GOTV](gotv.md) delay modifications can cause problems.
+    If you want to set your `tv_delay`, do it in the `cvars` section of your [match configuration](match_schema.md).
+
+    ```
+    mp_do_warmup_period
+    mp_restartgame
+    mp_warmup_end
+    mp_warmup_pausetimer   
+    mp_warmup_start
+    mp_warmuptime
+    mp_warmuptime_all_players_connected
+    tv_delay
+    tv_delaymapchange
+    tv_enable
+    tv_record
+    tv_stoprecord
+    ```
+
 ## Server Setup
 
 **These options will generally not be directly presented to clients.**

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -17,8 +17,7 @@ the explanation of the [match schema](../match_schema), that section will overri
 ### Phase Configuration Files
 
 You should also have three config files. These can be edited, but we recommend not
-blindly pasting another config in (e.g. ESL, CEVO). Configs that execute warmup commands (`mp_warmup_end`, for
-example) **will** cause problems. These must only include commands you would run in the console (such
+blindly pasting another config in (e.g. ESL, CEVO). These must only include commands you would run in the console (such
 as `mp_friendly_fire 1`) and should determine the rules for those three stage of your match. You can
 also [point to other files](#config-files) by editing the main config file.
 

--- a/documentation/docs/getting_started.md
+++ b/documentation/docs/getting_started.md
@@ -33,8 +33,8 @@ file as soon as a player joins by setting [`get5_autoload_config`](../configurat
 
 ## Scrims {: #scrims }
 
-While Get5 is intended for matches (league matches, LAN-matches, cups, etc.), it can be used for everyday
-scrims/gathers/whatever as well. If that is your use case, you should do a few things differently. We call "_having a
+While Get5 is intended for matches (league matches, LANs, cups, etc.), it can be used for everyday
+scrims or gathers as well. If that is your use case, you should do a few things differently. We call "_having a
 home team defined and anyone else on the opposing team_" a **scrim**, and loading this configuration is referred to as
 **scrim mode**.
 

--- a/documentation/docs/getting_started.md
+++ b/documentation/docs/getting_started.md
@@ -5,7 +5,7 @@
     While you can just jump right in, we recommend you read the [configuration](../configuration) and
     [match schema](../match_schema) sections of the documentation to understand what Get5 can do.
 
-## Quick Start
+## Quick Start {: #quick-start }
 
 If you want to create a match quickly without modifying anything, you must set two properties:
 
@@ -18,17 +18,25 @@ call [`get5_creatematch`](../commands/#get5_creatematch). There is also a simple
 from by typing [`!get5`](../commands/#get5) in the game chat. Note that you must
 be [a server administrator](../installation/#administrators) to do this.
 
-## Scrims
+## Match Configuration {: #match-configuration }
+
+The default operation mode for Get5 is the configuration and loading of
+a [match configuration file](../match_schema). This file should contain all the players and coaches, their team
+name and optionally flag and logo as well as any spectators/casters. Once you've created your file you can load it
+using the [`get5_loadmatch`](../commands/#get5_loadmatch) command or configure your server to automatically load the
+file as soon as a player joins by setting [`get5_autoload_config`](../configuration/#get5_autoload_config).
+
+!!! tip "Lock it down"
+
+    When loading match configurations, ensure that [`get5_check_auths`](../configuration/#get5_check_auths) is enabled.
+    This ensures that people are locked to the correct teams and that nobody else can join the server.
+
+## Scrims {: #scrims }
 
 While Get5 is intended for matches (league matches, LAN-matches, cups, etc.), it can be used for everyday
 scrims/gathers/whatever as well. If that is your use case, you should do a few things differently. We call "_having a
-home team defined and anyone else on the opposing team_" a **scrim**.
-
-### Letting the opposing team in {: #opposing-team }
-
-Get5 can be configured to kick all players from the server if no match is loaded. You should disable this for a scrim
-server. To do so, edit [`cfg/sourcemod/get5.cfg`](../configuration/#main-config) and make sure that
-[`get5_kick_when_no_match_loaded`](../configuration/#get5_kick_when_no_match_loaded) to `0`.
+home team defined and anyone else on the opposing team_" a **scrim**, and loading this configuration is referred to as
+**scrim mode**.
 
 ### Adding your team's Steam IDs {: #home-team }
 
@@ -37,9 +45,23 @@ located at `addons/sourcemod/configs/get5/scrim_template.cfg` and add in *your* 
 their Steam IDs (any format works). After doing this, any user who does not belong in `team1` will implicitly be set
 to `team2`.
 
+!!! warning "Coaches in scrims"
+
+    You **cannot** set the [`coaches`](../match_schema/#schema) section in a scrim template. Instead, add everyone to
+    the [`players`](../match_schema/#schema) section and use the [`!coach`](../commands/#coach) command to become a
+    [coach](coaching.md) after joining the game. If the team is full (defined by
+    [`players_per_team`](../match_schema/#schema)), additional players will automatically be moved to coach if there are
+    available slots.
+
 You can list however many players you want. Add all your coaches, analysts, ringers, and such. If someone on your list
 ends up being on the other team in a scrim, you can use the [`!ringer`](../commands/#ringer) command to temporarily swap
 them (similarly, you can use it to put someone not in the list on your team temporarily).
+
+### Letting the opposing team in {: #opposing-team }
+
+Get5 can be configured to kick all players from the server if no match is loaded. You should disable this for a scrim
+server. To do so, edit [`cfg/sourcemod/get5.cfg`](../configuration/#main-config) and make sure that
+[`get5_kick_when_no_match_loaded`](../configuration/#get5_kick_when_no_match_loaded) is set to `0`.
 
 ### Starting the Match
 
@@ -48,7 +70,8 @@ use the [`get5_scrim`](../commands/#get5_scrim) command when the server is on th
 RCON or as a regular console command if you are [a server administrator](../installation/#administrators).
 You could also type [`!scrim`](../commands/#scrim) in chat.
 
-Once you've done this, all that has to happen is teams to [ready up](../commands/#ready) to start the match.
+Once you've done this, all that is required is for both teams to [ready up](../commands/#ready) and the match will
+begin.
 
 !!! danger "Practice Mode"
 
@@ -62,4 +85,5 @@ You can (and should) edit
 the [scrim template](https://github.com/splewis/get5/blob/master/configs/get5/scrim_template.cfg)
 at `addons/sourcemod/configs/get5/scrim_template.cfg`. In this you can set any scrim-specific properties in the `cvars`
 section. The template defaults to `mp_match_can_clinch 0` (designed for practice) which you should disable if playing a
-real match. You may also want to lower `tv_delay` (and maybe `tv_enable` so you can record your scrims).
+real match. You may also want to lower `tv_delay` (and maybe set `tv_enable 1` so you can [record your scrims](gotv.md))
+.

--- a/documentation/docs/gotv.md
+++ b/documentation/docs/gotv.md
@@ -4,13 +4,6 @@ Get5 can be configured to automatically record matches. This is enabled by defau
 of [`get5_demo_name_format`](../configuration/#get5_demo_name_format) and can be disabled by setting that parameter to
 an empty string.
 
-!!! warning "Don't mess too much with the delay!"
-
-    Changing the `tv_delay` or `tv_enable` in `warmup.cfg`, `live.cfg` etc. is going to cause problems with your demos.
-    We recommend you set this variable either on your server in general or only once in the `cvar` section of your
-    [match configuration](../match_schema). You should also not set `tv_delaymapchange` as Get5 handles this
-    automatically.
-
 Demo recording starts once all teams have readied up and ends shortly following a map result. When a demo file is
 written to disk, the [`Get5_OnDemoFinished`](events_and_forwards.md) forward is called, which you can use to move the
 file or upload it somewhere. The filename can also be found in the map-section of the
@@ -20,3 +13,15 @@ Get5 will automatically adjust the [`mp_match_restart_delay`](https://totalcsgo.
 map ends if GOTV is enabled to ensure that it won't be shorter than what is required for the GOTV broadcast to finish.
 Players will also not be [kicked from the server](../configuration/#get5_kick_when_no_match_loaded) before this delay
 has passed.
+
+!!! warning "Don't mess too much with the TV! :tv:"
+
+    Changing `tv_delay` or `tv_enable` in `warmup.cfg`, `live.cfg` etc. is going to cause problems with your demos.
+    We recommend you set `tv_delay` either on your server in general or only once in the `cvars` section of your
+    [match configuration](../match_schema). You should also not set `tv_delaymapchange` as Get5 handles this
+    automatically.
+    
+    We recommend that you **do not** set `tv_enable` in your match configuration, as it **requires** a map change for
+    the GOTV bot to join the server. You should enable GOTV in your general server config and refrain from turning it on
+    and off with Get5. Note that setting `tv_enable 1` won't allow people to join your server's GOTV. You must also set
+    `tv_advertise_watchable 1`, so you don't have to worry about ghosting if this is disabled.

--- a/documentation/docs/match_schema.md
+++ b/documentation/docs/match_schema.md
@@ -123,7 +123,8 @@ interface Get5Match {
     cvars.<br><br>**`Default: ""`**
 28. Match teams can also be loaded from a separate file, allowing you to easily re-use a match configuration for
     different sets of teams. A `fromfile` value could be `"addons/sourcemod/configs/get5/team_nip.json"`, and that file
-    should contain a valid `Get5MatchTeam` object.
+    should contain a valid `Get5MatchTeam` object. Note that the file you point to must be in the same format as the
+    main file, so pointing to a `.cfg` file when the main file is `.json` will **not** work.
 29. _Optional_<br>The name of the spectator team.<br><br>**`Default: "casters"`**
 30. _Optional_<br>The spectator/caster Steam IDs and names.
 31. _Optional_<br>Determines the starting sides for each map. If this array is shorter than `num_maps`, `side_type` will

--- a/documentation/docs/match_schema.md
+++ b/documentation/docs/match_schema.md
@@ -66,8 +66,9 @@ interface Get5Match {
    match IDs from another source, they **must** be integers (in a string) and must increment between
    matches.<br><br>**`Default: ""`**
 2. _Optional_<br>The number of maps to play in the series.<br><br>**`Default: 3`**
-3. _Optional_<br>The number of players per team.<br><br>**`Default: 5`**
-4. _Optional_<br>The maximum number of coaches per team.<br><br>**`Default: 2`**
+3. _Optional_<br>The number of players per team. You should **never** set this to a value higher than the number of
+   players you want to actually play in a game, *excluding* coaches.<br><br>**`Default: 5`**
+4. _Optional_<br>The maximum number of [coaches](coaching.md) per team.<br><br>**`Default: 2`**
 5. _Optional_<br>The minimum number of players of each team that must type [`!ready`](../commands/#ready) for the game
    to begin.<br><br>**`Default: 1`**
 6. _Optional_<br>The minimum number of spectators that must be [`!ready`](../commands/#ready) for the game to
@@ -106,8 +107,8 @@ interface Get5Match {
     regular server-commands and any [`Get5 configuration parameter`](configuration.md),
     i.e. `{"hostname": "Match #3123 - Astralis vs. NaVi"}`.<br><br>**`Default: undefined`**
 23. _Optional_<br>Similarly to `players`, this object maps [coaches](coaching.md) using their Steam ID and
-    name, locking them to the coach slot until removed
-    using [`get5_removeplayer`](../commands/#get5_removeplayer)<br><br>**`Default: undefined`**
+    name, locking them to the coach slot unless removed using [`get5_removeplayer`](../commands/#get5_removeplayer).
+    Setting a Steam ID as coach takes precedence over being set as a player.<br><br>**`Default: undefined`**
 24. _Required_<br>The players on the team.
 25. _Optional_<br>Wrapper of the server's `mp_teammatchstat_txt` cvar, but can use `{MAPNUMBER}` and `{MAXMAPS}` as
     variables that get replaced with their integer values. In a BoX series, you probably don't want to set this since

--- a/documentation/docs/match_schema.md
+++ b/documentation/docs/match_schema.md
@@ -105,8 +105,9 @@ interface Get5Match {
 22. _Optional_<br>Various commands to execute on the server when loading the match configuration. This can be both
     regular server-commands and any [`Get5 configuration parameter`](configuration.md),
     i.e. `{"hostname": "Match #3123 - Astralis vs. NaVi"}`.<br><br>**`Default: undefined`**
-23. _Optional_<br>Similarly to `players`, this object maps coaches using their Steam ID and
-    name.<br><br>**`Default: undefined`**
+23. _Optional_<br>Similarly to `players`, this object maps [coaches](coaching.md) using their Steam ID and
+    name, locking them to the coach slot until removed
+    using [`get5_removeplayer`](../commands/#get5_removeplayer)<br><br>**`Default: undefined`**
 24. _Required_<br>The players on the team.
 25. _Optional_<br>Wrapper of the server's `mp_teammatchstat_txt` cvar, but can use `{MAPNUMBER}` and `{MAXMAPS}` as
     variables that get replaced with their integer values. In a BoX series, you probably don't want to set this since

--- a/documentation/docs/match_schema.md
+++ b/documentation/docs/match_schema.md
@@ -93,7 +93,9 @@ interface Get5Match {
 14. _Optional_<br>Wrapper for the server's `mp_teamprediction_pct`. This determines the chances of `team1`
     winning.<br><br>**`Default: 0`**
 15. _Optional_<br>Wrapper for the server's `mp_teamprediction_txt`.<br><br>**`Default: ""`**
-16. _Required_<br>The team's name. Sets `mp_teamname_1` or `mp_teamname_2`. Printed frequently in chat.
+16. _Optional_<br>The team's name. Sets `mp_teamname_1` or `mp_teamname_2`. Printed frequently in chat. If you don't
+    define a team name, it will be set to `team_` followed by the name of the captain, i.e. `team_s1mple`.
+    <br><br>**`Default: ""`**
 17. _Optional_<br>A short version of the team name, used in clan tags in-game (requires
     that [`get5_set_client_clan_tags`](../configuration#get5_set_client_clan_tags) is disabled).
     <br><br>**`Default: ""`**

--- a/documentation/docs/translations.md
+++ b/documentation/docs/translations.md
@@ -177,3 +177,19 @@ end with a full stop as this is added automatically.
 | `VetoCountdown`                             | Veto commencing in _3_ seconds.                                                                                                                                          | Chat       |
 | `NewVersionAvailable`                       | A newer version of Get5 is available. Please visit _splewis.github.io/get5_ to update.                                                                                   | Chat       |
 | `PrereleaseVersionWarning`                  | You are running an unofficial version of Get5 (_0.9.0-c7af39a_) intended for development and testing only. This message can be disabled with _get5_print_update_notice_. | Chat       |
+
+## Supported Languages {: #supported-languages }
+
+These are the languages Get5 supports. The links will take you to the source translation file for the language on
+GitHub. Most languages are incomplete, and if a translation string is missing, the English default will be used.
+
+#### :flag_gb: [English](https://github.com/splewis/get5/blob/development/translations/get5.phrases.txt) (default) {: #en }
+#### :flag_fr: [French](https://github.com/splewis/get5/tree/development/translations/fr/get5.phrases.txt) {: #fr }
+#### :flag_de: [German](https://github.com/splewis/get5/tree/development/translations/de/get5.phrases.txt) {: #de }
+#### :flag_es: [Spanish](https://github.com/splewis/get5/tree/development/translations/es/get5.phrases.txt) {: #es }
+#### :flag_cn: [Chinese](https://github.com/splewis/get5/tree/development/translations/chi/get5.phrases.txt) {: #cn }
+#### :flag_dk: [Danish](https://github.com/splewis/get5/tree/development/translations/da/get5.phrases.txt) {: #da }
+#### :flag_hu: [Hungarian](https://github.com/splewis/get5/tree/development/translations/hu/get5.phrases.txt) {: #hu }
+#### :flag_pl: [Polish](https://github.com/splewis/get5/tree/development/translations/pl/get5.phrases.txt) {: #pl }
+#### :flag_pt: [Portuguese](https://github.com/splewis/get5/tree/development/translations/pt/get5.phrases.txt) {: #pt }
+#### :flag_ru: [Russian](https://github.com/splewis/get5/tree/development/translations/ru/get5.phrases.txt) {: #ru }

--- a/documentation/docs/translations.md
+++ b/documentation/docs/translations.md
@@ -29,9 +29,9 @@ entire language file**.
     ```
 
     1. The `#format` parameter indicates the order and types of parameters. These will *not* be defined in other 
-       and you should only provide the language string itself (with its language prefix, i.e. `en`). The original file
-       indicates what `{1}`, `{2}` and `{3}` are. In this case, the first and second arguments are strings and the third
-       is a number.
+       languages, and you should only provide the language string itself (with its language prefix, i.e. `en`). The
+       original file indicates what `{1}`, `{2}` and `{3}` are. In this case, the first and second arguments are strings
+       and the third is a number.
     2. Use the English strings and the [reference](#reference) below to determine how to translate the string.
 
 As the string implies, this example is used when a team picks a map, and the output is printed to chat and looks like
@@ -158,7 +158,12 @@ end with a full stop as this is added automatically.
 | `CaptainLeftOnVetoInfoMessage`              | A captain left during the veto, pausing the veto.                                                                                                                        | Chat       |
 | `ReadyToResumeVetoInfoMessage`              | Type _!ready_ when you are ready to resume the veto.                                                                                                                     | Chat       |
 | `MatchConfigLoadedInfoMessage`              | Loaded match config.                                                                                                                                                     | Chat       |
-| `MoveToCoachInfoMessage`                    | You were moved to the coach position because your team is full.                                                                                                          | Chat       |
+| `MoveToCoachInfoMessage`                    | You were moved to the coach position as your team is full.                                                                                                               | Chat       |
+| `CannotLeaveCoachingTeamIsFull`             | You cannot leave the coach position as your team is full.                                                                                                                | Chat       |
+| `CoachingNotEnabled`                        | Coaching is not enabled. You must set _sv_coaching_enabled_ to 1.                                                                                                        | Chat       |
+| `PlayerIsCoachingTeam`                      | _PlayerName_ is coaching _Team A_.                                                                                                                                       | Chat       |
+| `CanOnlyCoachDuringWarmup`                  | You can only change to or from coach during warmup.                                                                                                                      | Chat       |
+| `AllCoachSlotsFilledForTeam`                | All coach slots (_2_) are currently filled for your team.                                                                                                                | Chat       |
 | `ReadyTag`                                  | **[READY]** PlayerName: Hey, I'm ready...                                                                                                                                | Chat       |
 | `NotReadyTag`                               | **[NOT READY]** PlayerName: Hey, I'm not ready...                                                                                                                        | Chat       |
 | `MapVetoPickMenuText`                       | Select a map to PLAY:                                                                                                                                                    | Menu       |

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -37,6 +37,7 @@ nav:
       - Getting Started: getting_started.md
       - Match Schema: match_schema.md
       - Commands: commands.md
+      - Coaching: coaching.md
       - Pausing: pausing.md
       - Backup System: backup.md
       - GOTV & Demos: gotv.md

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -1010,6 +1010,8 @@ public Action Command_EndMatch(int client, int args) {
   Call_Finish();
   EventLogger_LogAndDeleteEvent(mapResultEvent);
 
+  StopRecording(1.0); // must go before EndSeries as it depends on g_MatchID.
+
   // No delay required when not kicking players.
   EndSeries(winningTeam, false, 0.0, false);
 
@@ -1036,7 +1038,6 @@ public Action Command_EndMatch(int client, int args) {
     delete g_KnifeDecisionTimer;
   }
 
-  StopRecording(1.0);
   ServerCommand("mp_restartgame 1");
 
   return Plugin_Handled;

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -1273,7 +1273,7 @@ public Action Event_MatchOver(Event event, const char[] name, bool dontBroadcast
       }
     } else if (g_SeriesCanClinch) {
       // This adjusts for ties!
-      int actualMapsToWin = ((g_MapsToPlay.Length - tiedMaps) / 2) + 1;
+      int actualMapsToWin = MapsToWin(g_MapsToPlay.Length - tiedMaps);
       if (t1maps == actualMapsToWin) {
         // Team 1 won
         EndSeries(Get5Team_1, true, restartDelay);

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -114,7 +114,6 @@ ConVar g_CoachingEnabledCvar;
 
 /** Series config game-state **/
 int g_MapsToWin = 1;  // Maps needed to win the series.
-bool g_BO2Match = false;
 bool g_SeriesCanClinch = true;
 int g_RoundNumber = -1;  // The round number, 0-indexed. -1 if the match is not live.
 // The active map number, used by stats. Required as the calculated round number changes immediately
@@ -1908,11 +1907,10 @@ public bool FormatCvarString(ConVar cvar, char[] buffer, int len) {
   strcopy(team2Str, sizeof(team2Str), g_TeamNames[Get5Team_2]);
   ReplaceString(team2Str, sizeof(team2Str), " ", "_");
 
-  int mapNumber = g_TeamSeriesScores[Get5Team_1] + g_TeamSeriesScores[Get5Team_2] + 1;
   // MATCHTITLE must go first as it can contain other placeholders
   ReplaceString(buffer, len, "{MATCHTITLE}", g_MatchTitle, false);
-  ReplaceStringWithInt(buffer, len, "{MAPNUMBER}", mapNumber, false);
-  ReplaceStringWithInt(buffer, len, "{MAXMAPS}", MaxMapsToPlay(g_MapsToWin));
+  ReplaceStringWithInt(buffer, len, "{MAPNUMBER}", Get5_GetMapNumber() + 1, false);
+  ReplaceStringWithInt(buffer, len, "{MAXMAPS}", g_NumberOfMapsInSeries, false);
   ReplaceString(buffer, len, "{MATCHID}", g_MatchID, false);
   ReplaceString(buffer, len, "{MAPNAME}", mapName, false);
   ReplaceStringWithInt(buffer, len, "{SERVERID}", g_ServerIdCvar.IntValue, false);

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -1580,7 +1580,7 @@ public Action Event_RoundStart(Event event, const char[] name, bool dontBroadcas
   // ghost, depending on where the camera drops them. Especially important for coaches.
   // We do this step *before* we write the backup, so we don't have any lingering players in case of a restore.
   LOOP_CLIENTS(i) {
-    if (IsPlayer(i) && !IsClientSourceTV(i) && GetClientTeam(i) == CS_TEAM_NONE) {
+    if (IsPlayer(i) && GetClientTeam(i) == CS_TEAM_NONE) {
       CheckClientTeam(i);
     }
   }

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -837,9 +837,8 @@ public void OnConfigsExecuted() {
   LOOP_TEAMS(team) {
     g_TeamGivenStopCommand[team] = false;
     g_TeamReadyForUnpause[team] = false;
-
     // We don't need to check for g_WaitingForRoundBackup here, as a backup will override the pauses consumed anyway; if
-    // the map is changed, we always load the backup pauses.
+    // the map is changed, we always load the backup pauses. See the RestoreFromBackup function.
     g_TacticalPauseTimeUsed[team] = 0;
     g_TacticalPausesUsed[team] = 0;
     g_TechnicalPausesUsed[team] = 0;
@@ -855,6 +854,11 @@ public void OnConfigsExecuted() {
     ChangeState(Get5State_Warmup);
     ExecCfg(g_WarmupCfgCvar);
     StartWarmup();
+  }
+  // This must not be called when waiting for a backup, as it will set the sides incorrectly if the team swapped in
+  // knife or if the backup target is the second half.
+  if (!g_WaitingForRoundBackup) {
+    SetStartingTeams();
   }
 }
 
@@ -1581,7 +1585,7 @@ public Action Event_RoundStart(Event event, const char[] name, bool dontBroadcas
     }
   }
 
-  if (g_GameState >= Get5State_Warmup) {
+  if (g_GameState == Get5State_Warmup || g_GameState == Get5State_KnifeRound || g_GameState == Get5State_Live) {
     WriteBackup();
   }
 

--- a/scripting/get5/backups.sp
+++ b/scripting/get5/backups.sp
@@ -1,5 +1,6 @@
 #define TEMP_MATCHCONFIG_BACKUP_PATTERN "get5_match_config_backup%d.txt"
 #define TEMP_VALVE_BACKUP_PATTERN "get5_temp_backup%d.txt"
+#define TEMP_VALVE_NAMES_FILE_PATTERN "get5_names%d.txt"
 
 public Action Command_LoadBackup(int client, int args) {
   if (!g_BackupSystemEnabledCvar.BoolValue) {

--- a/scripting/get5/backups.sp
+++ b/scripting/get5/backups.sp
@@ -175,8 +175,10 @@ void WriteBackupStructure(const char[] path) {
 
   kv.SetNum("series_draw", g_TeamSeriesScores[Get5Team_None]);
 
-  kv.SetNum("team1_pauses_used", g_TacticalPausesUsed[Get5Team_1]);
-  kv.SetNum("team2_pauses_used", g_TacticalPausesUsed[Get5Team_2]);
+  kv.SetNum("team1_tac_pauses_used", g_TacticalPausesUsed[Get5Team_1]);
+  kv.SetNum("team2_tac_pauses_used", g_TacticalPausesUsed[Get5Team_2]);
+  kv.SetNum("team1_tech_pauses_used", g_TechnicalPausesUsed[Get5Team_1]);
+  kv.SetNum("team2_tech_pauses_used", g_TechnicalPausesUsed[Get5Team_2]);
   kv.SetNum("team1_pause_time_used", g_TacticalPauseTimeUsed[Get5Team_1]);
   kv.SetNum("team2_pause_time_used", g_TacticalPauseTimeUsed[Get5Team_2]);
 
@@ -254,6 +256,17 @@ bool RestoreFromBackup(const char[] path) {
     kv.GoBack();
   }
 
+  if (g_GameState != Get5State_Live) {
+    // This isn't perfect, but it's better than resetting all pauses used to zero in cases of restore on a new server.
+    // If restoring while live, we just retain the current pauses used, as they should be the "most correct".
+    g_TacticalPausesUsed[Get5Team_1] = kv.GetNum("team1_tac_pauses_used", 0);
+    g_TacticalPausesUsed[Get5Team_2] = kv.GetNum("team2_tac_pauses_used", 0);
+    g_TechnicalPausesUsed[Get5Team_1] = kv.GetNum("team1_tech_pauses_used", 0);
+    g_TechnicalPausesUsed[Get5Team_2] = kv.GetNum("team2_tech_pauses_used", 0);
+    g_TacticalPauseTimeUsed[Get5Team_1] = kv.GetNum("team1_pause_time_used", 0);
+    g_TacticalPauseTimeUsed[Get5Team_2] = kv.GetNum("team2_pause_time_used", 0);
+  }
+
   kv.GetString("matchid", g_MatchID, sizeof(g_MatchID));
   g_GameState = view_as<Get5State>(kv.GetNum("gamestate"));
 
@@ -269,12 +282,6 @@ bool RestoreFromBackup(const char[] path) {
   // This ensures that the MapNumber logic correctly calculates the map number when there have been
   // draws.
   g_TeamSeriesScores[Get5Team_None] = kv.GetNum("series_draw", 0);
-
-  // This isn't perfect, but it's better than resetting all pauses used to zero in cases of restore on a new server.
-  g_TacticalPausesUsed[Get5Team_1] =  kv.GetNum("team1_pauses_used", 0);
-  g_TacticalPausesUsed[Get5Team_2] =  kv.GetNum("team2_pauses_used", 0);
-  g_TacticalPauseTimeUsed[Get5Team_1] =  kv.GetNum("team1_pause_time_used", 0);
-  g_TacticalPauseTimeUsed[Get5Team_2] =  kv.GetNum("team2_pause_time_used", 0);
 
   // Immediately set map number global var to ensure anything below doesn't break.
   g_MapNumber = Get5_GetMapNumber();

--- a/scripting/get5/backups.sp
+++ b/scripting/get5/backups.sp
@@ -7,6 +7,11 @@ public Action Command_LoadBackup(int client, int args) {
     return Plugin_Handled;
   }
 
+  if (g_PendingSideSwap || InHalftimePhase()) {
+    ReplyToCommand(client, "You cannot load a backup during halftime.");
+    return Plugin_Handled;
+  }
+
   char path[PLATFORM_MAX_PATH];
   if (args >= 1 && GetCmdArg(1, path, sizeof(path))) {
     if (RestoreFromBackup(path)) {

--- a/scripting/get5/backups.sp
+++ b/scripting/get5/backups.sp
@@ -359,8 +359,7 @@ public void RestoreGet5Backup() {
   // This variable is reset on a timer since the implementation of the
   // mp_backup_restore_load_file doesn't do everything in one frame.
   g_DoingBackupRestoreNow = true;
-  ExecCfg(g_LiveCfgCvar); // async
-  CreateTimer(0.5, Timer_ExecMatchConfig, _, TIMER_FLAG_NO_MAPCHANGE);
+  ExecCfg(g_LiveCfgCvar);
 
   if (g_SavedValveBackup) {
     ChangeState(Get5State_Live);
@@ -371,24 +370,13 @@ public void RestoreGet5Backup() {
     SetStartingTeams();
     if (g_GameState == Get5State_Live) {
       EndWarmup();
-      EndWarmup();
-      ServerCommand("mp_restartgame 5");
+      RestartGame(5);
       PauseGame(Get5Team_None, Get5PauseType_Backup);
     } else {
-      EnsureIndefiniteWarmup();
+      StartWarmup();
     }
-
     g_DoingBackupRestoreNow = false;
   }
-}
-
-public Action Timer_ExecMatchConfig(Handle timer) {
-  // This needs to go on a callback because ServerCommand("exec") is async, so the config will load
-  // *after* the match cvars if we put them in RestoreGet5Backup, which we don't want, as that's not the order in which
-  // they were loaded when the match was initially set up.
-  SetMatchTeamCvars();
-  ExecuteMatchConfigCvars();
-  return Plugin_Handled;
 }
 
 public Action Time_StartRestore(Handle timer) {

--- a/scripting/get5/backups.sp
+++ b/scripting/get5/backups.sp
@@ -397,7 +397,7 @@ void RestoreGet5Backup() {
   // Last step is assigning players to their teams. This is normally done inside LoadMatchConfig, but since we need
   // the team sides to be applied from the backup, we skip it then and do it here.
   LOOP_CLIENTS(i) {
-    if (IsAuthedPlayer(i) && !IsClientSourceTV(i)) {
+    if (IsPlayer(i)) {
       CheckClientTeam(i);
     }
   }
@@ -414,7 +414,7 @@ public Action Time_StartRestore(Handle timer) {
 public Action Timer_FinishBackup(Handle timer) {
   // This ensures that coaches are moved to their slots.
   LOOP_CLIENTS(i) {
-    if (IsPlayer(i) && !IsClientSourceTV(i)) {
+    if (IsPlayer(i)) {
       CheckClientTeam(i);
     }
   }

--- a/scripting/get5/debug.sp
+++ b/scripting/get5/debug.sp
@@ -99,8 +99,17 @@ static void AddGlobalStateInfo(File f) {
   WriteArrayList(f, "g_MapPoolList", g_MapPoolList);
   WriteArrayList(f, "g_MapsToPlay", g_MapsToPlay);
   WriteArrayList(f, "g_MapsLeftInVetoPool", g_MapsLeftInVetoPool);
-  // TODO: write g_MapSides (it's not a string so WriteArrayList doesn't work).
-
+  f.WriteLine("Defined map sides:");
+  for (int i = 0; i < g_MapSides.Length; i++) {
+    SideChoice c = g_MapSides.Get(i);
+    if (c == SideChoice_Team1CT) {
+      f.WriteLine("g_MapSides(%d) = team1_ct", i);
+    } else if (c == SideChoice_Team1T) {
+      f.WriteLine("g_MapSides(%d) = team1_t", i);
+    } else {
+      f.WriteLine("g_MapSides(%d) = knife", i);
+    }
+  }
   f.WriteLine("g_MatchTitle = %s", g_MatchTitle);
   f.WriteLine("g_PlayersPerTeam = %d", g_PlayersPerTeam);
   f.WriteLine("g_CoachesPerTeam = %d", g_CoachesPerTeam);

--- a/scripting/get5/debug.sp
+++ b/scripting/get5/debug.sp
@@ -111,7 +111,6 @@ static void AddGlobalStateInfo(File f) {
   f.WriteLine("g_InScrimMode = %d", g_InScrimMode);
   f.WriteLine("g_SeriesCanClinch = %d", g_SeriesCanClinch);
   f.WriteLine("g_HasKnifeRoundStarted = %d", g_HasKnifeRoundStarted);
-  f.WriteLine("g_AssignTeamNonePlayersOnRoundStart = %d", g_AssignTeamNonePlayersOnRoundStart);
 
   f.WriteLine("g_MapChangePending = %d", g_MapChangePending);
   f.WriteLine("g_PendingSideSwap = %d", g_PendingSideSwap);

--- a/scripting/get5/debug.sp
+++ b/scripting/get5/debug.sp
@@ -94,7 +94,6 @@ static void AddGlobalStateInfo(File f) {
   f.WriteLine("g_MatchID = %s", g_MatchID);
   f.WriteLine("g_RoundNumber = %d", g_RoundNumber);
   f.WriteLine("g_MapsToWin = %d", g_MapsToWin);
-  f.WriteLine("g_BO2Match = %d", g_BO2Match);
   f.WriteLine("g_LastVetoTeam = %d", g_LastVetoTeam);
   WriteArrayList(f, "g_MapPoolList", g_MapPoolList);
   WriteArrayList(f, "g_MapsToPlay", g_MapsToPlay);

--- a/scripting/get5/debug.sp
+++ b/scripting/get5/debug.sp
@@ -111,6 +111,7 @@ static void AddGlobalStateInfo(File f) {
   f.WriteLine("g_InScrimMode = %d", g_InScrimMode);
   f.WriteLine("g_SeriesCanClinch = %d", g_SeriesCanClinch);
   f.WriteLine("g_HasKnifeRoundStarted = %d", g_HasKnifeRoundStarted);
+  f.WriteLine("g_AssignUnTeamedPlayersOnRoundStart = %d", g_AssignUnTeamedPlayersOnRoundStart);
 
   f.WriteLine("g_MapChangePending = %d", g_MapChangePending);
   f.WriteLine("g_PendingSideSwap = %d", g_PendingSideSwap);

--- a/scripting/get5/debug.sp
+++ b/scripting/get5/debug.sp
@@ -111,7 +111,7 @@ static void AddGlobalStateInfo(File f) {
   f.WriteLine("g_InScrimMode = %d", g_InScrimMode);
   f.WriteLine("g_SeriesCanClinch = %d", g_SeriesCanClinch);
   f.WriteLine("g_HasKnifeRoundStarted = %d", g_HasKnifeRoundStarted);
-  f.WriteLine("g_AssignUnTeamedPlayersOnRoundStart = %d", g_AssignUnTeamedPlayersOnRoundStart);
+  f.WriteLine("g_AssignTeamNonePlayersOnRoundStart = %d", g_AssignTeamNonePlayersOnRoundStart);
 
   f.WriteLine("g_MapChangePending = %d", g_MapChangePending);
   f.WriteLine("g_PendingSideSwap = %d", g_PendingSideSwap);

--- a/scripting/get5/goinglive.sp
+++ b/scripting/get5/goinglive.sp
@@ -32,7 +32,7 @@ public Action Timer_GoToLiveAfterWarmupCountdown(Handle timer) {
   }
   Get5_MessageToAll("%t", "MatchBeginInSecondsInfoMessage", countdown);
   StartWarmup(countdown);
-  LogDebug("Started warmup countdown to live in %s seconds.", countdown);
+  LogDebug("Started warmup countdown to live in %d seconds.", countdown);
   return Plugin_Handled;
 }
 

--- a/scripting/get5/goinglive.sp
+++ b/scripting/get5/goinglive.sp
@@ -49,17 +49,15 @@ public Action MatchLive(Handle timer) {
 
   AnnouncePhaseChange("%t", "MatchIsLiveInfoMessage");
 
-  if (!g_PrintUpdateNoticeCvar.BoolValue) {
-    return Plugin_Handled;
-  }
-
-  if (g_RunningPrereleaseVersion) {
-    char conVarName[64];
-    g_PrintUpdateNoticeCvar.GetName(conVarName, sizeof(conVarName));
-    FormatCvarName(conVarName, sizeof(conVarName), conVarName);
-    Get5_MessageToAll("%t", "PrereleaseVersionWarning", PLUGIN_VERSION, conVarName);
-  } else if (g_NewerVersionAvailable) {
-    Get5_MessageToAll("%t", "NewVersionAvailable", GET5_GITHUB_PAGE);
+  if (g_PrintUpdateNoticeCvar.BoolValue) {
+    if (g_RunningPrereleaseVersion) {
+      char conVarName[64];
+      g_PrintUpdateNoticeCvar.GetName(conVarName, sizeof(conVarName));
+      FormatCvarName(conVarName, sizeof(conVarName), conVarName);
+      Get5_MessageToAll("%t", "PrereleaseVersionWarning", PLUGIN_VERSION, conVarName);
+    } else if (g_NewerVersionAvailable) {
+      Get5_MessageToAll("%t", "NewVersionAvailable", GET5_GITHUB_PAGE);
+    }
   }
 
   /**

--- a/scripting/get5/goinglive.sp
+++ b/scripting/get5/goinglive.sp
@@ -56,6 +56,7 @@ public Action MatchLive(Handle timer) {
   if (g_RunningPrereleaseVersion) {
     char conVarName[64];
     g_PrintUpdateNoticeCvar.GetName(conVarName, sizeof(conVarName));
+    FormatCvarName(conVarName, sizeof(conVarName), conVarName);
     Get5_MessageToAll("%t", "PrereleaseVersionWarning", PLUGIN_VERSION, conVarName);
   } else if (g_NewerVersionAvailable) {
     Get5_MessageToAll("%t", "NewVersionAvailable", GET5_GITHUB_PAGE);

--- a/scripting/get5/kniferounds.sp
+++ b/scripting/get5/kniferounds.sp
@@ -42,14 +42,12 @@ static void PerformSideSwap(bool swap) {
 
     LOOP_CLIENTS(i) {
       if (IsValidClient(i)) {
-        int team = GetClientTeam(i);
-        if (team == CS_TEAM_T) {
-          SwitchPlayerTeam(i, CS_TEAM_CT);
-        } else if (team == CS_TEAM_CT) {
-          SwitchPlayerTeam(i, CS_TEAM_T);
-        } else if (IsClientCoaching(i)) {
-          int correctTeam = Get5TeamToCSTeam(GetClientMatchTeam(i));
-          UpdateCoachTarget(i, correctTeam);
+        if (IsFakeClient(i)) {
+          // Because bots never have an assigned team, they won't be moved around by CheckClientTeam. We kick them to
+          // prevent one team from having too many players. They will rejoin if defined in the live config.
+          KickClient(i);
+        } else {
+          CheckClientTeam(i);
         }
       }
     }

--- a/scripting/get5/kniferounds.sp
+++ b/scripting/get5/kniferounds.sp
@@ -47,7 +47,7 @@ static void PerformSideSwap(bool swap) {
           // prevent one team from having too many players. They will rejoin if defined in the live config.
           KickClient(i);
         } else {
-          CheckClientTeam(i);
+          CheckClientTeam(i, false);
         }
       }
     }

--- a/scripting/get5/kniferounds.sp
+++ b/scripting/get5/kniferounds.sp
@@ -1,6 +1,5 @@
 public Action StartKnifeRound(Handle timer) {
   g_HasKnifeRoundStarted = false;
-  g_PendingSideSwap = false;
 
   // Removes ready tags
   SetMatchTeamCvars();
@@ -81,13 +80,14 @@ public void EndKnifeRound(bool swap) {
   Call_PushCell(knifeEvent);
   Call_Finish();
 
+  if (g_KnifeDecisionTimer != INVALID_HANDLE) {
+    LogDebug("Stopped knife decision timer as a choice was made before it expired.");
+    delete g_KnifeDecisionTimer;
+  }
+
   EventLogger_LogAndDeleteEvent(knifeEvent);
-
-  ChangeState(Get5State_GoingLive);
-  CreateTimer(3.0, StartGoingLive, _, TIMER_FLAG_NO_MAPCHANGE);
-
   g_KnifeWinnerTeam = Get5Team_None;
-  EnsureIndefiniteWarmup();
+  StartGoingLive();
 }
 
 static bool AwaitingKnifeDecision(int client) {

--- a/scripting/get5/kniferounds.sp
+++ b/scripting/get5/kniferounds.sp
@@ -40,12 +40,12 @@ static void PerformSideSwap(bool swap) {
     g_TeamSide[Get5Team_1] = tmp;
 
     LOOP_CLIENTS(i) {
-      if (IsValidClient(i)) {
+      if (IsValidClient(i) && !IsClientSourceTV(i)) {
         if (IsFakeClient(i)) {
           // Because bots never have an assigned team, they won't be moved around by CheckClientTeam. We kick them to
           // prevent one team from having too many players. They will rejoin if defined in the live config.
           KickClient(i);
-        } else if (!IsClientSourceTV(i)) {
+        } else {
           CheckClientTeam(i, false);
         }
       }

--- a/scripting/get5/kniferounds.sp
+++ b/scripting/get5/kniferounds.sp
@@ -45,7 +45,7 @@ static void PerformSideSwap(bool swap) {
           // Because bots never have an assigned team, they won't be moved around by CheckClientTeam. We kick them to
           // prevent one team from having too many players. They will rejoin if defined in the live config.
           KickClient(i);
-        } else {
+        } else if (!IsClientSourceTV(i)) {
           CheckClientTeam(i, false);
         }
       }

--- a/scripting/get5/mapveto.sp
+++ b/scripting/get5/mapveto.sp
@@ -82,7 +82,7 @@ public void VetoController(int client) {
   }
 
   int mapsLeft = g_MapsLeftInVetoPool.Length;
-  int maxMaps = MaxMapsToPlay(g_MapsToWin);
+  int maxMaps = g_NumberOfMapsInSeries;
 
   int mapsPicked = g_MapsToPlay.Length;
   int sidesSet = g_MapSides.Length;
@@ -110,7 +110,7 @@ public void VetoController(int client) {
   // The purpose is to force the veto process to take a
   // ban/ban/ban/ban/pick/pick/last map unused process for BO2's.
   bool bo2_hack = false;
-  if (g_BO2Match && (mapsLeft == 3 || mapsLeft == 2)) {
+  if (g_NumberOfMapsInSeries == 2 && (mapsLeft == 3 || mapsLeft == 2)) {
     bo2_hack = true;
   }
 
@@ -157,7 +157,7 @@ public void VetoController(int client) {
     VetoFinished();
 
   } else if (mapsLeft == 1) {
-    if (g_BO2Match) {
+    if (g_NumberOfMapsInSeries == 2) {
       // Terminate the veto since we've had ban-ban-ban-ban-pick-pick
       VetoFinished();
       return;

--- a/scripting/get5/matchconfig.sp
+++ b/scripting/get5/matchconfig.sp
@@ -590,8 +590,7 @@ static void LoadTeamDataJson(JSON_Object json, Get5Team matchTeam) {
       LogError("Cannot load team config from file \"%s\", fromfile");
     } else {
       LoadTeamDataJson(fromfileJson, matchTeam);
-      fromfileJson.Cleanup();
-      delete fromfileJson;
+      json_cleanup_and_delete(fromfileJson);
     }
   }
 

--- a/scripting/get5/matchconfig.sp
+++ b/scripting/get5/matchconfig.sp
@@ -63,12 +63,6 @@ stock bool LoadMatchConfig(const char[] config, bool restoreBackup = false) {
     return false;
   }
 
-  if (!g_CheckAuthsCvar.BoolValue &&
-      (GetTeamAuths(Get5Team_1).Length != 0 || GetTeamAuths(Get5Team_2).Length != 0)) {
-    LogError(
-        "Setting player auths in the \"players\" section has no impact with get5_check_auths 0");
-  }
-
   // Copy all the maps into the veto pool.
   char mapName[PLATFORM_MAX_PATH];
   for (int i = 0; i < g_MapPoolList.Length; i++) {
@@ -150,6 +144,14 @@ stock bool LoadMatchConfig(const char[] config, bool restoreBackup = false) {
     Call_Finish();
 
     EventLogger_LogAndDeleteEvent(startEvent);
+
+    if (!g_CheckAuthsCvar.BoolValue &&
+        (GetTeamAuths(Get5Team_1).Length != 0
+        || GetTeamAuths(Get5Team_2).Length != 0
+        || GetTeamCoaches(Get5Team_1).Length != 0
+        || GetTeamCoaches(Get5Team_2).Length != 0)) {
+      LogError("Setting player auths in the \"players\" or \"coaches\" section has no impact with get5_check_auths 0");
+    }
   }
 
   AddTeamLogosToDownloadTable();

--- a/scripting/get5/matchconfig.sp
+++ b/scripting/get5/matchconfig.sp
@@ -151,7 +151,7 @@ bool LoadMatchConfig(const char[] config, bool restoreBackup = false) {
     // When restoring from backup, assigning to teams is done after loading the match config as it depends on the sides
     // being set correctly by the backup, so we put it inside this "if" here.
     LOOP_CLIENTS(i) {
-      if (IsAuthedPlayer(i) && !IsClientSourceTV(i)) {
+      if (IsPlayer(i)) {
         CheckClientTeam(i);
       }
     }

--- a/scripting/get5/stats.sp
+++ b/scripting/get5/stats.sp
@@ -166,7 +166,7 @@ public void Stats_Reset() {
 public void Stats_InitSeries() {
   Stats_Reset();
   char seriesType[32];
-  Format(seriesType, sizeof(seriesType), "bo%d", MaxMapsToPlay(g_MapsToWin));
+  Format(seriesType, sizeof(seriesType), "bo%d", g_NumberOfMapsInSeries);
   g_StatsKv.SetString(STAT_SERIESTYPE, seriesType);
   g_StatsKv.SetString(STAT_SERIES_TEAM1NAME, g_TeamNames[Get5Team_1]);
   g_StatsKv.SetString(STAT_SERIES_TEAM2NAME, g_TeamNames[Get5Team_2]);

--- a/scripting/get5/teamlogic.sp
+++ b/scripting/get5/teamlogic.sp
@@ -13,7 +13,7 @@ public Action Timer_PlacePlayerOnJoin(Handle timer, int userId) {
 }
 
 void CheckClientTeam(int client, bool useDefaultTeamSelection = true) {
-  if (!g_CheckAuthsCvar.BoolValue || IsFakeClient(client) || IsClientSourceTV(client)) {
+  if (!g_CheckAuthsCvar.BoolValue || IsFakeClient(client)) {
     // Teams are not enforced; do nothing.
     return;
   }
@@ -115,7 +115,7 @@ public void CoachingChangedHook(ConVar convar, const char[] oldValue, const char
   if (StringToInt(oldValue) != 0 && !convar.BoolValue) {
     LogDebug("Detected sv_coaching_enabled was disabled. Checking for coaches.");
     LOOP_CLIENTS(i) {
-      if (IsAuthedPlayer(i) && IsClientCoaching(i)) {
+      if (IsPlayer(i) && IsClientCoaching(i)) {
         CheckClientTeam(i);
       }
     }

--- a/scripting/get5/teamlogic.sp
+++ b/scripting/get5/teamlogic.sp
@@ -13,7 +13,7 @@ public Action Timer_PlacePlayerOnJoin(Handle timer, int userId) {
 }
 
 void CheckClientTeam(int client, bool useDefaultTeamSelection = true) {
-  if (!g_CheckAuthsCvar.BoolValue) {
+  if (!g_CheckAuthsCvar.BoolValue || IsFakeClient(client) || IsClientSourceTV(client)) {
     // Teams are not enforced; do nothing.
     return;
   }
@@ -69,7 +69,6 @@ void CheckClientTeam(int client, bool useDefaultTeamSelection = true) {
 static void PlacePlayerOnTeam(int client) {
   if (g_PendingSideSwap || InHalftimePhase()) {
     LogDebug("Blocking attempt to join a team due to halftime or pending team swap.");
-    g_AssignTeamNonePlayersOnRoundStart = true;
     return;
   }
   CheckClientTeam(client);
@@ -266,10 +265,6 @@ Get5Team CSTeamToGet5Team(int csTeam) {
 }
 
 Get5Team GetAuthMatchTeam(const char[] steam64) {
-  if (g_GameState == Get5State_None) {
-    return Get5Team_None;
-  }
-
   if (g_InScrimMode) {
     return IsAuthOnTeam(steam64, Get5Team_1) ? Get5Team_1 : Get5Team_2;
   }

--- a/scripting/get5/teamlogic.sp
+++ b/scripting/get5/teamlogic.sp
@@ -129,7 +129,9 @@ public Action Command_SmCoach(int client, int args) {
   }
 
   if (!g_CoachingEnabledCvar.BoolValue) {
-    Get5_Message(client, "%t", "CoachingNotEnabled", "sv_coaching_enabled");
+    char formattedCoachingCvar[64];
+    FormatCvarName(formattedCoachingCvar, sizeof(formattedCoachingCvar), "sv_coaching_enabled");
+    Get5_Message(client, "%t", "CoachingNotEnabled", formattedCoachingCvar);
     return Plugin_Continue;
   }
 

--- a/scripting/get5/teamlogic.sp
+++ b/scripting/get5/teamlogic.sp
@@ -1,11 +1,5 @@
 public Action Command_JoinGame(int client, const char[] command, int argc) {
-  if (g_GameState != Get5State_None && g_CheckAuthsCvar.BoolValue && IsPlayer(client) &&
-      !g_PendingSideSwap) {
-    // In order to avoid duplication of team-join logic, we directly call the same handle that would
-    // be called if the user selected any team after joining. Since Command_JoinTeam handles the
-    // actual joining using a FakeClientCommand, we don't have to do any team-logic here and it
-    // won't matter what we pass to Command_JoinTeam. The only thing that's important is that the
-    // command argument is empty, as that avoids a call to GetCmdArg in that function.
+  if (g_GameState != Get5State_None && g_CheckAuthsCvar.BoolValue && IsPlayer(client)) {
     CreateTimer(0.1, Timer_PlacePlayerOnJoin, GetClientUserId(client), TIMER_FLAG_NO_MAPCHANGE);
   }
   return Plugin_Continue;
@@ -14,217 +8,173 @@ public Action Command_JoinGame(int client, const char[] command, int argc) {
 public Action Timer_PlacePlayerOnJoin(Handle timer, int userId) {
   int client = GetClientOfUserId(userId);
   if (client) {  // Client might have disconnected between timer and callback.
-    Command_JoinTeam(client, "", 1);
+    PlacePlayerOnTeam(client);
   }
 }
 
 public void CheckClientTeam(int client) {
   Get5Team correctTeam = GetClientMatchTeam(client);
-  int csTeam = Get5TeamToCSTeam(correctTeam);
-  int currentTeam = GetClientTeam(client);
-
-  if (!CheckIfClientCoachingAndMoveToCoach(client, correctTeam) && csTeam != currentTeam) {
-    SwitchPlayerTeam(client, csTeam);
+  if (correctTeam == Get5Team_None) {
+    RememberAndKickClient(client, "%t", "YouAreNotAPlayerInfoMessage");
+    return;
   }
+
+  Get5Side correctSide = view_as<Get5Side>(Get5TeamToCSTeam(correctTeam));
+
+  if (correctSide == Get5Side_None) {
+    // This should not be possible.
+    LogError("Client %d belongs to no side. This is an unexpected error and should be reported.", client);
+    return;
+  }
+
+  int coachesOnTeam = CountCoachesOnTeam(correctTeam, client);
+  // If the player is fixed to coaching, always ensure they end there and on the correct side.
+  if (g_CoachingEnabledCvar.BoolValue && IsClientCoachForTeam(client, correctTeam)) {
+    if (GetClientCoachingSide(client) == correctSide) {
+      // Player is already coaching the correct team and is on spectator; do nothing.
+      return;
+    }
+    // If there are free coach spots on the team, send the player there
+    if (coachesOnTeam < g_CoachesPerTeam) {
+      SetClientCoaching(client, correctSide);
+    } else {
+      KickClient(client, "%t", "TeamIsFullInfoMessage");
+    }
+    return;
+  }
+
+  // If player was not locked to coaching, check if their team's current size -self is less than the max.
+  if (CountPlayersOnTeam(correctTeam, client) < g_PlayersPerTeam) {
+    SwitchPlayerTeam(client, view_as<int>(correctSide));
+    return;
+  }
+
+  // We end here if a player was not a predefined coach while there was no space. If coaching is enabled, we drop
+  // the player in there, and if not, they must be kicked.
+  if (g_CoachingEnabledCvar.BoolValue && coachesOnTeam < g_CoachesPerTeam) {
+    Get5_Message(client, "%t", "MoveToCoachInfoMessage");
+    // In scrim mode, we don't put coaches or players of the "away" team into any auth arrays; they default to the
+    // opposite of the home team. If a full team's coach disconnects or leaves, they should be placed on the coach
+    // team if their team is full. In a regular match, they will have called .coach before the map starts and will
+    // be placed by auth.
+    if (!g_InScrimMode) {
+      MovePlayerToCoachInConfig(client, correctTeam);
+    }
+    SetClientCoaching(client, correctSide);
+    return;
+  }
+
+  KickClient(client, "%t", "TeamIsFullInfoMessage");
+}
+
+static void PlacePlayerOnTeam(int client) {
+  if (g_PendingSideSwap || InHalftimePhase()) {
+    LogDebug("Blocking attempt to join a team due to halftime or pending team swap.");
+    g_AssignUnTeamedPlayersOnRoundStart = true;
+    return;
+  }
+  CheckClientTeam(client);
 }
 
 public Action Command_JoinTeam(int client, const char[] command, int argc) {
-  if (!IsAuthedPlayer(client) || argc < 1)
-    return Plugin_Stop;
-
-  // Don't do anything if not live/not in startup phase.
-  if (g_GameState == Get5State_None) {
+  if (g_GameState == Get5State_None || !g_CheckAuthsCvar.BoolValue) {
     return Plugin_Continue;
   }
-
-  // Don't enforce team joins.
-  if (!g_CheckAuthsCvar.BoolValue) {
-    return Plugin_Continue;
-  }
-
-  if (g_PendingSideSwap) {
-    LogDebug("Blocking teamjoin due to pending swap");
+  if (!IsAuthedPlayer(client) || argc < 1) {
+    LogDebug("Preventing unauthorized/no argument client %d from joining a team.", client);
     return Plugin_Stop;
   }
-
-  Get5Team correctTeam = GetClientMatchTeam(client);
-  int csTeam = Get5TeamToCSTeam(correctTeam);
-
-  // This is required as it avoids an exception due to calling this function
-  // from Timer_PlacePlayerOnJoin, which gets called from Command_JoinGame.
-  if (!StrEqual("", command)) {
-    char arg[4];
-    int team_to;
-    GetCmdArg(1, arg, sizeof(arg));
-    team_to = StringToInt(arg);
-
-    LogDebug("%L jointeam command, from %d to %d", client, GetClientTeam(client), team_to);
-
-    // don't let someone change to a "none" team (e.g. using auto-select)
-    if (team_to == CS_TEAM_NONE) {
-      return Plugin_Stop;
-    }
-
-    if (csTeam == team_to) {
-      if (CheckIfClientCoachingAndMoveToCoach(client, correctTeam)) {
-        return Plugin_Stop;
-      } else {
-        return Plugin_Continue;
-      }
-    }
+  char arg[4];
+  GetCmdArg(1, arg, sizeof(arg));
+  int team_to = StringToInt(arg);
+  // Ensure team_to argument can be safely converted to Get5Side. Users *could* type "jointeam 4434" if they wanted.
+  if (team_to == CS_TEAM_T || team_to == CS_TEAM_CT || team_to == CS_TEAM_SPECTATOR) {
+    PlacePlayerOnTeam(client);
   }
-
-  LogDebug("jointeam, gamephase = %d", GetGamePhase());
-
-  if (csTeam != GetClientTeam(client)) {
-    int count = CountPlayersOnCSTeam(csTeam);
-
-    if (count >= g_PlayersPerTeam) {
-      if (!g_CoachingEnabledCvar.BoolValue) {
-        KickClient(client, "%t", "TeamIsFullInfoMessage");
-      } else {
-        // Only attempt to move to coach if we are not full on coaches already.
-        if (GetTeamCoaches(correctTeam).Length <= g_CoachesPerTeam) {
-          char auth[AUTH_LENGTH];
-          LogDebug("Forcing player %N to coach", client);
-          GetAuth(client, auth, sizeof(auth));
-          // Only output MoveToCoachInfoMessage if we are not
-          // in the coach array already.
-          if (!IsAuthOnTeamCoach(auth, correctTeam)) {
-            Get5_Message(client, "%t", "MoveToCoachInfoMessage");
-          }
-          MoveClientToCoach(client);
-        } else {
-          KickClient(client, "%t", "TeamIsFullInfoMessage");
-        }
-      }
-    } else if (!CheckIfClientCoachingAndMoveToCoach(client, correctTeam)) {
-      LogDebug("Forcing player %N onto %d", client, csTeam);
-      FakeClientCommand(client, "jointeam %d", csTeam);
-    }
-  }
-
   return Plugin_Stop;
 }
 
-public bool CheckIfClientCoachingAndMoveToCoach(int client, Get5Team team) {
-  if (!g_CoachingEnabledCvar.BoolValue) {
-    return false;
-  }
-  // Force user to join the coach if specified by config or reconnect.
+static bool IsClientCoachForTeam(int client, Get5Team team) {
   char clientAuth64[AUTH_LENGTH];
-  GetAuth(client, clientAuth64, AUTH_LENGTH);
-  if (IsAuthOnTeamCoach(clientAuth64, team)) {
-    MoveClientToCoach(client);
-    return true;
-  }
-  return false;
+  return GetAuth(client, clientAuth64, AUTH_LENGTH) && IsAuthOnTeamCoach(clientAuth64, team);
 }
 
-public void MoveClientToCoach(int client) {
-  LogDebug("MoveClientToCoach %L", client);
-  Get5Team matchTeam = GetClientMatchTeam(client);
-  if (matchTeam != Get5Team_1 && matchTeam != Get5Team_2) {
-    return;
-  }
-
-  if (!g_CoachingEnabledCvar.BoolValue) {
-    return;
-  }
-
-  int csTeam = Get5TeamToCSTeam(matchTeam);
-
-  if (g_PendingSideSwap) {
-    LogDebug("Blocking coach move due to pending swap");
-    return;
-  }
-
-  char teamString[4];
-  char clientAuth[64];
-  CSTeamString(csTeam, teamString, sizeof(teamString));
-  GetAuth(client, clientAuth, AUTH_LENGTH);
-  if (!IsAuthOnTeamCoach(clientAuth, matchTeam)) {
-    AddCoachToTeam(clientAuth, matchTeam, "");
-    // If we're already on the team, make sure we remove ourselves
-    // to ensure data is correct in the backups.
-    int index = GetTeamAuths(matchTeam).FindString(clientAuth);
-    if (index >= 0) {
-      GetTeamAuths(matchTeam).Erase(index);
-    }
-  }
-
-  // If we're in warmup we use the in-game
-  // coaching command. Otherwise we manually move them to spec
-  // and set the coaching target.
-  // If in freeze time, we have to manually move as well.
-  if (InWarmup()) {
-    LogDebug("Moving %L indirectly to coach slot via coach cmd", client);
-    g_MovingClientToCoach[client] = true;
-    FakeClientCommand(client, "coach %s", teamString);
-    g_MovingClientToCoach[client] = false;
-  } else {
-    LogDebug("Moving %L directly to coach slot", client);
-    SwitchPlayerTeam(client, CS_TEAM_SPECTATOR);
-    UpdateCoachTarget(client, csTeam);
-    // Need to set to avoid third person view bug.
-    SetEntProp(client, Prop_Send, "m_iObserverMode", 4);
-  }
+void SetClientCoaching(int client, Get5Side side) {
+  LogDebug("Setting client %d as spectator and coach for side %d.", client, side);
+  SwitchPlayerTeam(client, CS_TEAM_SPECTATOR);
+  SetEntProp(client, Prop_Send, "m_iCoachingTeam", side);
+  SetEntProp(client, Prop_Send, "m_iObserverMode", 4);
+  SetEntProp(client, Prop_Send, "m_iAccount", 0); // Ensures coaches have no money if they were to rejoin the game.
 }
 
 public Action Command_SmCoach(int client, int args) {
-  char auth[AUTH_LENGTH];
   if (g_GameState == Get5State_None) {
     return Plugin_Continue;
   }
 
   if (!g_CoachingEnabledCvar.BoolValue) {
-    return Plugin_Handled;
+    Get5_Message(client, "%t", "CoachingNotEnabled", "sv_coaching_enabled");
+    return Plugin_Continue;
   }
 
-  GetAuth(client, auth, sizeof(auth));
   Get5Team matchTeam = GetClientMatchTeam(client);
-  // Don't allow a new coach if spots are full.
-  if (GetTeamCoaches(matchTeam).Length > g_CoachesPerTeam) {
-    return Plugin_Stop;
+
+  if (matchTeam == Get5Team_None) {
+    return Plugin_Continue;
   }
 
-  MoveClientToCoach(client);
-  // Update the backup structure as well for round restores, covers edge
-  // case of users joining, coaching, stopping, and getting 16k cash as player.
-  WriteBackup();
-  return Plugin_Handled;
+  Get5Side currentlyCoaching = GetClientCoachingSide(client);
+  Get5Side side = view_as<Get5Side>(Get5TeamToCSTeam(matchTeam));
+
+  if (currentlyCoaching == side) {
+    // Already coaching for the right side.
+    return Plugin_Continue;
+  }
+
+  if (g_PendingSideSwap || InHalftimePhase() || (!InFreezeTime() && !InWarmup())) {
+    Get5_Message(client, "%t", "CanOnlyCoachDuringFreezetimeOrWarmup");
+    return Plugin_Continue;
+  }
+
+  // Don't allow a new coach if spots are full.
+  if (CountCoachesOnTeam(matchTeam, client) >= g_CoachesPerTeam) {
+    Get5_Message(client, "%t", "AllCoachSlotsFilledForTeam", g_CoachesPerTeam);
+    return Plugin_Continue;
+  }
+
+  if (!g_InScrimMode) {
+    // If we're in scrim mode, we don't update the coaches auth array ever.
+    MovePlayerToCoachInConfig(client, matchTeam);
+  }
+
+  // Actually move the player to coach + spec
+  SetClientCoaching(client, side);
+  return Plugin_Continue;
+}
+
+static void MovePlayerToCoachInConfig(const int client, const Get5Team team) {
+  char auth[AUTH_LENGTH];
+  GetAuth(client, auth, sizeof(auth));
+  if (AddCoachToTeam(auth, team, "")) {
+    // If we're already on the team, make sure we remove ourselves
+    // to ensure data is correct in the backups.
+    int index = GetTeamAuths(team).FindString(auth);
+    if (index >= 0) {
+      LogDebug("Removing client %d from regular team auth array for team %d", client, team);
+      GetTeamAuths(team).Erase(index);
+    }
+  }
 }
 
 public Action Command_Coach(int client, const char[] command, int argc) {
   if (g_GameState == Get5State_None) {
     return Plugin_Continue;
   }
-
-  if (!g_CoachingEnabledCvar.BoolValue) {
-    return Plugin_Handled;
-  }
-
-  if (!IsAuthedPlayer(client)) {
-    return Plugin_Stop;
-  }
-
-  if (InHalftimePhase()) {
-    return Plugin_Stop;
-  }
-
-  if (g_MovingClientToCoach[client] || !g_CheckAuthsCvar.BoolValue) {
-    LogDebug("Command_Coach: %L, letting pass-through", client);
-    return Plugin_Continue;
-  }
-
-  MoveClientToCoach(client);
-  // Update the backup structure as well for round restores, covers edge
-  // case of users joining, coaching, stopping, and getting 16k cash as player.
-  WriteBackup();
+  ReplyToCommand(client, "Please use .coach in chat or sm_coach instead of the built-in console coach command.");
   return Plugin_Stop;
 }
 
-public Get5Team GetClientMatchTeam(int client) {
+Get5Team GetClientMatchTeam(int client) {
   if (!g_CheckAuthsCvar.BoolValue) {
     return CSTeamToGet5Team(GetClientTeam(client));
   } else {
@@ -232,7 +182,7 @@ public Get5Team GetClientMatchTeam(int client) {
     if (GetAuth(client, auth, sizeof(auth))) {
       Get5Team playerTeam = GetAuthMatchTeam(auth);
       if (playerTeam == Get5Team_None) {
-        playerTeam = GetAuthMatchTeamCoach(auth);
+        playerTeam = GetAuthMatchCoachTeam(auth);
       }
       return playerTeam;
     } else {
@@ -241,7 +191,7 @@ public Get5Team GetClientMatchTeam(int client) {
   }
 }
 
-public int Get5TeamToCSTeam(Get5Team t) {
+int Get5TeamToCSTeam(Get5Team t) {
   if (t == Get5Team_1) {
     return g_TeamSide[Get5Team_1];
   } else if (t == Get5Team_2) {
@@ -253,7 +203,7 @@ public int Get5TeamToCSTeam(Get5Team t) {
   }
 }
 
-public Get5Team CSTeamToGet5Team(int csTeam) {
+Get5Team CSTeamToGet5Team(int csTeam) {
   if (csTeam == g_TeamSide[Get5Team_1]) {
     return Get5Team_1;
   } else if (csTeam == g_TeamSide[Get5Team_2]) {
@@ -265,7 +215,7 @@ public Get5Team CSTeamToGet5Team(int csTeam) {
   }
 }
 
-public Get5Team GetAuthMatchTeam(const char[] steam64) {
+Get5Team GetAuthMatchTeam(const char[] steam64) {
   if (g_GameState == Get5State_None) {
     return Get5Team_None;
   }
@@ -283,7 +233,7 @@ public Get5Team GetAuthMatchTeam(const char[] steam64) {
   return Get5Team_None;
 }
 
-public Get5Team GetAuthMatchTeamCoach(const char[] steam64) {
+Get5Team GetAuthMatchCoachTeam(const char[] steam64) {
   if (g_GameState == Get5State_None) {
     return Get5Team_None;
   }
@@ -301,38 +251,42 @@ public Get5Team GetAuthMatchTeamCoach(const char[] steam64) {
   return Get5Team_None;
 }
 
-stock int CountPlayersOnCSTeam(int team, int exclude = -1) {
+int CountCoachesOnTeam(Get5Team team, int exclude = -1) {
   int count = 0;
+  Get5Side side = view_as<Get5Side>(Get5TeamToCSTeam(team));
   LOOP_CLIENTS(i) {
-    if (i != exclude && IsAuthedPlayer(i) && GetClientTeam(i) == team) {
+    if (i != exclude && IsAuthedPlayer(i) && GetClientMatchTeam(i) == team && GetClientCoachingSide(i) == side) {
       count++;
     }
   }
   return count;
 }
 
-stock int CountPlayersOnMatchTeam(Get5Team team, int exclude = -1) {
+int CountPlayersOnTeam(Get5Team team, int exclude = -1) {
   int count = 0;
+  Get5Side side = view_as<Get5Side>(Get5TeamToCSTeam(team));
   LOOP_CLIENTS(i) {
-    if (i != exclude && IsAuthedPlayer(i) && GetClientMatchTeam(i) == team) {
+    if (i != exclude && IsAuthedPlayer(i) && GetClientMatchTeam(i) == team && view_as<Get5Side>(GetClientTeam(i)) == side) {
       count++;
     }
   }
   return count;
 }
 
-// Returns the match team a client is the captain of, or MatchTeam_None.
-public Get5Team GetCaptainTeam(int client) {
-  if (client == GetTeamCaptain(Get5Team_1)) {
-    return Get5Team_1;
-  } else if (client == GetTeamCaptain(Get5Team_2)) {
-    return Get5Team_2;
-  } else {
-    return Get5Team_None;
+Get5Side GetClientCoachingSide(int client) {
+  if (GetClientTeam(client) != CS_TEAM_SPECTATOR) {
+   return Get5Side_None;
   }
+  int side = GetEntProp(client, Prop_Send, "m_iCoachingTeam");
+  if (side == CS_TEAM_CT) {
+    return Get5Side_CT;
+  } else if (side == CS_TEAM_T) {
+    return Get5Side_T;
+  }
+  return Get5Side_None;
 }
 
-public int GetTeamCaptain(Get5Team team) {
+int GetTeamCaptain(Get5Team team) {
   // If not forcing auths, take the 1st client on the team.
   if (!g_CheckAuthsCvar.BoolValue) {
     LOOP_CLIENTS(i) {
@@ -356,7 +310,7 @@ public int GetTeamCaptain(Get5Team team) {
   return -1;
 }
 
-public int GetNextTeamCaptain(int client) {
+int GetNextTeamCaptain(int client) {
   if (client == g_VetoCaptains[Get5Team_1]) {
     return g_VetoCaptains[Get5Team_2];
   } else {
@@ -364,23 +318,23 @@ public int GetNextTeamCaptain(int client) {
   }
 }
 
-public ArrayList GetTeamAuths(Get5Team team) {
+ArrayList GetTeamAuths(Get5Team team) {
   return g_TeamAuths[team];
 }
 
-public ArrayList GetTeamCoaches(Get5Team team) {
+ArrayList GetTeamCoaches(Get5Team team) {
   return g_TeamCoaches[team];
 }
 
-public bool IsAuthOnTeam(const char[] auth, Get5Team team) {
+bool IsAuthOnTeam(const char[] auth, Get5Team team) {
   return GetTeamAuths(team).FindString(auth) >= 0;
 }
 
-public bool IsAuthOnTeamCoach(const char[] auth, Get5Team team) {
+bool IsAuthOnTeamCoach(const char[] auth, Get5Team team) {
   return GetTeamCoaches(team).FindString(auth) >= 0;
 }
 
-public void SetStartingTeams() {
+void SetStartingTeams() {
   int mapNumber = Get5_GetMapNumber();
   if (mapNumber >= g_MapSides.Length || g_MapSides.Get(mapNumber) == SideChoice_KnifeRound) {
     g_TeamSide[Get5Team_1] = TEAM1_STARTING_SIDE;
@@ -399,12 +353,8 @@ public void SetStartingTeams() {
   g_TeamStartingSide[Get5Team_2] = g_TeamSide[Get5Team_2];
 }
 
-public int GetMapScore(int mapNumber, Get5Team team) {
+int GetMapScore(int mapNumber, Get5Team team) {
   return g_TeamScoresPerMap.Get(mapNumber, view_as<int>(team));
-}
-
-public bool HasMapScore(int mapNumber) {
-  return GetMapScore(mapNumber, Get5Team_1) != 0 || GetMapScore(mapNumber, Get5Team_2) != 0;
 }
 
 bool AddPlayerToTeam(const char[] auth, Get5Team team, const char[] name) {
@@ -433,7 +383,7 @@ bool AddCoachToTeam(const char[] auth, Get5Team team, const char[] name) {
     return false;
   }
 
-  if (GetAuthMatchTeamCoach(steam64) == Get5Team_None) {
+  if (GetAuthMatchCoachTeam(steam64) == Get5Team_None) {
     GetTeamCoaches(team).PushString(steam64);
     Get5_SetPlayerName(auth, name);
     return true;
@@ -470,7 +420,7 @@ bool RemovePlayerFromTeams(const char[] auth) {
   return false;
 }
 
-public void LoadPlayerNames() {
+void LoadPlayerNames() {
   KeyValues namesKv = new KeyValues("Names");
   int numNames = 0;
   LOOP_TEAMS(team) {
@@ -510,7 +460,7 @@ public void LoadPlayerNames() {
   delete namesKv;
 }
 
-public void SwapScrimTeamStatus(int client) {
+void SwapScrimTeamStatus(int client) {
   // If we're in any team -> remove from any team list.
   // If we're not in any team -> add to team1.
   char auth[AUTH_LENGTH];
@@ -521,6 +471,6 @@ public void SwapScrimTeamStatus(int client) {
       ConvertAuthToSteam64(auth, steam64);
       GetTeamAuths(Get5Team_1).PushString(steam64);
     }
+    CheckClientTeam(client);
   }
-  CheckClientTeam(client);
 }

--- a/scripting/get5/teamlogic.sp
+++ b/scripting/get5/teamlogic.sp
@@ -492,7 +492,8 @@ void LoadPlayerNames() {
   }
 
   if (numNames > 0) {
-    char nameFile[] = "get5_names.txt";
+    char nameFile[PLATFORM_MAX_PATH];
+    GetTempFilePath(nameFile, sizeof(nameFile), TEMP_VALVE_NAMES_FILE_PATTERN);
     DeleteFile(nameFile);
     if (namesKv.ExportToFile(nameFile)) {
       ServerCommand("sv_load_forced_client_names_file %s", nameFile);

--- a/scripting/get5/tests.sp
+++ b/scripting/get5/tests.sp
@@ -21,11 +21,15 @@ public void Get5_Test() {
 static void Utils_Test() {
   SetTestContext("Utils_Test");
 
-  // MaxMapsToPlay
-  AssertEq("MaxMapsToPlay1", MaxMapsToPlay(1), 1);
-  AssertEq("MaxMapsToPlay2", MaxMapsToPlay(2), 3);
-  AssertEq("MaxMapsToPlay3", MaxMapsToPlay(3), 5);
-  AssertEq("MaxMapsToPlay4", MaxMapsToPlay(4), 7);
+  // MapsToWin
+  AssertEq("MapsToWin1", MapsToWin(1), 1);
+  AssertEq("MapsToWin2", MapsToWin(2), 2);
+  AssertEq("MapsToWin3", MapsToWin(3), 2);
+  AssertEq("MapsToWin4", MapsToWin(4), 3);
+  AssertEq("MapsToWin5", MapsToWin(5), 3);
+  AssertEq("MapsToWin6", MapsToWin(6), 4);
+  AssertEq("MapsToWin7", MapsToWin(7), 4);
+  AssertEq("MapsToWin8", MapsToWin(8), 5);
 
   // ConvertAuthToSteam64
   char input[64] = "STEAM_0:1:52245092";
@@ -71,7 +75,6 @@ static void KV_Test() {
   SetTestContext("KV_Test");
 
   AssertEq("maps_to_win", g_MapsToWin, 2);
-  AssertEq("bo2_series", g_BO2Match, false);
   AssertEq("num_maps", g_NumberOfMapsInSeries, 3);
   AssertEq("skip_veto", g_SkipVeto, false);
   AssertEq("players_per_team", g_PlayersPerTeam, 5);

--- a/scripting/get5/util.sp
+++ b/scripting/get5/util.sp
@@ -176,6 +176,7 @@ stock bool InFreezeTime() {
 
 stock void StartWarmup(int warmupTime = 0) {
   ServerCommand("mp_do_warmup_period 1");
+  ServerCommand("mp_warmuptime_all_players_connected 0");
   if (!InWarmup()) {
     ServerCommand("mp_warmup_start");
   }

--- a/scripting/get5/util.sp
+++ b/scripting/get5/util.sp
@@ -66,22 +66,12 @@ stock int ConvertCSTeamToDefaultWinReason(int side) {
   return view_as<int>(side == CS_TEAM_CT ? CSRoundEnd_CTWin : CSRoundEnd_TerroristWin) + 1;
 }
 
-/**
- * Switches and respawns a player onto a new team.
- */
 stock void SwitchPlayerTeam(int client, int team) {
+  // Check avoids killing player if they're already on the right team.
   if (GetClientTeam(client) == team) {
     return;
   }
-
-  LogDebug("SwitchPlayerTeam %L to %d", client, team);
-  if (team > CS_TEAM_SPECTATOR) {
-    CS_SwitchTeam(client, team);
-    CS_UpdateClientModel(client);
-    CS_RespawnPlayer(client);
-  } else {
-    ChangeClientTeam(client, team);
-  }
+  ChangeClientTeam(client, team);
 }
 
 /**
@@ -208,12 +198,7 @@ stock void RestartGame(int delay) {
 }
 
 stock bool IsClientCoaching(int client) {
-  return GetClientTeam(client) == CS_TEAM_SPECTATOR &&
-         GetEntProp(client, Prop_Send, "m_iCoachingTeam") != 0;
-}
-
-stock void UpdateCoachTarget(int client, int csTeam) {
-  SetEntProp(client, Prop_Send, "m_iCoachingTeam", csTeam);
+  return GetClientCoachingSide(client) != Get5Side_None;
 }
 
 stock void SetTeamInfo(int csTeam, const char[] name, const char[] flag = "",
@@ -699,7 +684,7 @@ stock Get5BombSite GetNearestBombsite(int client) {
   float aDist = GetVectorDistance(aCenter, pos, true);
   float bDist = GetVectorDistance(bCenter, pos, true);
 
-  LogDebug("Bomb planted. Distance to A: %d. Distance to B: %d.", aDist, bDist);
+  LogDebug("Bomb planted. Distance to A: %f. Distance to B: %f.", aDist, bDist);
 
   return (aDist < bDist) ? Get5BombSite_A : Get5BombSite_B;
 }

--- a/scripting/get5/util.sp
+++ b/scripting/get5/util.sp
@@ -497,11 +497,12 @@ stock int AuthToClient(const char[] auth) {
   return -1;
 }
 
-stock int MaxMapsToPlay(int mapsToWin) {
-  if (g_BO2Match)
-    return 2;
-  else
-    return 2 * mapsToWin - 1;
+stock int MapsToWin(int numberOfMaps) {
+  if (numberOfMaps <= 2) {
+    return numberOfMaps;
+  } else {
+    return (numberOfMaps / 2) + 1;
+  }
 }
 
 stock void CSTeamString(int csTeam, char[] buffer, int len) {

--- a/scripting/get5/util.sp
+++ b/scripting/get5/util.sp
@@ -181,7 +181,7 @@ stock void StartWarmup(int warmupTime = 0) {
     ServerCommand("mp_warmup_start");
   }
   if (warmupTime < 1) {
-    LogDebug("Setting indefinite pause.");
+    LogDebug("Setting indefinite warmup.");
     // Setting mp_warmuptime to anything less than 7 triggers the countdown to restart regardless of
     // mp_warmup_pausetimer 1, and this might be tick-related, so we set it to 10 just for good measure.
     ServerCommand("mp_warmuptime 10");

--- a/scripting/get5/util.sp
+++ b/scripting/get5/util.sp
@@ -498,11 +498,8 @@ stock int AuthToClient(const char[] auth) {
 }
 
 stock int MapsToWin(int numberOfMaps) {
-  if (numberOfMaps <= 2) {
-    return numberOfMaps;
-  } else {
-    return (numberOfMaps / 2) + 1;
-  }
+  // This works because integers are rounded down; so 3 / 2 = 1.5, which becomes 1 as integer.
+  return (numberOfMaps / 2) + 1;
 }
 
 stock void CSTeamString(int csTeam, char[] buffer, int len) {

--- a/scripting/get5/util.sp
+++ b/scripting/get5/util.sp
@@ -124,6 +124,10 @@ stock void FormatChatCommand(char[] buffer, const int bufferLength, const char[]
   Format(buffer, bufferLength, "{GREEN}%s{NORMAL}", command);
 }
 
+stock void FormatCvarName(char[] buffer, const int bufferLength, const char[] cVar) {
+  Format(buffer, bufferLength, "{GRAY}%s{NORMAL}", cVar);
+}
+
 stock void FormatPlayerName(char[] buffer, const int bufferLength, const int client, const Get5Side forcedSide = Get5Side_None) {
   // Used when injecting the team for coaching players, who are always on team spectator.
   Get5Side side;

--- a/translations/da/get5.phrases.txt
+++ b/translations/da/get5.phrases.txt
@@ -326,7 +326,27 @@
     }
     "MoveToCoachInfoMessage"
     {
-        "da"            "Da dit hold er fuldt, blev du flyttet til trænerposition."
+        "da"            "Da dit hold er fyldt, blev du flyttet til trænerposition."
+    }
+    "CannotLeaveCoachingTeamIsFull"
+    {
+        "da"            "Du kan ikke forlade trænerpositionen, da dit hold er fyldt."
+    }
+    "CoachingNotEnabled"
+    {
+        "da"            "Trænerindstillingen er ikke aktiveret. {1} skal sættes til 1."
+    }
+    "PlayerIsCoachingTeam"
+    {
+        "da"            "{1} er træner for {2}."
+    }
+    "CanOnlyCoachDuringWarmup"
+    {
+        "da"            "Du kan kun skifte til og fra trænerposition under opvarmning,"
+    }
+    "AllCoachSlotsFilledForTeam"
+    {
+        "da"            "Alle trænerpositioner ({1}) for dit hold er fyldt."
     }
     "ReadyTag"
     {

--- a/translations/get5.phrases.txt
+++ b/translations/get5.phrases.txt
@@ -61,7 +61,7 @@
     }
     "TeamIsFullInfoMessage"
     {
-        "en"            "Your team is full."
+        "en"            "Your team is full"
     }
     "TeamForfeitInfoMessage"
     {
@@ -387,16 +387,25 @@
     }
     "MoveToCoachInfoMessage"
     {
-        "en"            "You were moved to the coach position because your team is full."
+        "en"            "You were moved to the coach position as your team is full."
+    }
+    "CannotLeaveCoachingTeamIsFull"
+    {
+        "en"            "You cannot leave the coach position as your team is full."
     }
     "CoachingNotEnabled"
     {
         "#format"       "{1:s}"
         "en"            "Coaching is not enabled. You must set {1} to 1."
     }
-    "CanOnlyCoachDuringFreezetimeOrWarmup"
+    "PlayerIsCoachingTeam"
     {
-        "en"            "You can only request to coach during warmup or freezetime."
+        "#format"       "{1:s},{2:s}"
+        "en"            "{1} is coaching {2}."
+    }
+    "CanOnlyCoachDuringWarmup"
+    {
+        "en"            "You can only change to or from coach during warmup."
     }
     "AllCoachSlotsFilledForTeam"
     {

--- a/translations/get5.phrases.txt
+++ b/translations/get5.phrases.txt
@@ -389,6 +389,20 @@
     {
         "en"            "You were moved to the coach position because your team is full."
     }
+    "CoachingNotEnabled"
+    {
+        "#format"       "{1:s}"
+        "en"            "Coaching is not enabled. You must set {1} to 1."
+    }
+    "CanOnlyCoachDuringFreezetimeOrWarmup"
+    {
+        "en"            "You can only request to coach during warmup or freezetime."
+    }
+    "AllCoachSlotsFilledForTeam"
+    {
+        "#format"       "{1:d}"
+        "en"            "All coach slots ({1}) are currently filled for your team."
+    }
     "ReadyTag"
     {
         "en"            "[READY]"


### PR DESCRIPTION
As per discussion with @PhlexPlexico, I've spent some time refactoring the logic for handling coaching. Over the years this code had grown increasingly spaghetti, and a lot of time has been spent by contributors and testers to figure out all the kinks of the coaching system. I've applied everything we learned to this PR in attempt to make the code more readable and easier to understand.

Some key points:

1. The `coach` command in console can no longer be used. We simply block it and tell the client to use the `!coach` chat command or `sm_coach` in console. We do this because the built-in coaching mechanisms are hard to work around and cause weird bugs when used in backups. You can only use this command in freezetime and during warmup.
2. You should now **never** set `players_per_team` to more than the number of players you want to actually have playing. In "scrim mode", anyone joining when the team is full will automatically be placed on coach or kicked if there are no more coach slots. If you are coach and not the last to join, simply call `!coach` in chat and you will be moved there. In non-scrim mode - that is, when both teams are provided in a regular match config - anyone in the `coaches` array will *never* be allowed to join the game as anything but a coach. If you are in the regular `players` array and call `!coach`. you will be moved to the coach array and locked there unless removed using `get5_removeplayer`.
3. You can rejoin the game during warmup if you were not supposed to be coaching. Just call `.coach` again. If the team is full, you cannot rejoin the game.
4. If you join the game during halftime, you are now automatically placed on the right team when the following round starts. This applies to both players and coaches and prevents coaches from simply not selecting a team and ghosting.
5. If your `players_per_team` is set to less than the number of players already on a side, and you load the match configuration, the entire team that exceeded the `players_per_team` will be kicked and must rejoin, but this is a caveat I think we can live with.
6. Dedicated documentation added for coaching to explain all this.
7. Added some defensive if-statements when using `get5_addplayer`,  `get5_addkickedplayer` and `get5_addcoach` to prevent these from being executed during backups or halftime.
8. We **only** update the backup on round start, not when adding or removing players or coaches. A backup should be point-in-time and should not be partially modified at a later stage. If you add a coach or player and restore to a game state where this was not done, they should be kicked from the game and the command should be run again. An exception is the native `SetMatchId` which **has** to update the backup as it changes the match ID.

I've tested this pretty extensively with -maV on Discord and found no issues.

Part 2:
1. Refactored the entire team placement logic. It was a bit of a mess, and this was only because coaching was also a mess.
2. Added a "discouraged parameters" section to the configuration file documentation, as we want to prevent users from putting warmup and restarts into their config files.
3. Got rid of `g_BO2Match` and replace its logic with the added `g_NumberOfMapsInSeries` from https://github.com/splewis/get5/pull/856
4. Fixed a **bunch** of problems with backups, such as being on the wrong side if restoring to a different map and a round number after halftime.
5. Merged `OnConfigsExecuted` and `OnMapStart` since they are always called in succession and SourceMod recommends only using `OnConfigsExecuted` if you set/read cvars: https://sm.alliedmods.net/new-api/sourcemod/OnConfigsExecuted
6. Removed a bunch of `stock` and `public` modifiers.
7. Moved `WriteBackup()` call to `RoundStart` instead of `RoundPreStart`, as it allows for the Valve backup to be written for the first round. For some odd reason, the first round Valve backup has not been written to disk when this call is in `RoundPreStart`, leading to weird handling of valve backups if you wanted to restore to round 0.
8. Added a game restart post-knife, as this is necessary to clear the scoreboard UI. Otherwise the team winning the knife-round will have their win lingering in the middle of the round-win-indicators until the first round is played out. This also helps cleaning up the "going live" logic and tightly couples the announcement to the round start instead of using a timer.
9. Removed a lot of redundant calls to various functions that were stacked on top of eachother.
10. Prevent loading backups during halftime.
11. Added a `RestartGame()` call before loading a Valve backup, as it ensures the game is not in a state that's not prepared for backup (such as bots only alive or after-round).
12. Added pauses used to the backups. They only reset to the backup state if the game is *not* being restored from a live state, meaning they can now be carried over to an entirely new server and restored in a "best effort" manner.
13. We now delete the temporary valve backup file created when exporting the valve backup from a get5 backup.
14. Added `g_MapSides` content to debug output.
15. Fixed missing deletion of "knife decision" timer when a team makes a decision. Previously it would just run its trigger and do nothing because the game was not in a state that expected a knife decision.
16. Fixed some problems with `{MAXMAPS}` and `{MAPNUMBER}` being wrong when formatting them, such as not taking ties or `g_SeriesCanClinch` into consideration.
17. Tightly couple `ExecCfg()` to a call to `SetMatchTeamCvars()` and `ExecuteMatchConfigCvars`, as `ExecCfg` makes a call to `exec xx.cfg` which is async: the two latter must always be set **after** a config file load.
18. Converted `MaxMapsToPlay()` to a more sensible `MapsToWin()` function. The logic was kind of inverted and unnecessary.
19. Fixed a bunch of redundant calls and weird logic in `EnsureIndefiniteWarmup` and merged it into `StartWarmup`.
20. Team-join menu is now never used for any reason.
21. If you disable coaching with `sv_coaching_enabled 0`, existing coaches will be kicked, as they would otherwise become regular spectators. 
22. Added collision protection to the `get5_names.txt` file using the already established logic for this using `{SERVERID}`.

I've tested as much as I can solo, but I need someone to run some tests on this branch.