### PR TITLE
Ensure that g_MatchID is reset 

### DIFF
--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -1343,6 +1343,7 @@ void EndSeries(Get5Team winningTeam, bool printWinnerMessage, float restoreDelay
 
   EventLogger_LogAndDeleteEvent(event);
   ChangeState(Get5State_None);
+  g_MatchID = "";
 
   // We don't want to kick players until after the specified delay, as it will kick casters
   // potentially before GOTV ends.

--- a/scripting/get5/matchconfig.sp
+++ b/scripting/get5/matchconfig.sp
@@ -36,6 +36,7 @@ stock bool LoadMatchConfig(const char[] config, bool restoreBackup = false) {
     ClearArray(GetTeamAuths(team));
   }
 
+  g_MatchID = "";
   g_ReadyTimeWaitingUsed = 0;
   g_HasKnifeRoundStarted = false;
   g_MapChangePending = false;


### PR DESCRIPTION
If you end the series or if a match configuration fails to load, you will be stuck with an invalid `g_MatchId` variable. This causes the backup system to incorrectly look for only backups belonging to that match, where it should be listing all backups. 