### PR TITLE
Allow for customizing team color names

### DIFF
--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -143,6 +143,18 @@ if [`get5_print_damage`](#get5_print_damage) is disabled.
 :   The tag applied before plugin messages. Note that at least one character must come before
 a [color modifier](#color-substitutes). **`Default: "[{YELLOW}Get5{NORMAL}]"`**
 
+####`get5_team1_color`
+:   The [color](#color-substitutes) to use when printing the name of `team1` in chat
+messages.<br>**`Default: "{LIGHT_GREEN}"`**
+
+####`get5_team2_color`
+:   The [color](#color-substitutes) to use when printing the name of `team2` in chat
+messages.<br>**`Default: "{PINK}"`**
+
+####`get5_spec_color`
+:   The [color](#color-substitutes) to use when printing the name of `spectators` in chat
+messages.<br>**`Default: "{NORMAL}"`**
+
 ## Pausing
 
 ####`get5_pausing_enabled`

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -40,8 +40,6 @@
 #define MAX_CVAR_LENGTH 128
 #define MATCH_END_DELAY_AFTER_TV 15
 
-#define TEAM1_COLOR "{LIGHT_GREEN}"
-#define TEAM2_COLOR "{PINK}"
 #define TEAM1_STARTING_SIDE CS_TEAM_CT
 #define TEAM2_STARTING_SIDE CS_TEAM_T
 #define KNIFE_CONFIG "get5/knife.cfg"
@@ -102,6 +100,9 @@ ConVar g_WarmupCfgCvar;
 ConVar g_PrintUpdateNoticeCvar;
 ConVar g_RoundBackupPathCvar;
 ConVar g_PhaseAnnouncementCountCvar;
+ConVar g_Team1NameColorCvar;
+ConVar g_Team2NameColorCvar;
+ConVar g_SpecNameColorCvar;
 
 // Autoset convars (not meant for users to set)
 ConVar g_GameStateCvar;
@@ -215,12 +216,6 @@ bool g_ClientReady[MAXPLAYERS + 1];         // Whether clients are marked ready.
 int g_TeamSide[MATCHTEAM_COUNT];            // Current CS_TEAM_* side for the team.
 int g_TeamStartingSide[MATCHTEAM_COUNT];
 int g_ReadyTimeWaitingUsed = 0;
-char g_DefaultTeamColors[][] = {
-    TEAM1_COLOR,
-    TEAM2_COLOR,
-    "{NORMAL}",
-    "{NORMAL}",
-};
 
 char g_LastKickedPlayerAuth[64];
 
@@ -445,6 +440,15 @@ public void OnPluginStart() {
   g_PhaseAnnouncementCountCvar = CreateConVar(
       "get5_phase_announcement_count", "5",
       "The number of times Get5 will print 'Knife' or 'Match is LIVE' when the game starts. Set to 0 to disable.");
+  g_Team1NameColorCvar = CreateConVar(
+      "get5_team1_color", "{LIGHT_GREEN}",
+      "The color used for the name of team 1 in chat messages.");
+  g_Team2NameColorCvar = CreateConVar(
+      "get5_team2_color", "{PINK}",
+      "The color used for the name of team 2 in chat messages.");
+  g_SpecNameColorCvar = CreateConVar(
+      "get5_spec_color", "{NORMAL}",
+      "The color used for the name of spectators in chat messages.");
 
   /** Create and exec plugin's configuration file **/
   AutoExecConfig(true, "get5");

--- a/scripting/get5/matchconfig.sp
+++ b/scripting/get5/matchconfig.sp
@@ -428,9 +428,7 @@ static bool LoadMatchFromKv(KeyValues kv) {
     kv.GetString("name", g_TeamNames[Get5Team_Spec], MAX_CVAR_LENGTH,
                  CONFIG_SPECTATORSNAME_DEFAULT);
     kv.GoBack();
-
-    Format(g_FormattedTeamNames[Get5Team_Spec], MAX_CVAR_LENGTH, "%s%s{NORMAL}",
-           g_DefaultTeamColors[Get5Team_Spec], g_TeamNames[Get5Team_Spec]);
+    FormatTeamName(Get5Team_Spec);
   }
 
   if (kv.JumpToKey("team1")) {
@@ -546,9 +544,7 @@ static bool LoadMatchFromJson(JSON_Object json) {
     json_object_get_string_safe(spec, "name", g_TeamNames[Get5Team_Spec], MAX_CVAR_LENGTH,
                                 CONFIG_SPECTATORSNAME_DEFAULT);
     AddJsonAuthsToList(spec, "players", GetTeamAuths(Get5Team_Spec), AUTH_LENGTH);
-
-    Format(g_FormattedTeamNames[Get5Team_Spec], MAX_CVAR_LENGTH, "%s%s{NORMAL}",
-           g_DefaultTeamColors[Get5Team_Spec], g_TeamNames[Get5Team_Spec]);
+    FormatTeamName(Get5Team_Spec);
   }
 
   JSON_Object team1 = json.GetObject("team1");
@@ -616,8 +612,8 @@ static void LoadTeamDataJson(JSON_Object json, Get5Team matchTeam) {
   if (StrEqual(fromfile, "")) {
     // TODO: this needs to support both an array and a dictionary
     // For now, it only supports an array
-    JSON_Object coaches = json.GetObject("coaches");
     AddJsonAuthsToList(json, "players", GetTeamAuths(matchTeam), AUTH_LENGTH);
+    JSON_Object coaches = json.GetObject("coaches");
     if (coaches != null) {
       AddJsonAuthsToList(json, "coaches", GetTeamCoaches(matchTeam), AUTH_LENGTH);
     }
@@ -638,8 +634,7 @@ static void LoadTeamDataJson(JSON_Object json, Get5Team matchTeam) {
   }
 
   g_TeamSeriesScores[matchTeam] = json_object_get_int_safe(json, "series_score", 0);
-  Format(g_FormattedTeamNames[matchTeam], MAX_CVAR_LENGTH, "%s%s{NORMAL}",
-         g_DefaultTeamColors[matchTeam], g_TeamNames[matchTeam]);
+  FormatTeamName(matchTeam);
 }
 
 static void LoadTeamData(KeyValues kv, Get5Team matchTeam) {
@@ -666,8 +661,21 @@ static void LoadTeamData(KeyValues kv, Get5Team matchTeam) {
   }
 
   g_TeamSeriesScores[matchTeam] = kv.GetNum("series_score", 0);
-  Format(g_FormattedTeamNames[matchTeam], MAX_CVAR_LENGTH, "%s%s{NORMAL}",
-         g_DefaultTeamColors[matchTeam], g_TeamNames[matchTeam]);
+  FormatTeamName(matchTeam);
+}
+
+static void FormatTeamName(const Get5Team team) {
+  char color[32];
+  if (team == Get5Team_1) {
+    g_Team1NameColorCvar.GetString(color, sizeof(color));
+  } else if (team == Get5Team_2) {
+    g_Team2NameColorCvar.GetString(color, sizeof(color));
+  } else if (team == Get5Team_Spec) {
+    g_SpecNameColorCvar.GetString(color, sizeof(color));
+  } else {
+    color = "{NORMAL}";
+  }
+  Format(g_FormattedTeamNames[team], MAX_CVAR_LENGTH, "%s%s{NORMAL}", color, g_TeamNames[team]);
 }
 
 static void LoadDefaultMapList(ArrayList list) {
@@ -1065,14 +1073,16 @@ public Action Command_CreateMatch(int client, int args) {
 
   char teamName[MAX_CVAR_LENGTH];
 
+  // If team names are empty because nobody is on on the server, the will be set by
+  // CheckTeamNameStatus during ready-phase.
   kv.JumpToKey("team1", true);
   int count = AddPlayersToAuthKv(kv, Get5Team_1, teamName);
-  kv.SetString("name", count > 0 ? teamName : "Team 1");
+  kv.SetString("name", count > 0 ? teamName : "");
   kv.GoBack();
 
   kv.JumpToKey("team2", true);
   count = AddPlayersToAuthKv(kv, Get5Team_2, teamName);
-  kv.SetString("name", count > 0 ? teamName : "Team 2");
+  kv.SetString("name", count > 0 ? teamName : "");
   kv.GoBack();
 
   kv.JumpToKey("spectators", true);
@@ -1282,12 +1292,6 @@ public void CheckTeamNameStatus(Get5Team team) {
         }
       }
     }
-
-    char colorTag[32] = TEAM1_COLOR;
-    if (team == Get5Team_2)
-      colorTag = TEAM2_COLOR;
-
-    Format(g_FormattedTeamNames[team], MAX_CVAR_LENGTH, "%s%s{NORMAL}", colorTag,
-           g_TeamNames[team]);
+    FormatTeamName(team);
   }
 }

--- a/scripting/get5/matchconfig.sp
+++ b/scripting/get5/matchconfig.sp
@@ -1074,15 +1074,17 @@ public Action Command_CreateMatch(int client, int args) {
   char teamName[MAX_CVAR_LENGTH];
 
   // If team names are empty because nobody is on on the server, the will be set by
-  // CheckTeamNameStatus during ready-phase.
+  // CheckTeamNameStatus during ready-phase. We cannot write empty strings to KeyValues, so we just skip them.
   kv.JumpToKey("team1", true);
-  int count = AddPlayersToAuthKv(kv, Get5Team_1, teamName);
-  kv.SetString("name", count > 0 ? teamName : "");
+  if (AddPlayersToAuthKv(kv, Get5Team_1, teamName) > 0) {
+    kv.SetString("name", teamName);
+  }
   kv.GoBack();
 
   kv.JumpToKey("team2", true);
-  count = AddPlayersToAuthKv(kv, Get5Team_2, teamName);
-  kv.SetString("name", count > 0 ? teamName : "");
+  if (AddPlayersToAuthKv(kv, Get5Team_2, teamName) > 0) {
+    kv.SetString("name", teamName);
+  }
   kv.GoBack();
 
   kv.JumpToKey("spectators", true);


### PR DESCRIPTION
Pretty straight-forward this one.

I reverted the change from https://github.com/splewis/get5/pull/835 as I had not realized the names would be set later during ready-phase, when people had joined.