### PR TITLE
0.10.2

### DIFF
--- a/documentation/docs/commands.md
+++ b/documentation/docs/commands.md
@@ -227,14 +227,16 @@ from the server immediately.
 
 ####`get5_ringer <target>` {: #get5_ringer }
 :   Adds/removes a ringer to/from the home scrim team. `target` is the name of the player, their user ID or their Steam
-ID. Similar to [`!ringer`](../commands/#ringer) in chat.
+ID. Similar to [`!ringer`](../commands/#ringer) in chat. To target a user or Steam ID, prefix it with a `#`, i.e.
+`get5_ringer #43` to target user ID 43.
+See [this article](https://wiki.alliedmods.net/Admin_Commands_(SourceMod)#How_to_Target) for details.
 
 !!! example "User ID vs client index"
 
-    To view user IDs, type `users` in console. In this example, `3` is the user ID and `1` is the client index:
+    To view user IDs, type `users` in console. In this example, `43` is the user ID and `1` is the client index:
     ```
     > users
-    1:3:"Quinn"
+    1:43:"Quinn"
     ```
 
 ####`get5_debuginfo [file]` {: #get5_debuginfo }

--- a/documentation/docs/match_schema.md
+++ b/documentation/docs/match_schema.md
@@ -129,12 +129,28 @@ interface Get5Match {
     point to must be in the same format as the main file, so pointing to a `.cfg` file when the main file is `.json`
     will **not** work.
 29. _Optional_<br>The name of the spectator team.<br><br>**`Default: "casters"`**
-30. _Optional_<br>The spectator/caster Steam IDs and names.
+30. _Optional_<br>The spectator/caster Steam IDs and names. Setting a Steam ID as spectator takes precedence over being
+    set as a player or coach.
 31. _Optional_<br>Determines the starting sides for each map. If this array is shorter than `num_maps`, `side_type` will
     determine the side-behavior of the remaining maps. Ignored if `skip_veto` is `false`.
     <br><br>**`Default: undefined`**
 32. _Optional_<br>If `false`, the entire map list will be played, regardless of score. If `true`, a series will be won
     when the series score for a team exceeds the number of maps divided by two.<br><br>**`Default: true`**
+
+!!! info "Team assignment priority"
+
+    If you define a Steam ID in more than one location in your match configuration, it will be evaluated in this order
+    to determine where to put the player:
+
+    1. Spectator
+    2. Coach for `team1`
+    3. Coach for `team2`
+    4. Player for `team1`
+    5. Player for `team2`
+
+    If a player's Steam ID was not found in any of these locations, they will be
+    [removed from the server](../configuration/#get5_check_auths) unless you are
+    in [scrim mode](../getting_started/#scrims).
 
 ## Examples {: #example }
 

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -122,7 +122,7 @@ int g_MapNumber = 0;             // the current map number, starting at 0.
 int g_NumberOfMapsInSeries = 0;  // the number of maps to play in the series.
 char g_MatchID[MATCH_ID_LENGTH];
 ArrayList g_MapPoolList = null;
-ArrayList g_TeamAuths[MATCHTEAM_COUNT];
+ArrayList g_TeamPlayers[MATCHTEAM_COUNT];
 ArrayList g_TeamCoaches[MATCHTEAM_COUNT];
 StringMap g_PlayerNames;
 char g_TeamNames[MATCHTEAM_COUNT][MAX_CVAR_LENGTH];
@@ -571,8 +571,8 @@ public void OnPluginStart() {
   g_CvarValues = new ArrayList(MAX_CVAR_LENGTH);
   g_TeamScoresPerMap = new ArrayList(MATCHTEAM_COUNT);
 
-  for (int i = 0; i < sizeof(g_TeamAuths); i++) {
-    g_TeamAuths[i] = new ArrayList(AUTH_LENGTH);
+  for (int i = 0; i < sizeof(g_TeamPlayers); i++) {
+    g_TeamPlayers[i] = new ArrayList(AUTH_LENGTH);
     // Same length.
     g_TeamCoaches[i] = new ArrayList(AUTH_LENGTH);
   }

--- a/scripting/get5/debug.sp
+++ b/scripting/get5/debug.sp
@@ -133,7 +133,7 @@ static void AddGlobalStateInfo(File f) {
     GetTeamString(team, buffer, sizeof(buffer));
     f.WriteLine("Team info for %s (%d):", buffer, team);
     f.WriteLine("g_TeamNames = %s", g_TeamNames[team]);
-    WriteArrayList(f, "g_TeamAuths", g_TeamAuths[team]);
+    WriteArrayList(f, "g_TeamPlayers", g_TeamPlayers[team]);
     f.WriteLine("g_TeamTags = %s", g_TeamTags[team]);
     f.WriteLine("g_FormattedTeamNames = %s", g_FormattedTeamNames[team]);
     f.WriteLine("g_TeamFlags = %s", g_TeamFlags[team]);

--- a/scripting/get5/natives.sp
+++ b/scripting/get5/natives.sp
@@ -166,11 +166,11 @@ public int Native_GetPlayerTeam(Handle plugin, int numParams) {
   GetNativeString(1, auth, sizeof(auth));
 
   char steam64Auth[AUTH_LENGTH];
+  Get5Team team = Get5Team_None;
   if (ConvertAuthToSteam64(auth, steam64Auth, false)) {
-    return view_as<int>(GetAuthMatchTeam(steam64Auth));
-  } else {
-    return view_as<int>(Get5Team_None);
+    team = GetAuthMatchTeam(steam64Auth);
   }
+  return view_as<int>(team);
 }
 
 public int Native_CSTeamToGet5Team(Handle plugin, int numParams) {

--- a/scripting/get5/natives.sp
+++ b/scripting/get5/natives.sp
@@ -168,7 +168,7 @@ public int Native_GetPlayerTeam(Handle plugin, int numParams) {
   char steam64Auth[AUTH_LENGTH];
   Get5Team team = Get5Team_None;
   if (ConvertAuthToSteam64(auth, steam64Auth, false)) {
-    team = GetAuthMatchTeam(steam64Auth);
+    team = GetMatchTeamFromAuth(steam64Auth);
   }
   return view_as<int>(team);
 }

--- a/scripting/get5/stats.sp
+++ b/scripting/get5/stats.sp
@@ -932,15 +932,10 @@ static Action Stats_RoundMVPEvent(Event event, const char[] name, bool dontBroad
   }
 }
 
-static int GetPlayerStat(int client, const char[] field) {
+static int IncrementPlayerStatByValue(int client, const char[] field, int incrementBy) {
   GoToPlayer(client);
-  int value = g_StatsKv.GetNum(field);
-  GoBackFromPlayer();
-  return value;
-}
-
-static int SetPlayerStat(int client, const char[] field, int newValue) {
-  GoToPlayer(client);
+  int current = g_StatsKv.GetNum(field, 0);
+  int newValue = current + incrementBy;
   g_StatsKv.SetNum(field, newValue);
   GoBackFromPlayer();
   return newValue;
@@ -1015,8 +1010,7 @@ int AddToPlayerStat(int client, const char[] field, int delta) {
     return 0;
   }
   LogDebug("Updating player stat %s for %L", field, client);
-  int value = GetPlayerStat(client, field);
-  return SetPlayerStat(client, field, value + delta);
+  return IncrementPlayerStatByValue(client, field, delta);
 }
 
 static int IncrementPlayerStat(int client, const char[] field) {

--- a/scripting/get5/teamlogic.sp
+++ b/scripting/get5/teamlogic.sp
@@ -17,6 +17,15 @@ void CheckClientTeam(int client) {
     return;
   }
 
+  if (correctTeam == Get5Team_Spec) {
+    if (CountPlayersOnTeam(correctTeam, client) >= FindConVar("mp_spectators_max").IntValue) {
+      KickClient(client, "%t", "TeamIsFullInfoMessage");
+    } else {
+      SwitchPlayerTeam(client, Get5Side_Spec);
+    }
+    return;
+  }
+
   Get5Side correctSide = view_as<Get5Side>(Get5TeamToCSTeam(correctTeam));
   if (correctSide == Get5Side_None) {
     // This should not be possible.
@@ -126,7 +135,7 @@ void CoachingChangedHook(ConVar convar, const char[] oldValue, const char[] newV
 
 Action Command_SmCoach(int client, int args) {
   if (g_GameState == Get5State_None || !IsPlayer(client)) {
-    return Plugin_Continue;
+    return;
   }
 
   if (!g_CheckAuthsCvar.BoolValue) {
@@ -136,25 +145,25 @@ Action Command_SmCoach(int client, int args) {
     } else if (side == Get5Side_T) {
       FakeClientCommand(client, "coach t");
     }
-    return Plugin_Continue;
+    return;
   }
 
   if (!g_CoachingEnabledCvar.BoolValue) {
     char formattedCoachingCvar[64];
     FormatCvarName(formattedCoachingCvar, sizeof(formattedCoachingCvar), "sv_coaching_enabled");
     Get5_Message(client, "%t", "CoachingNotEnabled", formattedCoachingCvar);
-    return Plugin_Continue;
+    return;
   }
 
   Get5Team matchTeam = GetClientMatchTeam(client);
 
-  if (matchTeam == Get5Team_None) {
-    return Plugin_Continue;
+  if (matchTeam == Get5Team_None || matchTeam == Get5Team_Spec) {
+    return;
   }
 
   if (g_GameState > Get5State_Warmup) {
     Get5_Message(client, "%t", "CanOnlyCoachDuringWarmup");
-    return Plugin_Continue;
+    return;
   }
 
   // These counts are excluding the client, so >=.
@@ -166,37 +175,36 @@ Action Command_SmCoach(int client, int args) {
     if (IsClientCoaching(client)) {
       if (playerSlotsFull) {
         Get5_Message(client, "%t", "CannotLeaveCoachingTeamIsFull");
-        return Plugin_Continue;
+        return;
       }
       // Fall-through to CheckClientTeam(i) below, which moves the player back on the team because
       // they are not defined as a coach in auth.
     } else {
       if (coachSlotsFull) {
         Get5_Message(client, "%t", "AllCoachSlotsFilledForTeam", g_CoachesPerTeam);
-        return Plugin_Continue;
+        return;
       }
       // We use SetClientCoaching instead of fall-though because of missing auth.
       SetClientCoaching(client, view_as<Get5Side>(Get5TeamToCSTeam(matchTeam)));
-      return Plugin_Continue;
+      return;
     }
   } else {
     if (IsClientCoachForTeam(client, matchTeam)) {
       if (playerSlotsFull) {
         Get5_Message(client, "%t", "CannotLeaveCoachingTeamIsFull");
-        return Plugin_Continue;
+        return;
       }
       MoveCoachToPlayerInConfig(client, matchTeam);
     } else {
       if (coachSlotsFull) {
         Get5_Message(client, "%t", "AllCoachSlotsFilledForTeam", g_CoachesPerTeam);
-        return Plugin_Continue;
+        return;
       }
       MovePlayerToCoachInConfig(client, matchTeam);
     }
   }
   // Move the player. This would potentially kick them if we did not perform above checks.
   CheckClientTeam(client);
-  return Plugin_Continue;
 }
 
 static void MovePlayerToCoachInConfig(const int client, const Get5Team team) {
@@ -205,10 +213,10 @@ static void MovePlayerToCoachInConfig(const int client, const Get5Team team) {
   if (AddCoachToTeam(auth, team, "")) {
     // If we're already on the team, make sure we remove ourselves
     // to ensure data is correct in the backups.
-    int index = GetTeamAuths(team).FindString(auth);
+    int index = GetTeamPlayers(team).FindString(auth);
     if (index >= 0) {
       LogDebug("Removing client %d from player team auth array for team %d.", client, team);
-      GetTeamAuths(team).Erase(index);
+      GetTeamPlayers(team).Erase(index);
     }
   }
 }
@@ -244,11 +252,7 @@ Get5Team GetClientMatchTeam(int client) {
   } else {
     char auth[AUTH_LENGTH];
     if (GetAuth(client, auth, sizeof(auth))) {
-      Get5Team playerTeam = GetAuthMatchTeam(auth);
-      if (playerTeam == Get5Team_None) {
-        playerTeam = GetAuthMatchCoachTeam(auth);
-      }
-      return playerTeam;
+      return GetAuthMatchTeam(auth);
     } else {
       return Get5Team_None;
     }
@@ -279,33 +283,31 @@ Get5Team CSTeamToGet5Team(int csTeam) {
   }
 }
 
-Get5Team GetAuthMatchTeam(const char[] steam64) {
-  if (g_InScrimMode) {
-    return IsAuthOnTeam(steam64, Get5Team_1) ? Get5Team_1 : Get5Team_2;
+Get5Team GetAuthMatchTeam(const char[] steam64, bool includeCoaches = true, bool includePlayers = true) {
+  // Spectator always takes priority.
+  if (IsAuthOnTeamPlayer(steam64, Get5Team_Spec)) {
+    return Get5Team_Spec;
   }
-
-  for (int i = 0; i < MATCHTEAM_COUNT; i++) {
-    Get5Team team = view_as<Get5Team>(i);
-    if (IsAuthOnTeam(steam64, team)) {
-      return team;
+  // No locked coaches in scrim mode; everyone not a player on team 1 is player on team 2.
+  if (g_InScrimMode) {
+    return IsAuthOnTeamPlayer(steam64, Get5Team_1) ? Get5Team_1 : Get5Team_2;
+  }
+  // If not scrim, first check coaches.
+  if (includeCoaches) {
+    if (IsAuthOnTeamCoach(steam64, Get5Team_1)) {
+      return Get5Team_1;
+    }
+    if (IsAuthOnTeamCoach(steam64, Get5Team_2)) {
+      return Get5Team_2;
     }
   }
-  return Get5Team_None;
-}
-
-Get5Team GetAuthMatchCoachTeam(const char[] steam64) {
-  if (g_GameState == Get5State_None) {
-    return Get5Team_None;
-  }
-
-  if (g_InScrimMode) {
-    return IsAuthOnTeamCoach(steam64, Get5Team_1) ? Get5Team_1 : Get5Team_2;
-  }
-
-  for (int i = 0; i < MATCHTEAM_COUNT; i++) {
-    Get5Team team = view_as<Get5Team>(i);
-    if (IsAuthOnTeamCoach(steam64, team)) {
-      return team;
+  // Then players.
+  if (includePlayers) {
+    if (IsAuthOnTeamPlayer(steam64, Get5Team_1)) {
+      return Get5Team_1;
+    }
+    if (IsAuthOnTeamPlayer(steam64, Get5Team_2)) {
+      return Get5Team_2;
     }
   }
   return Get5Team_None;
@@ -364,7 +366,7 @@ int GetTeamCaptain(Get5Team team) {
   }
 
   // For consistency, always take the 1st auth on the list.
-  ArrayList auths = GetTeamAuths(team);
+  ArrayList auths = GetTeamPlayers(team);
   char buffer[AUTH_LENGTH];
   for (int i = 0; i < auths.Length; i++) {
     auths.GetString(i, buffer, sizeof(buffer));
@@ -384,16 +386,16 @@ int GetNextTeamCaptain(int client) {
   }
 }
 
-ArrayList GetTeamAuths(Get5Team team) {
-  return g_TeamAuths[team];
+ArrayList GetTeamPlayers(Get5Team team) {
+  return g_TeamPlayers[team];
 }
 
 ArrayList GetTeamCoaches(Get5Team team) {
   return g_TeamCoaches[team];
 }
 
-static bool IsAuthOnTeam(const char[] auth, Get5Team team) {
-  return GetTeamAuths(team).FindString(auth) >= 0;
+static bool IsAuthOnTeamPlayer(const char[] auth, Get5Team team) {
+  return GetTeamPlayers(team).FindString(auth) >= 0;
 }
 
 static bool IsAuthOnTeamCoach(const char[] auth, Get5Team team) {
@@ -429,8 +431,8 @@ bool AddPlayerToTeam(const char[] auth, Get5Team team, const char[] name) {
     return false;
   }
 
-  if (GetAuthMatchTeam(steam64) == Get5Team_None) {
-    GetTeamAuths(team).PushString(steam64);
+  if (GetAuthMatchTeam(steam64, false, true) == Get5Team_None) {
+    GetTeamPlayers(team).PushString(steam64);
     Get5_SetPlayerName(auth, name);
     return true;
   } else {
@@ -439,17 +441,12 @@ bool AddPlayerToTeam(const char[] auth, Get5Team team, const char[] name) {
 }
 
 bool AddCoachToTeam(const char[] auth, Get5Team team, const char[] name) {
-  if (team == Get5Team_Spec) {
-    LogDebug("Not allowed to coach a spectator team.");
-    return false;
-  }
-
   char steam64[AUTH_LENGTH];
   if (!ConvertAuthToSteam64(auth, steam64)) {
     return false;
   }
 
-  if (GetAuthMatchCoachTeam(steam64) == Get5Team_None) {
+  if (GetAuthMatchTeam(steam64, true, false) == Get5Team_None) {
     GetTeamCoaches(team).PushString(steam64);
     Get5_SetPlayerName(auth, name);
     return true;
@@ -463,27 +460,31 @@ bool RemovePlayerFromTeams(const char[] auth) {
   if (!ConvertAuthToSteam64(auth, steam64)) {
     return false;
   }
-
-  for (int i = 0; i < MATCHTEAM_COUNT; i++) {
+  bool found = false;
+  LOOP_TEAMS(i) {
     Get5Team team = view_as<Get5Team>(i);
-    int index = GetTeamAuths(team).FindString(steam64);
-    if (index >= 0) {
-      GetTeamAuths(team).Erase(index);
-    } else {
-      index = GetTeamCoaches(team).FindString(steam64);
-      if (index >= 0) {
-        GetTeamCoaches(team).Erase(index);
-      }
+    if (RemoveFromTeamAuthArrayAndKick(steam64, GetTeamPlayers(team))) {
+      found = true;
     }
-    if (index >= 0) {
-      int target = AuthToClient(steam64);
-      if (IsAuthedPlayer(target) && !g_InScrimMode) {
-        RememberAndKickClient(target, "%t", "YouAreNotAPlayerInfoMessage");
-      }
-      return true;
+    if (RemoveFromTeamAuthArrayAndKick(steam64, GetTeamCoaches(team))) {
+      found = true;
     }
   }
-  return false;
+  return found;
+}
+
+static bool RemoveFromTeamAuthArrayAndKick(const char[] auth, const ArrayList team) {
+  int index = team.FindString(auth);
+  if (index == -1) {
+    return false;
+  }
+  team.Erase(index);
+  int target = AuthToClient(auth);
+  // RemovePlayerFromTeams is used with get5_ringer, so we don't kick in scrim mode!
+  if (IsAuthedPlayer(target) && !g_InScrimMode) {
+    RememberAndKickClient(target, "%t", "YouAreNotAPlayerInfoMessage");
+  }
+  return true;
 }
 
 void LoadPlayerNames() {
@@ -492,7 +493,7 @@ void LoadPlayerNames() {
   LOOP_TEAMS(team) {
     char id[AUTH_LENGTH + 1];
     char name[MAX_NAME_LENGTH + 1];
-    ArrayList ids = GetTeamAuths(team);
+    ArrayList ids = GetTeamPlayers(team);
     ArrayList coachIds = GetTeamCoaches(team);
     for (int i = 0; i < ids.Length; i++) {
       ids.GetString(i, id, sizeof(id));
@@ -536,7 +537,7 @@ void SwapScrimTeamStatus(int client) {
     if (!alreadyInList) {
       char steam64[AUTH_LENGTH];
       ConvertAuthToSteam64(auth, steam64);
-      GetTeamAuths(Get5Team_1).PushString(steam64);
+      GetTeamPlayers(Get5Team_1).PushString(steam64);
     }
     CheckClientTeam(client);
   }

--- a/scripting/get5/teamlogic.sp
+++ b/scripting/get5/teamlogic.sp
@@ -252,7 +252,7 @@ Get5Team GetClientMatchTeam(int client) {
   } else {
     char auth[AUTH_LENGTH];
     if (GetAuth(client, auth, sizeof(auth))) {
-      return GetAuthMatchTeam(auth);
+      return GetMatchTeamFromAuth(auth);
     } else {
       return Get5Team_None;
     }
@@ -283,7 +283,7 @@ Get5Team CSTeamToGet5Team(int csTeam) {
   }
 }
 
-Get5Team GetAuthMatchTeam(const char[] steam64, bool includeCoaches = true, bool includePlayers = true) {
+Get5Team GetMatchTeamFromAuth(const char[] steam64, bool includeCoaches = true, bool includePlayers = true) {
   // Spectator always takes priority.
   if (IsAuthOnTeamPlayer(steam64, Get5Team_Spec)) {
     return Get5Team_Spec;
@@ -431,7 +431,7 @@ bool AddPlayerToTeam(const char[] auth, Get5Team team, const char[] name) {
     return false;
   }
 
-  if (GetAuthMatchTeam(steam64, false, true) == Get5Team_None) {
+  if (GetMatchTeamFromAuth(steam64, false, true) == Get5Team_None) {
     GetTeamPlayers(team).PushString(steam64);
     Get5_SetPlayerName(auth, name);
     return true;
@@ -446,7 +446,7 @@ bool AddCoachToTeam(const char[] auth, Get5Team team, const char[] name) {
     return false;
   }
 
-  if (GetAuthMatchTeam(steam64, true, false) == Get5Team_None) {
+  if (GetMatchTeamFromAuth(steam64, true, false) == Get5Team_None) {
     GetTeamCoaches(team).PushString(steam64);
     Get5_SetPlayerName(auth, name);
     return true;

--- a/scripting/get5/version.sp
+++ b/scripting/get5/version.sp
@@ -1,6 +1,6 @@
 #tryinclude "manual_version.sp"
 #if !defined PLUGIN_VERSION
-#define PLUGIN_VERSION "0.10.1-dev"
+#define PLUGIN_VERSION "0.10.2-dev"
 #endif
 
 // This MUST be the latest version in x.y.z semver format followed by -dev.


### PR DESCRIPTION
It seems there are some problems related to spectators and the priority of team-selection if a player is defined in multiple places in a match configuration.

1. This change ensures that team assignment is always in this priority:

    1. Spectator
    2. Coach for team1
    3. Coach for team2
    4. Player on team1
    5. Player on team2

2. Spectators cannot ".coach" and they will be removed if they exceed the `mp_spectators_max` cvar.
3. Renamed `GetTeamAuths` to `GetTeamPlayers`, so it has more consistent naming, as the one for coaches simply is `GetTeamCoaches`. Renamed `g_TeamAuths` to `g_TeamPlayers` as well.
4. `GetAuthMatchCoachTeam` has been merged into `GetMatchTeamFromAuth` and renamed for a single-point-of-entry that handles the logical flow for which team you belong to.
5. Consistently reset the player auth arrays when loading teams or spectator dictionaries. This was a bit hit-and-miss before.
6. Allow spectators in scrim templates, which this new logic allows.
7. Avoid duplicate calls to `GetClientMatchTeam` in `GetPlayerStat` + `GetPlayerStat` when incrementing stats. Tested and works.

I would like to release this as 0.10.2.