### PR TITLE
Optimize calls to stat increments

### DIFF
--- a/scripting/get5/stats.sp
+++ b/scripting/get5/stats.sp
@@ -921,15 +921,10 @@ static Action Stats_RoundMVPEvent(Event event, const char[] name, bool dontBroad
   }
 }
 
-static int GetPlayerStat(int client, const char[] field) {
+static int IncrementPlayerStatByValue(int client, const char[] field, int incrementBy) {
   GoToPlayer(client);
-  int value = g_StatsKv.GetNum(field);
-  GoBackFromPlayer();
-  return value;
-}
-
-static int SetPlayerStat(int client, const char[] field, int newValue) {
-  GoToPlayer(client);
+  int current = g_StatsKv.GetNum(field, 0);
+  int newValue = current + incrementBy;
   g_StatsKv.SetNum(field, newValue);
   GoBackFromPlayer();
   return newValue;
@@ -1004,8 +999,7 @@ int AddToPlayerStat(int client, const char[] field, int delta) {
     return 0;
   }
   LogDebug("Updating player stat %s for %L", field, client);
-  int value = GetPlayerStat(client, field);
-  return SetPlayerStat(client, field, value + delta);
+  return IncrementPlayerStatByValue(client, field, delta);
 }
 
 static int IncrementPlayerStat(int client, const char[] field) {


### PR DESCRIPTION
When I was working on https://github.com/splewis/get5/pull/876, I noticed that we do this:

```c
int value = GetPlayerStat(client, field);
return SetPlayerStat(client, field, value + delta);
```

 - which triggers a call to `GetClientMatchTeam` for both reading the value **and** writing it just after. This doubles the calls to this function which has to auth and then check all team arrays to find out where a player belongs. This is already time-consuming enough, so doing it twice for absolutely no reason is not very clever.