### PR TITLE
Get rid of g_WaitingForRoundBackup and introduce backup game state + clean up associated map-change logic and timers

### DIFF
--- a/documentation/docs/commands.md
+++ b/documentation/docs/commands.md
@@ -150,7 +150,7 @@ from the server immediately.
         "plugin_version": string, // (1)
         "gamestate": "none" | "pre_veto" | "veto" | "warmup"
             | "knife" | "waiting_for_knife_decision"
-            | "going_live" | "live" | "post_game", // (2)
+            | "going_live" | "live" | "pending_restore" | "post_game", // (2)
         "paused": boolean, // (3)
         "loaded_config_file": string | undefined, // (4)
         "matchid": string | undefined, // (5)
@@ -164,7 +164,7 @@ from the server immediately.
     ```
 
     1. The version of Get5 you are currently running, along with that version's commit. `Example: "0.8.1-8ef7ffa3"`
-    2. The current state of the game. The definition lists them in the order they occur.
+    2. The current state of the game. The definition lists them in the order they would typically occur.
     3. Whether the game is currently paused.
     4. The match configuration file currently loaded. `Example: "addons/sourcemod/configs/get5/match_config.json"`.
     5. The current match ID. Empty string if not defined or `scrim` or `manual` if using

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -177,7 +177,6 @@ Get5Team g_LastVetoTeam;
 Menu g_ActiveVetoMenu = null;
 
 /** Backup data **/
-bool g_WaitingForRoundBackup = false;
 bool g_DoingBackupRestoreNow = false;
 
 // Stats values
@@ -228,6 +227,7 @@ ArrayList g_ChatAliasesCommands;
 char g_DemoFileName[PLATFORM_MAX_PATH];
 bool g_MapChangePending = false;
 bool g_PendingSideSwap = false;
+Handle g_PendingMapChangeTimer = INVALID_HANDLE;
 
 // version check state
 bool g_RunningPrereleaseVersion = false;
@@ -630,14 +630,17 @@ public void OnPluginStart() {
 
 static Action Timer_InfoMessages(Handle timer) {
   if (g_GameState == Get5State_Live || g_GameState == Get5State_None) {
-    return Plugin_Continue;
+    return;
   }
 
   char readyCommandFormatted[64];
   FormatChatCommand(readyCommandFormatted, sizeof(readyCommandFormatted), "!ready");
 
-  // Handle pre-veto messages
-  if (g_GameState == Get5State_PreVeto) {
+  if (g_GameState == Get5State_PendingRestore) {
+    if (!IsTeamsReady() && !IsDoingRestoreOrMapChange()) {
+      Get5_MessageToAll("%t", "ReadyToRestoreBackupInfoMessage", readyCommandFormatted);
+    }
+  } else if (g_GameState == Get5State_PreVeto) {
     if (IsTeamsReady() && !IsSpectatorsReady()) {
       Get5_MessageToAll("%t", "WaitingForCastersReadyInfoMessage",
                         g_FormattedTeamNames[Get5Team_Spec], readyCommandFormatted);
@@ -645,29 +648,21 @@ static Action Timer_InfoMessages(Handle timer) {
       Get5_MessageToAll("%t", "ReadyToVetoInfoMessage", readyCommandFormatted);
     }
     MissingPlayerInfoMessage();
-  } else if (g_GameState == Get5State_Warmup && !g_MapChangePending) {
-    // Handle warmup state, provided we're not waiting for a map change
-    // Backups take priority
-    if (!IsTeamsReady() && g_WaitingForRoundBackup) {
-      Get5_MessageToAll("%t", "ReadyToRestoreBackupInfoMessage", readyCommandFormatted);
-      return Plugin_Continue;
-    }
-
-    // Find out what we're waiting for
-    if (IsTeamsReady() && !IsSpectatorsReady()) {
-      Get5_MessageToAll("%t", "WaitingForCastersReadyInfoMessage",
-                        g_FormattedTeamNames[Get5Team_Spec], readyCommandFormatted);
-    } else {
-      if (g_MapSides.Get(Get5_GetMapNumber()) == SideChoice_KnifeRound) {
-        Get5_MessageToAll("%t", "ReadyToKnifeInfoMessage", readyCommandFormatted);
+  } else if (g_GameState == Get5State_Warmup) {
+    if (!g_MapChangePending) {
+      // Find out what we're waiting for
+      if (IsTeamsReady() && !IsSpectatorsReady()) {
+        Get5_MessageToAll("%t", "WaitingForCastersReadyInfoMessage",
+                          g_FormattedTeamNames[Get5Team_Spec], readyCommandFormatted);
       } else {
-        Get5_MessageToAll("%t", "ReadyToStartInfoMessage", readyCommandFormatted);
+        bool knifeRound = g_MapSides.Get(g_MapNumber) == SideChoice_KnifeRound;
+        Get5_MessageToAll("%t", knifeRound ? "ReadyToKnifeInfoMessage" : "ReadyToStartInfoMessage",
+                          readyCommandFormatted);
       }
+      MissingPlayerInfoMessage();
+    } else if (g_DisplayGotvVetoCvar.BoolValue && GetTvDelay() > 0) {
+      Get5_MessageToAll("%t", "WaitingForGOTVVetoInfoMessage");
     }
-    MissingPlayerInfoMessage();
-  } else if (g_DisplayGotvVetoCvar.BoolValue && g_GameState == Get5State_Warmup &&
-             g_MapChangePending && GetTvDelay() > 0) {
-    Get5_MessageToAll("%t", "WaitingForGOTVVetoInfoMessage");
   } else if (g_GameState == Get5State_WaitingForKnifeRoundDecision) {
     // Handle waiting for knife decision
     char formattedStayCommand[64];
@@ -681,8 +676,6 @@ static Action Timer_InfoMessages(Handle timer) {
     // Handle postgame
     Get5_MessageToAll("%t", "WaitingForGOTVBrodcastEndingInfoMessage");
   }
-
-  return Plugin_Continue;
 }
 
 public void OnClientAuthorized(int client, const char[] auth) {
@@ -841,7 +834,7 @@ static Action Timer_ConfigsExecutedCallback(Handle timer) {
   LOOP_TEAMS(team) {
     g_TeamGivenStopCommand[team] = false;
     g_TeamReadyForUnpause[team] = false;
-    if (!g_WaitingForRoundBackup) {
+    if (g_GameState != Get5State_PendingRestore) {
       g_TacticalPauseTimeUsed[team] = 0;
       g_TacticalPausesUsed[team] = 0;
       g_TechnicalPausesUsed[team] = 0;
@@ -854,21 +847,26 @@ static Action Timer_ConfigsExecutedCallback(Handle timer) {
   SetServerStateOnStartup(true);
   // This must not be called when waiting for a backup, as it will set the sides incorrectly if the
   // team swapped in knife or if the backup target is the second half.
-  if (!g_WaitingForRoundBackup) {
+  if (g_GameState != Get5State_PendingRestore) {
     SetStartingTeams();
+  }
+
+  // If the map is changed while a map timer is counting down, kill the timer. This could happen if
+  // a too long mp_match_restart_delay was set and admins decide to manually intervene.
+  if (g_PendingMapChangeTimer != INVALID_HANDLE) {
+    delete g_PendingMapChangeTimer;
+    LogDebug("Killed g_PendingMapChangeTimer as map was changed.");
   }
 }
 
 static Action Timer_CheckReady(Handle timer) {
   if (g_GameState == Get5State_None) {
-    return Plugin_Continue;
+    return;
   }
-
-  if (g_DoingBackupRestoreNow) {
-    LogDebug("Timer_CheckReady: Waiting for restore");
-    return Plugin_Continue;
+  if (IsDoingRestoreOrMapChange()) {
+    LogDebug("Timer_CheckReady: Waiting for restore or map change");
+    return;
   }
-
   CheckTeamNameStatus(Get5Team_1);
   CheckTeamNameStatus(Get5Team_2);
   UpdateClanTags();
@@ -884,35 +882,23 @@ static Action Timer_CheckReady(Handle timer) {
     } else {
       CheckReadyWaitingTimes();
     }
-  }
-
-  // Handle ready checks for warmup, provided we are not waiting for a map change
-  if (g_GameState == Get5State_Warmup && !g_MapChangePending) {
+  } else if (g_GameState == Get5State_PendingRestore) {
     // We don't wait for spectators when restoring backups
-    if (IsTeamsReady() && g_WaitingForRoundBackup) {
+    if (IsTeamsReady()) {
       LogDebug("Timer_CheckReady: restoring from backup");
-      g_WaitingForRoundBackup = false;
       RestoreGet5Backup();
-      return Plugin_Continue;
     }
-
+  } else if (g_GameState == Get5State_Warmup) {
+    // Handle ready checks for warmup, provided we are not waiting for a map change
     // Wait for both players and spectators before going live
     if (IsTeamsReady() && IsSpectatorsReady()) {
       LogDebug("Timer_CheckReady: all teams ready to start");
-      if (g_MapSides.Get(Get5_GetMapNumber()) == SideChoice_KnifeRound) {
-        LogDebug("Timer_CheckReady: starting with a knife round");
-        StartGame(true);
-      } else {
-        LogDebug("Timer_CheckReady: starting without a knife round");
-        StartGame(false);
-      }
+      StartGame(g_MapSides.Get(g_MapNumber) == SideChoice_KnifeRound);
       StartRecording();
     } else {
       CheckReadyWaitingTimes();
     }
   }
-
-  return Plugin_Continue;
 }
 
 static void CheckReadyWaitingTimes() {
@@ -963,7 +949,7 @@ static bool CheckReadyWaitingTime(Get5Team team) {
 }
 
 bool CheckAutoLoadConfig() {
-  if (g_GameState == Get5State_None && !g_WaitingForRoundBackup) {
+  if (g_GameState == Get5State_None) {
     char autoloadConfig[PLATFORM_MAX_PATH];
     g_AutoLoadConfigCvar.GetString(autoloadConfig, sizeof(autoloadConfig));
     if (!StrEqual(autoloadConfig, "")) {
@@ -1006,7 +992,6 @@ static Action Command_EndMatch(int client, int args) {
   }
 
   // Call game-ending forwards.
-  g_MapChangePending = false;
   int team1score = CS_GetTeamScore(Get5TeamToCSTeam(Get5Team_1));
   int team2score = CS_GetTeamScore(Get5TeamToCSTeam(Get5Team_2));
 
@@ -1033,20 +1018,6 @@ static Action Command_EndMatch(int client, int args) {
   } else {
     Get5_MessageToAll("%t", "AdminForceEndWithWinnerInfoMessage",
                       g_FormattedTeamNames[winningTeam]);
-  }
-
-  if (g_ActiveVetoMenu != null) {
-    g_ActiveVetoMenu.Cancel();
-  }
-
-  if (g_KnifeCountdownTimer != INVALID_HANDLE) {
-    LogDebug("Killing knife announce countdown timer.");
-    delete g_KnifeCountdownTimer;
-  }
-
-  if (g_KnifeDecisionTimer != INVALID_HANDLE) {
-    LogDebug("Killing knife decision timer.");
-    delete g_KnifeDecisionTimer;
   }
 
   RestartGame();
@@ -1295,17 +1266,23 @@ static Action Event_MatchOver(Event event, const char[] name, bool dontBroadcast
     convertSecondsToMinutesAndSeconds(RoundToFloor(restartDelay), timeToMapChangeFormatted,
                                       sizeof(timeToMapChangeFormatted));
 
+    // g_MapChangePending is set in ChangeMap, but since we want to announce now and change the
+    // state immediately while waiting for the restartDelay, we set it here also.
     g_MapChangePending = true;
     FormatMapName(nextMap, nextMap, sizeof(nextMap), true, true);
     Get5_MessageToAll("%t", "NextSeriesMapInfoMessage", nextMap, timeToMapChangeFormatted);
     ChangeState(Get5State_PostGame);
     // Subtracting 4 seconds makes the map change 1 second before the timer expires, as there is a 3
     // second built-in delay in the ChangeMap function called by Timer_NextMatchMap.
-    CreateTimer(restartDelay - 4, Timer_NextMatchMap);
+    g_PendingMapChangeTimer = CreateTimer(restartDelay - 4, Timer_NextMatchMap);
   }
 }
 
 Action Timer_NextMatchMap(Handle timer) {
+  g_PendingMapChangeTimer = INVALID_HANDLE;
+  if (g_GameState == Get5State_None) {
+    return;
+  }
   char map[PLATFORM_MAX_PATH];
   g_MapsToPlay.GetString(Get5_GetMapNumber(), map, sizeof(map));
   // If you change these 3 seconds for whatever reason, you must adjust the counter-offset in
@@ -1365,6 +1342,30 @@ static void EndSeries(Get5Team winningTeam, bool printWinnerMessage, float resto
     // change before GOTV broadcast ends, so we don't do this until the current match restart delay
     // has passed.
     CreateTimer(restoreDelay, Timer_RestoreMatchCvars, _, TIMER_FLAG_NO_MAPCHANGE);
+  }
+
+  // If the match is ended during pending map change;
+  if (g_PendingMapChangeTimer != INVALID_HANDLE) {
+    LogDebug("Killing g_PendingMapChangeTimer as match was ended.");
+    delete g_PendingMapChangeTimer;
+  }
+
+  // If the match is ended during knife countdown;
+  if (g_KnifeCountdownTimer != INVALID_HANDLE) {
+    LogDebug("Killing g_KnifeCountdownTimer as match was ended.");
+    delete g_KnifeCountdownTimer;
+  }
+
+  // If the match is ended during knife decision countdown;
+  if (g_KnifeDecisionTimer != INVALID_HANDLE) {
+    LogDebug("Killing g_KnifeDecisionTimer as match was ended.");
+    delete g_KnifeDecisionTimer;
+  }
+
+  // If a veto menu was open when the match ended, close it;
+  if (g_ActiveVetoMenu != null) {
+    LogDebug("Deleted g_ActiveVetoMenu.");
+    g_ActiveVetoMenu.Cancel();
   }
 }
 
@@ -1730,16 +1731,16 @@ static void SetServerStateOnStartup(bool force) {
     // Only run on first client connect or if forced (during OnConfigsExecuted).
     return;
   }
-  // It shouldn't really be possible to end up here, as the server *should* reload the map anyway when first player
-  // joins, but as a safeguard we don't want to move a live game that's not pending a backup or map change into warmup
-  // on player connect.
-  if (!force && g_GameState == Get5State_Live && !g_WaitingForRoundBackup && !g_MapChangePending) {
+  // It shouldn't really be possible to end up here, as the server *should* reload the map anyway
+  // when first player joins, but as a safeguard we don't want to move a live game into warmup on
+  // player connect.
+  if (!force && g_GameState == Get5State_Live) {
     return;
   }
-  // If the server is in preveto when someone joins or the configs exec, it should remain in
-  // that state. This would happen if the a config with veto is loaded before someone joins the
-  // server.
-  if (g_GameState != Get5State_PreVeto) {
+  // If the server is in preveto or pending backup when someone joins or the configs exec, it should
+  // remain in that state. This would happen if the a config with veto is loaded before someone
+  // joins the server.
+  if (g_GameState != Get5State_PreVeto && g_GameState != Get5State_PendingRestore) {
     ChangeState(Get5State_Warmup);
   }
   ExecCfg(g_WarmupCfgCvar);

--- a/scripting/get5/backups.sp
+++ b/scripting/get5/backups.sp
@@ -238,16 +238,8 @@ static void WriteBackupStructure(const char[] path) {
   char mapName[PLATFORM_MAX_PATH];
   GetCurrentMap(mapName, sizeof(mapName));
 
-  if (g_GameState == Get5State_Veto) {
-    kv.SetNum("gamestate", view_as<int>(Get5State_PreVeto));
-  } else if (g_GameState == Get5State_Warmup ||
-             g_GameState == Get5State_WaitingForKnifeRoundDecision ||
-             g_GameState == Get5State_KnifeRound || g_GameState == Get5State_GoingLive ||
-             g_GameState == Get5State_PostGame) {
-    kv.SetNum("gamestate", view_as<int>(Get5State_Warmup));
-  } else if (g_GameState == Get5State_Live) {
-    kv.SetNum("gamestate", view_as<int>(Get5State_Live));
-  }
+  // Assume warmup; changed to live below if a valve backup exists.
+  kv.SetNum("gamestate", view_as<int>(Get5State_Warmup));
 
   kv.SetNum("team1_side", g_TeamSide[Get5Team_1]);
   kv.SetNum("team2_side", g_TeamSide[Get5Team_2]);
@@ -296,13 +288,14 @@ static void WriteBackupStructure(const char[] path) {
 
   if (g_GameState == Get5State_Live) {
     // Write valve's backup format into the file. This only applies to live rounds, as any pre-live
-    // backups should just restart the game to the knife round.
+    // backups should just restart the game to warmup (post-veto).
     char lastBackup[PLATFORM_MAX_PATH];
     ConVar lastBackupCvar = FindConVar("mp_backup_round_file_last");
     if (lastBackupCvar != null) {
       lastBackupCvar.GetString(lastBackup, sizeof(lastBackup));
       KeyValues valveBackup = new KeyValues("valve_backup");
       if (valveBackup.ImportFromFile(lastBackup)) {
+        kv.SetNum("gamestate", view_as<int>(Get5State_Live));
         kv.JumpToKey("valve_backup", true);
         KvCopySubkeys(valveBackup, kv);
         kv.GoBack();
@@ -353,8 +346,8 @@ bool RestoreFromBackup(const char[] path, bool restartRecording = true) {
 
   if (g_GameState != Get5State_Live) {
     // This isn't perfect, but it's better than resetting all pauses used to zero in cases of
-    // restore on a new server. If restoring while live, we just retain the current pauses used, as
-    // they should be the "most correct".
+    // restore on a new server or a different map. If restoring while live, we just retain the
+    // current pauses used, as they should be the "most correct".
     g_TacticalPausesUsed[Get5Team_1] = kv.GetNum("team1_tac_pauses_used", 0);
     g_TacticalPausesUsed[Get5Team_2] = kv.GetNum("team2_tac_pauses_used", 0);
     g_TechnicalPausesUsed[Get5Team_1] = kv.GetNum("team1_tech_pauses_used", 0);
@@ -422,10 +415,10 @@ bool RestoreFromBackup(const char[] path, bool restartRecording = true) {
   }
 
   // When loading pre-live, there is no Valve backup, so we assume -1.
-  g_WaitingForRoundBackup = false;
+  bool valveBackup = false;
   int roundNumberRestoredTo = -1;
   if (kv.JumpToKey("valve_backup")) {
-    g_WaitingForRoundBackup = true;
+    valveBackup = true;
     char tempValveBackup[PLATFORM_MAX_PATH];
     GetTempFilePath(tempValveBackup, sizeof(tempValveBackup), TEMP_VALVE_BACKUP_PATTERN);
     kv.ExportToFile(tempValveBackup);
@@ -444,6 +437,7 @@ bool RestoreFromBackup(const char[] path, bool restartRecording = true) {
     // If a map is to be changed, we want to suppress all stats events immediately, as the
     // Get5_OnBackupRestore is called now and we don't want events firing after this until the game
     // is live again.
+    ChangeState(valveBackup ? Get5State_PendingRestore : Get5State_Warmup);
     ChangeMap(currentSeriesMap, 3.0);
   } else {
     // We must assign players to their teams. This is normally done inside LoadMatchConfig, but
@@ -453,9 +447,9 @@ bool RestoreFromBackup(const char[] path, bool restartRecording = true) {
         CheckClientTeam(i);
       }
     }
-    if (g_WaitingForRoundBackup) {
+    if (valveBackup) {
       // Same map, but round restore with a Valve backup; do normal restore immediately with no
-      // ready-up.
+      // ready-up and no game-state change.
       RestoreGet5Backup(restartRecording);
     } else {
       // We are restarting to the same map for prelive; just go back into warmup and let players
@@ -495,7 +489,6 @@ void RestoreGet5Backup(bool restartRecording = true) {
   PauseGame(Get5Team_None, Get5PauseType_Backup);
   g_DoingBackupRestoreNow = true;  // reset after the backup has completed, suppresses various
                                    // events and hooks until then.
-  g_WaitingForRoundBackup = false;
   CreateTimer(1.5, Timer_StartRestore);
   if (restartRecording) {
     // Since a backup command forces the recording to stop, we restart it here once the backup has

--- a/scripting/get5/debug.sp
+++ b/scripting/get5/debug.sp
@@ -122,7 +122,6 @@ static void AddGlobalStateInfo(File f) {
 
   f.WriteLine("g_MapChangePending = %d", g_MapChangePending);
   f.WriteLine("g_PendingSideSwap = %d", g_PendingSideSwap);
-  f.WriteLine("g_WaitingForRoundBackup = %d", g_WaitingForRoundBackup);
   f.WriteLine("g_DoingBackupRestoreNow = %d", g_DoingBackupRestoreNow);
   f.WriteLine("g_ReadyTimeWaitingUsed = %d", g_ReadyTimeWaitingUsed);
   f.WriteLine("g_PausingTeam = %d", g_PausingTeam);

--- a/scripting/get5/kniferounds.sp
+++ b/scripting/get5/kniferounds.sp
@@ -17,6 +17,9 @@ Action StartKnifeRound(Handle timer) {
 
 static Action Timer_AnnounceKnife(Handle timer) {
   g_KnifeCountdownTimer = INVALID_HANDLE;
+  if (g_GameState == Get5State_None) {
+    return;
+  }
   AnnouncePhaseChange("{GREEN}%t", "KnifeInfoMessage");
 
   Get5KnifeRoundStartedEvent knifeEvent = new Get5KnifeRoundStartedEvent(g_MatchID, g_MapNumber);
@@ -30,7 +33,6 @@ static Action Timer_AnnounceKnife(Handle timer) {
   EventLogger_LogAndDeleteEvent(knifeEvent);
 
   g_HasKnifeRoundStarted = true;
-  return Plugin_Handled;
 }
 
 static void PerformSideSwap(bool swap) {

--- a/scripting/get5/mapveto.sp
+++ b/scripting/get5/mapveto.sp
@@ -76,9 +76,9 @@ static void VetoFinished() {
   g_MapChangePending = true;
   if (!g_SkipVeto && g_DisplayGotvVetoCvar.BoolValue) {
     // Players must wait for GOTV to end before we can change map, but we don't need to record that.
-    CreateTimer(float(GetTvDelay()) + delay, Timer_NextMatchMap);
+    g_PendingMapChangeTimer = CreateTimer(float(GetTvDelay()) + delay, Timer_NextMatchMap);
   } else {
-    CreateTimer(delay, Timer_NextMatchMap);
+    g_PendingMapChangeTimer = CreateTimer(delay, Timer_NextMatchMap);
   }
   // Always end recording here; ensures that we can successfully start one after veto.
   StopRecording(delay);

--- a/scripting/get5/matchconfig.sp
+++ b/scripting/get5/matchconfig.sp
@@ -52,7 +52,6 @@ bool LoadMatchConfig(const char[] config, bool restoreBackup = false) {
   g_CvarValues.Clear();
   g_TeamScoresPerMap.Clear();
 
-  g_WaitingForRoundBackup = false;
   g_LastGet5BackupCvar.SetString("");
 
   CloseCvarStorage(g_KnifeChangedCvars);
@@ -811,7 +810,7 @@ Action Command_AddPlayer(int client, int args) {
         client,
         "Cannot use get5_addplayer in scrim mode. Use get5_ringer to swap a player's team.");
     return Plugin_Handled;
-  } else if (g_DoingBackupRestoreNow || g_WaitingForRoundBackup) {
+  } else if (g_DoingBackupRestoreNow || g_GameState == Get5State_PendingRestore) {
     ReplyToCommand(client, "Cannot add players while waiting for round backup.");
     return Plugin_Handled;
   } else if (g_PendingSideSwap || InHalftimePhase()) {
@@ -867,7 +866,7 @@ Action Command_AddCoach(int client, int args) {
     ReplyToCommand(client,
                    "Coaches cannot be added in scrim mode. Use the !coach command in chat.");
     return Plugin_Handled;
-  } else if (g_DoingBackupRestoreNow || g_WaitingForRoundBackup) {
+  } else if (g_DoingBackupRestoreNow || g_GameState == Get5State_PendingRestore) {
     ReplyToCommand(client, "Cannot add coaches while waiting for round backup.");
     return Plugin_Handled;
   } else if (g_PendingSideSwap || InHalftimePhase()) {
@@ -942,7 +941,7 @@ Action Command_AddKickedPlayer(int client, int args) {
         client,
         "Cannot use get5_addkickedplayer in scrim mode. Use get5_ringer to swap a player's team.");
     return Plugin_Handled;
-  } else if (g_DoingBackupRestoreNow || g_WaitingForRoundBackup) {
+  } else if (g_DoingBackupRestoreNow || g_GameState == Get5State_PendingRestore) {
     ReplyToCommand(client, "Cannot add players while waiting for round backup.");
     return Plugin_Handled;
   } else if (g_PendingSideSwap || InHalftimePhase()) {

--- a/scripting/get5/readysystem.sp
+++ b/scripting/get5/readysystem.sp
@@ -7,9 +7,10 @@ void ResetReadyStatus() {
   SetAllClientsReady(false);
 }
 
-static bool IsReadyGameState() {
-  return (g_GameState == Get5State_PreVeto || g_GameState == Get5State_Warmup) &&
-         !g_MapChangePending;
+bool IsReadyGameState() {
+  return (g_GameState == Get5State_PreVeto || g_GameState == Get5State_Warmup ||
+          g_GameState == Get5State_PendingRestore) &&
+         !IsDoingRestoreOrMapChange();
 }
 
 // Client ready status
@@ -244,14 +245,13 @@ static void HandleReadyMessage(Get5Team team) {
 
   if (g_GameState == Get5State_PreVeto) {
     Get5_MessageToAll("%t", "TeamReadyToVetoInfoMessage", g_FormattedTeamNames[team]);
+  } else if (g_GameState == Get5State_PendingRestore) {
+    Get5_MessageToAll("%t", "TeamReadyToRestoreBackupInfoMessage", g_FormattedTeamNames[team]);
   } else if (g_GameState == Get5State_Warmup) {
-    if (g_WaitingForRoundBackup) {
-      Get5_MessageToAll("%t", "TeamReadyToRestoreBackupInfoMessage", g_FormattedTeamNames[team]);
-    } else if (view_as<SideChoice>(g_MapSides.Get(g_MapNumber)) == SideChoice_KnifeRound) {
-      Get5_MessageToAll("%t", "TeamReadyToKnifeInfoMessage", g_FormattedTeamNames[team]);
-    } else {
-      Get5_MessageToAll("%t", "TeamReadyToBeginInfoMessage", g_FormattedTeamNames[team]);
-    }
+    bool knifeRound = view_as<SideChoice>(g_MapSides.Get(g_MapNumber)) == SideChoice_KnifeRound;
+    Get5_MessageToAll("%t",
+                      knifeRound ? "TeamReadyToKnifeInfoMessage" : "TeamReadyToBeginInfoMessage",
+                      g_FormattedTeamNames[team]);
   }
 }
 

--- a/scripting/get5/stats.sp
+++ b/scripting/get5/stats.sp
@@ -369,7 +369,7 @@ static void EndMolotovEvent(const char[] molotovKey) {
 
   Get5MolotovDetonatedEvent molotovObject;
   if (g_MolotovContainer.GetValue(molotovKey, molotovObject)) {
-    if (IsDoingRestoreOrMapChange()) {
+    if (g_GameState != Get5State_Live || IsDoingRestoreOrMapChange()) {
       delete molotovObject;
     } else {
       molotovObject.EndTime = GetRoundTime();
@@ -386,7 +386,7 @@ static void EndMolotovEvent(const char[] molotovKey) {
 static void EndHEEvent(const char[] grenadeKey) {
   Get5HEDetonatedEvent heObject;
   if (g_HEGrenadeContainer.GetValue(grenadeKey, heObject)) {
-    if (IsDoingRestoreOrMapChange()) {
+    if (g_GameState != Get5State_Live || IsDoingRestoreOrMapChange()) {
       delete heObject;
     } else {
       LogDebug("Calling Get5_OnHEGrenadeDetonated()");
@@ -402,7 +402,7 @@ static void EndHEEvent(const char[] grenadeKey) {
 static void EndFlashbangEvent(const char[] flashKey) {
   Get5FlashbangDetonatedEvent flashEvent;
   if (g_FlashbangContainer.GetValue(flashKey, flashEvent)) {
-    if (IsDoingRestoreOrMapChange()) {
+    if (g_GameState != Get5State_Live || IsDoingRestoreOrMapChange()) {
       delete flashEvent;
     } else {
       LogDebug("Calling Get5_OnFlashbangDetonated()");
@@ -505,12 +505,6 @@ static Action Stats_MolotovExtinguishedEvent(Event event, const char[] name, boo
 }
 
 static Action Stats_MolotovEndedEvent(Event event, const char[] name, bool dontBroadcast) {
-  // No backup check; the event is deleted in EndMolotovEvent to prevent leaks, as this function
-  // works like the the HE/flash timer callbacks which also do not check for backup state.
-  if (g_GameState != Get5State_Live) {
-    return;
-  }
-
   int entityId = event.GetInt("entityid");
 
   LogDebug("Molotov Event: %s, %d", name, entityId);

--- a/scripting/get5/util.sp
+++ b/scripting/get5/util.sp
@@ -226,8 +226,7 @@ stock void SetTeamInfo(int csTeam, const char[] name, const char[] flag = "",
   // Add Ready/Not ready tags to team name if in warmup.
   char taggedName[MAX_CVAR_LENGTH];
   if (g_ReadyTeamTagCvar.BoolValue) {
-    if ((g_GameState == Get5State_Warmup || g_GameState == Get5State_PreVeto) &&
-        !g_DoingBackupRestoreNow) {
+    if (IsReadyGameState()) {
       Get5Team matchTeam = CSTeamToGet5Team(csTeam);
       if (IsTeamReady(matchTeam)) {
         Format(taggedName, sizeof(taggedName), "%s %T", name, "ReadyTag", LANG_SERVER);
@@ -714,5 +713,5 @@ stock void convertSecondsToMinutesAndSeconds(int timeAsSeconds, char[] buffer,
 }
 
 stock bool IsDoingRestoreOrMapChange() {
-  return g_DoingBackupRestoreNow || g_WaitingForRoundBackup || g_MapChangePending;
+  return g_DoingBackupRestoreNow || g_MapChangePending;
 }

--- a/scripting/include/get5.inc
+++ b/scripting/include/get5.inc
@@ -38,6 +38,7 @@ enum Get5State {
   Get5State_WaitingForKnifeRoundDecision,  // waiting for a .stay/.swap command after the knife
   Get5State_GoingLive,                     // in the lo3 process
   Get5State_Live,                          // the match is live
+  Get5State_PendingRestore,                // pending restore to a live match
   Get5State_PostGame,                      // postgame screen + waiting for GOTV to finish broadcast
 };
 
@@ -1603,23 +1604,25 @@ methodmap Get5BombDefusedEvent < Get5PlayerBombEvent {
 stock void GameStateString(const Get5State state, char[] buffer, const int length) {
   switch (state) {
     case Get5State_None:
-      Format(buffer, length, "none");
+      FormatEx(buffer, length, "none");
     case Get5State_PreVeto:
-      Format(buffer, length, "pre_veto");
+      FormatEx(buffer, length, "pre_veto");
     case Get5State_Veto:
-      Format(buffer, length, "veto");
+      FormatEx(buffer, length, "veto");
     case Get5State_Warmup:
-      Format(buffer, length, "warmup");
+      FormatEx(buffer, length, "warmup");
     case Get5State_KnifeRound:
-      Format(buffer, length, "knife");
+      FormatEx(buffer, length, "knife");
     case Get5State_WaitingForKnifeRoundDecision:
-      Format(buffer, length, "waiting_for_knife_decision");
+      FormatEx(buffer, length, "waiting_for_knife_decision");
     case Get5State_GoingLive:
-      Format(buffer, length, "going_live");
+      FormatEx(buffer, length, "going_live");
     case Get5State_Live:
-      Format(buffer, length, "live");
+      FormatEx(buffer, length, "live");
+    case Get5State_PendingRestore:
+      FormatEx(buffer, length, "pending_restore");
     case Get5State_PostGame:
-      Format(buffer, length, "post_game");
+      FormatEx(buffer, length, "post_game");
   }
 }
 


### PR DESCRIPTION
I never liked the combination of game being in livemode with `g_WaitingForRoundBackup`. I think it makes more sense to have a gamestate that indicates that we're not live, but pending a restore to a live round.

This changes that. Untested so far.

It's a breaking change because of the new game state, but other than that everything should work the same, the code is just a little less messy in my opinion.