### PR TITLE
Fix problems with game going directly to live, skipping countdown

### DIFF
--- a/scripting/get5/kniferounds.sp
+++ b/scripting/get5/kniferounds.sp
@@ -98,10 +98,11 @@ static void EndKnifeRound(bool swap) {
 }
 
 static bool AwaitingKnifeDecision(int client) {
-  bool waiting = g_GameState == Get5State_WaitingForKnifeRoundDecision;
+  if (g_GameState != Get5State_WaitingForKnifeRoundDecision || g_KnifeWinnerTeam == Get5Team_None) {
+    return false;
+  }
   bool onWinningTeam = IsPlayer(client) && GetClientMatchTeam(client) == g_KnifeWinnerTeam;
-  bool admin = (client == 0);
-  return waiting && (onWinningTeam || admin);
+  return onWinningTeam || (client == 0);
 }
 
 Action Command_Stay(int client, int args) {
@@ -152,7 +153,7 @@ Action Command_T(int client, int args) {
 
 Action Timer_ForceKnifeDecision(Handle timer) {
   g_KnifeDecisionTimer = INVALID_HANDLE;
-  if (g_GameState == Get5State_WaitingForKnifeRoundDecision) {
+  if (g_GameState == Get5State_WaitingForKnifeRoundDecision && g_KnifeWinnerTeam != Get5Team_None) {
     Get5_MessageToAll("%t", "TeamLostTimeToDecideInfoMessage",
                       g_FormattedTeamNames[g_KnifeWinnerTeam]);
     EndKnifeRound(false);

--- a/scripting/get5/version.sp
+++ b/scripting/get5/version.sp
@@ -1,6 +1,6 @@
 #tryinclude "manual_version.sp"
 #if !defined PLUGIN_VERSION
-#define PLUGIN_VERSION "0.10.2-dev"
+#define PLUGIN_VERSION "0.10.3-dev"
 #endif
 
 // This MUST be the latest version in x.y.z semver format followed by -dev.

--- a/scripting/include/get5.inc
+++ b/scripting/include/get5.inc
@@ -36,7 +36,7 @@ enum Get5State {
   Get5State_Warmup,                        // setup done, waiting for players to ready up
   Get5State_KnifeRound,                    // in the knife round
   Get5State_WaitingForKnifeRoundDecision,  // waiting for a .stay/.swap command after the knife
-  Get5State_GoingLive,                     // in the lo3 process
+  Get5State_GoingLive,                     // counting down to live
   Get5State_Live,                          // the match is live
   Get5State_PostGame,                      // postgame screen + waiting for GOTV to finish broadcast
 };


### PR DESCRIPTION
A lovely race condition issue here.

On the current 0.10 release, there is a bug where if you time your `!swap` or `!stay` command "right", it will land in the 1 second gap between the plugin changing to "waiting for knife decision"  and actually going into warmup, which will send the game directly into live. This in itself is not so terrible, but this **also** means that the `OnRoundStart` event fires with `g_RoundNumber` set to 1 for the first round, where it should be 0. This breaks basically anything reading that forward, including the default MySQL extension.