### PR TITLE
0.10.1 option 1

### DIFF
--- a/configs/get5/example_match.cfg
+++ b/configs/get5/example_match.cfg
@@ -49,8 +49,7 @@
 		"players"
 		{
 			// Any of the 3 formats (steam2, steam3, steam64 profile) are acceptable.
-			// Note: the "players" section may be skipped if you set get5_check_auths to 0,
-			// but that is not recommended. You can also set player names that will be forced here.
+			// You can also set player names that will be forced here.
 			// If you don't want to force player names, just use an empty quote "".
 			"STEAM_0:1:52245092"		"splewis"
 			"[U:1:104490185]"		""

--- a/configs/get5/scrim_template.cfg
+++ b/configs/get5/scrim_template.cfg
@@ -32,7 +32,6 @@
 		"mp_overtime_enable"		"0"
 		"mp_match_restart_delay"	"15"
 		"get5_max_pause_time"		"0"
-		"get5_check_auths"		"1"
 		"get5_demo_name_format"		"scrim_{TIME}_{MAPNAME}" // Set to "" to disable recording
 		"get5_kick_when_no_match_loaded"		"0"
 		"get5_print_damage"		"1" // Enabling will print damage on round-end.

--- a/documentation/docs/commands.md
+++ b/documentation/docs/commands.md
@@ -112,19 +112,18 @@ you use the [MySQL extension](../stats_system/#mysql).
 name.
 
 ####`get5_addcoach <auth> <team1|team2> [name]` {: #get5_addcoach }
-:   Adds a Steam ID to a team as a coach. The name parameter optionally locks the player's
-name.
+:   Adds a Steam ID to a team as a coach. The name parameter optionally locks the player's name.
 
 ####`get5_removeplayer <auth>` {: #get5_removeplayer}
 :   Removes a steam ID from all teams (can be any format for the Steam ID). This also removes the player as
-a [coach](coaching.md). If [`get5_check_auths`](../configuration/#get5_check_auths) is set, the player will be removed
-from the server immediately.
+a [coach](coaching.md). If the player is present on the server, they will be kicked immediately. In scrim mode, you
+must use [`get5_ringer`](#get5_ringer) instead.
 
 ####`get5_addkickedplayer <team1|team2|spec> [name]` {: #get5_addkickedplayer }
 :   Adds the last kicked Steam ID to a team. The name parameter optionally locks the player's name.
 
 ####`get5_removekickedplayer <team1|team2|spec>` {: #get5_removekickedplayer }
-:   Removes the last kicked Steam ID from all teams. Cannot be used in scrim mode.
+:   Shortcut for [`get5_removeplayer`](#get5_removeplayer), targeting the last kicked player.
 
 ####`get5_forceready`
 :   Marks all teams as ready. `get5_forcestart` does the same thing.
@@ -227,7 +226,8 @@ from the server immediately.
 
 ####`get5_ringer <target>` {: #get5_ringer }
 :   Adds/removes a ringer to/from the home scrim team. `target` is the name of the player, their user ID or their Steam
-ID. Similar to [`!ringer`](../commands/#ringer) in chat.
+ID. Similar to [`!ringer`](../commands/#ringer) in chat. This command only works in
+[scrim mode](../getting_started/#scrims).
 
 !!! example "User ID vs client index"
 

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -35,7 +35,8 @@ cfg/get5/live.cfg # (3)
 
     You should avoid these commands in your live, knife and warmup configuration files, as all of these are handled by
     Get5 automatically. Introducing restarts, warmup changes or [GOTV](gotv.md) delay modifications can cause problems.
-    If you want to set your `tv_delay`, do it in the `cvars` section of your [match configuration](match_schema.md).
+    If you want to set your `tv_delay` or `tv_delay1`, do it in the `cvars` section of your
+    [match configuration](match_schema.md).
 
     ```
     mp_do_warmup_period
@@ -46,8 +47,10 @@ cfg/get5/live.cfg # (3)
     mp_warmuptime
     mp_warmuptime_all_players_connected
     tv_delay
+    tv_delay1
     tv_delaymapchange
     tv_enable
+    tv_enable1
     tv_record
     tv_stoprecord
     ```
@@ -79,9 +82,19 @@ disconnect even in warmup with the intention to reconnect!). **`Default: 0`**
 :   Whether to wait for map vetoes to be printed to GOTV before changing map. **`Default: 0`**
 
 ####`get5_check_auths`
-:   Whether the Steam IDs from the `players` and `coaches` sections of a [match configuration](../match_schema/#schema)
-are used to force players onto teams. Anyone not defined will be removed from the game, or if
-in [scrim mode](../getting_started/#scrims), put on `team2`. **`Default: 1`**
+:   Whether the Steam IDs from the `players`, `coaches` and `spectators` sections of a
+[match configuration](../match_schema/#schema) are used to force players onto teams. Anyone not defined will be removed
+from the game. This is automatically enabled when a match configuration is loaded.<br>**`Default: 1`**
+
+!!! warning "Team locking is required for Get5 to work"
+
+    You cannot disable `get5_check_auths` in the [`cvars`](../match_schema/#schema) section of your match configuration,
+    and you **must not** disable it in your [live, warmup or knife config files](#phase-configuration-files). Get5 does
+    not work properly if this is disabled during a match, and it should only be disabled on a server expecting to use
+    the [`get5_creatematch`](../commands/#get5_creatematch) or [`get5_scrim`](../commands/#get5_scrim) command to create
+    a match. If you require player replacements during a match, see [`get5_addplayer`](../commands/#get5_addplayer), 
+    [`get5_addcoach`](../commands/#get5_addcoach), [`get5_removeplayer`](../commands/#get5_removeplayer) and
+    [`get5_ringer`](../commands/#get5_ringer).
 
 ####`get5_print_update_notice`
 :   Whether to print to chat when the game goes live if a new version of Get5 is available. This only works if

--- a/documentation/docs/getting_started.md
+++ b/documentation/docs/getting_started.md
@@ -26,11 +26,6 @@ name and optionally flag and logo as well as any spectators/casters. Once you've
 using the [`get5_loadmatch`](../commands/#get5_loadmatch) command or configure your server to automatically load the
 file as soon as a player joins by setting [`get5_autoload_config`](../configuration/#get5_autoload_config).
 
-!!! tip "Lock it down"
-
-    When loading match configurations, ensure that [`get5_check_auths`](../configuration/#get5_check_auths) is enabled.
-    This ensures that people are locked to the correct teams and that nobody else can join the server.
-
 ## Scrims {: #scrims }
 
 While Get5 is intended for matches (league matches, LANs, cups, etc.), it can be used for everyday

--- a/documentation/docs/stats_system.md
+++ b/documentation/docs/stats_system.md
@@ -1,10 +1,5 @@
 # :material-chart-bar: Player Stats System
 
-!!! warning
-
-    None of the methods for collecting stats are going to be reliable if
-    [`get5_check_auths`](../configuration/#get5_check_auths) is set to `0`.
-
 ## SourceMod Forwards {: #forwards }
 
 If you're writing your own plugin, you can collect stats from the game using the

--- a/scripting/get5/backups.sp
+++ b/scripting/get5/backups.sp
@@ -486,10 +486,10 @@ bool RestoreFromBackup(const char[] path, bool restartRecording = true) {
 
 void RestoreGet5Backup(bool restartRecording = true) {
   // If you load a backup during a live round, the game might get stuck if there are only bots
-  // remaining and no players are alive. Other stuff will probably also go wrong, so we just reset
-  // the game before loading the backup to avoid any weird edge-cases.
+  // remaining and no players are alive. Other stuff will probably also go wrong, so we put the game into
+  // warmup. We **cannot** restart the game as that causes problems for tournaments using the logging system.
   if (!InWarmup()) {
-    RestartGame();
+    StartWarmup();
   }
   ExecCfg(g_LiveCfgCvar);
   PauseGame(Get5Team_None, Get5PauseType_Backup);

--- a/scripting/get5/kniferounds.sp
+++ b/scripting/get5/kniferounds.sp
@@ -40,15 +40,8 @@ static void PerformSideSwap(bool swap) {
     g_TeamSide[Get5Team_1] = tmp;
 
     LOOP_CLIENTS(i) {
-      if (IsValidClient(i) && !IsClientSourceTV(i)) {
-        if (IsFakeClient(i)) {
-          // Because bots never have an assigned team, they won't be moved around by
-          // CheckClientTeam. We kick them to prevent one team from having too many players. They
-          // will rejoin if defined in the live config.
-          KickClient(i);
-        } else {
-          CheckClientTeam(i, false);
-        }
+      if (IsPlayer(i)) {
+        CheckClientTeam(i, false);
       }
     }
     // Make sure g_MapSides has the correct values as well,

--- a/scripting/get5/version.sp
+++ b/scripting/get5/version.sp
@@ -1,6 +1,6 @@
 #tryinclude "manual_version.sp"
 #if !defined PLUGIN_VERSION
-#define PLUGIN_VERSION "0.10.0-dev"
+#define PLUGIN_VERSION "0.10.1-dev"
 #endif
 
 // This MUST be the latest version in x.y.z semver format followed by -dev.


### PR DESCRIPTION
A couple of problems that require immediate attention for 0.10:

1, We don't want to kick bots when team-swapping after knife; it kicks the secondary GOTV client (`tv_enable1`), which for some reason passes the `IsClientGoTV()`check, and also it is simply not necessary to kick bots.
2. We must set `get5_check_auths` to true when loading a match, as team swapping and such depends on this. It is set in the `cvars` section so that it can be restored to 0 (if that was the value it had) when the match ends.
3. We **cannot** restart the game when loading a backup. The game must be sent to warmup instead, as it otherwise causes problems for various tournament logging systems. I have verified that this *also* works fine to prevent bots from getting stuck if you restore the game when only bots are left alive - this was the reason it was implemented to begin with.