### PR TITLE
fix request memory leak and check for http status codes + added debug logging to apistats when no api key was provided

### DIFF
--- a/scripting/get5/natives.sp
+++ b/scripting/get5/natives.sp
@@ -21,6 +21,7 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
   CreateNative("Get5_AddLiveCvar", Native_AddLiveCvar);
   CreateNative("Get5_IncreasePlayerStat", Native_IncreasePlayerStat);
   CreateNative("Get5_GetMatchStats", Native_GetMatchStats);
+  CreateNative("Get5_CreateGet5HTTPRequest", Native_CreateGet5HTTPRequest);
   RegPluginLibrary("get5");
   return APLRes_Success;
 }
@@ -250,4 +251,11 @@ public int Native_GetMatchStats(Handle plugin, int numParams) {
     g_StatsKv.Rewind();
     return view_as<int>(true);
   }
+}
+
+public int Native_CreateGet5HTTPRequest(Handle plugin, int numParams) {
+  EHTTPMethod method = view_as<EHTTPMethod>(GetNativeCell(1));
+  char url[1024];
+  GetNativeString(2, url, sizeof(url));
+  return view_as<int>(CreateGet5HTTPRequest(method, url));
 }

--- a/scripting/include/get5.inc
+++ b/scripting/include/get5.inc
@@ -5,6 +5,7 @@
 
 #include <json>  // github.com/clugg/sm-json
 #include <cstrike>
+#include <SteamWorks>
 
 enum Get5Side {
   Get5Side_None = CS_TEAM_NONE,
@@ -135,6 +136,8 @@ native bool Get5_GetMatchStats(KeyValues kv);
 // Increases an (integer-typed) player statistic in the plugin's stats keyvalue structure.
 native int Get5_IncreasePlayerStat(int client, const char[] statName, int amount = 1);
 
+// Creates a Steamworks http(s) request with the get5 headers
+native Handle Get5_CreateGet5HTTPRequest(const EHTTPMethod method, const char[] url);
 
 methodmap Get5StatusTeam < JSON_Object {
 


### PR DESCRIPTION
when no api key is setted in get5_apistats, CreateRequest just returns INVALID_HANDLE and nothing happens, so i added debug logging in there. Related to: https://github.com/splewis/get5/issues/873#issuecomment-1244574027

Also since i touched apistats, i tried to implement the changes @nickdnk already suggested in #868

Please review my changes carefully, i might have deleted a request in a wrong place or smth like that, since i'm not able to test the changes at the moment.
