### PR TITLE
Format and commit code on push to master branch

### DIFF
--- a/.github/workflows/auto_formatter.yml
+++ b/.github/workflows/auto_formatter.yml
@@ -1,0 +1,28 @@
+name: Auto Format Code On Master Merge
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  auto-formatter-on-master:
+    name: Auto Format Code On Master Merge
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Clang format
+      run: |
+        sudo apt install clang-format
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - run: python ./misc/format.py
+
+    - uses: EndBug/add-and-commit@v9.1.0
+      with:
+        committer_name: GitHub Actions
+        committer_email: 41898282+github-actions[bot]@users.noreply.github.com
+        message: 'Run automatic format script as code does not match clang format rules.'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR is to just ensure we have correct formatting whenever we do a full release. This little bit of automation here is done so that other users who wish to contribute don't have to have clang-format installed, and if regular contributors forget to run formatting, it will be caught and updated downstream. This is what the commit message, and author will look like once it has been completed (if any formatting needs to be done)

![image](https://user-images.githubusercontent.com/3514085/188170413-99d45f2d-1c1a-45e4-a122-25fa4c365913.png)

I've taken the "Run Autoformatter" message from previous times when splewis has run the autoformatter on the main branch, so I figured it is a good enough message to show intent.

Will mark ready when 0.10 is released.