### PR TITLE
Remove deprecate bo2_series and maps_to_win match config params

### DIFF
--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -119,7 +119,8 @@ bool g_SeriesCanClinch = true;
 int g_RoundNumber = -1;  // The round number, 0-indexed. -1 if the match is not live.
 // The active map number, used by stats. Required as the calculated round number changes immediately
 // as a map ends, but before the map changes to the next.
-int g_MapNumber = 0;
+int g_MapNumber = 0; // the current map number, starting at 0.
+int g_NumberOfMapsInSeries = 0; // the number of maps to play in the series.
 char g_MatchID[MATCH_ID_LENGTH];
 ArrayList g_MapPoolList = null;
 ArrayList g_TeamAuths[MATCHTEAM_COUNT];

--- a/scripting/get5/tests.sp
+++ b/scripting/get5/tests.sp
@@ -72,6 +72,7 @@ static void KV_Test() {
 
   AssertEq("maps_to_win", g_MapsToWin, 2);
   AssertEq("bo2_series", g_BO2Match, false);
+  AssertEq("num_maps", g_NumberOfMapsInSeries, 3);
   AssertEq("skip_veto", g_SkipVeto, false);
   AssertEq("players_per_team", g_PlayersPerTeam, 5);
   AssertEq("favored_percentage_team1", g_FavoredTeamPercentage, 65);


### PR DESCRIPTION
While refactoring I came across this, which needs to go away. Separate PR to mark it as breaking change.