### PR TITLE
Use get5_server_id to prevent backup file collisions

### DIFF
--- a/documentation/docs/backup.md
+++ b/documentation/docs/backup.md
@@ -31,13 +31,13 @@ They print in the format `filepath timestamp team1 team2 map team1_score team2_s
 
 ```
 > get5_listbackups
-get5_backup_4_match1844_map0_prelive.cfg 2022-07-26 18:51:25 "Team A" "Team B"
-get5_backup_4_match1844_map0_round30.cfg 2022-07-26 19:13:41 "Team A" "Team B" de_dust2 2 28
-get5_backup_4_match1844_map0_round4.cfg 2022-07-26 18:55:01 "Team A" "Team B" de_dust2 2 2
-get5_backup_4_match1844_map0_round10.cfg 2022-07-26 18:59:25 "Team A" "Team B" de_dust2 2 8
-get5_backup_4_match1844_map0_round23.cfg 2022-07-26 19:08:13 "Team A" "Team B" de_dust2 2 21
-get5_backup_4_match1844_map0_round12.cfg 2022-07-26 19:00:26 "Team A" "Team B" de_dust2 2 10
-get5_backup_4_match1844_map0_round17.cfg 2022-07-26 19:03:39 "Team A" "Team B" de_dust2 2 15
+get5_backup4_match1844_map0_prelive.cfg 2022-07-26 18:51:25 "Team A" "Team B"
+get5_backup4_match1844_map0_round30.cfg 2022-07-26 19:13:41 "Team A" "Team B" de_dust2 2 28
+get5_backup4_match1844_map0_round4.cfg 2022-07-26 18:55:01 "Team A" "Team B" de_dust2 2 2
+get5_backup4_match1844_map0_round10.cfg 2022-07-26 18:59:25 "Team A" "Team B" de_dust2 2 8
+get5_backup4_match1844_map0_round23.cfg 2022-07-26 19:08:13 "Team A" "Team B" de_dust2 2 21
+get5_backup4_match1844_map0_round12.cfg 2022-07-26 19:00:26 "Team A" "Team B" de_dust2 2 10
+get5_backup4_match1844_map0_round17.cfg 2022-07-26 19:03:39 "Team A" "Team B" de_dust2 2 15
 ...
 ```
 
@@ -46,7 +46,7 @@ get5_backup_4_match1844_map0_round17.cfg 2022-07-26 19:03:39 "Team A" "Team B" d
     To load at the beginning of round 13 of the first map of match ID 1844 from a backup created on a
     [server with ID 4](../configuration/#get5_server_id), run [`get5_loadbackup`](../commands/#get5_loadbackup):
 
-    `get5_loadbackup get5_backup_4_match1844_map0_round12.cfg`
+    `get5_loadbackup get5_backup4_match1844_map0_round12.cfg`
 
 After loading a backup, the game state is restored and the game is [paused](../pausing/#backup). Both teams
 must [`!unpause`](../commands/#unpause) to continue.

--- a/documentation/docs/backup.md
+++ b/documentation/docs/backup.md
@@ -14,10 +14,12 @@ with [`get5_backup_system_enabled`](../configuration/#get5_backup_system_enabled
 ### How does it work? {: #how-to }
 
 Every time a round starts, CS:GO automatically writes a round backup file into the root of the `csgo` directory based on
-the value of `mp_backup_round_file`. The default value for this is `backup`. Get5 reads this file and copies it into its
+the value of `mp_backup_round_file`, which Get5 will automatically adjust
+to [prevent file collisions](../configuration/#get5_server_id). Get5 reads this file, copies it into its
 own file called `get5_backup_match%s_map%d_round%d.cfg`, where the arguments are `matchid`, `mapnumber`
-and `roundnumber`, respectively. A special backup called `get5_backup_match%s_map%d_prelive.cfg` is created and should
-be used if you want to restore to the beginning of the map, before the knife round.
+and `roundnumber`, respectively, and then deletes the original backup file. A special backup
+called `get5_backup_match%s_map%d_prelive.cfg` is created and should be used if you want to restore to the beginning of
+the map, before the knife round.
 
 ### Example
 

--- a/documentation/docs/backup.md
+++ b/documentation/docs/backup.md
@@ -14,8 +14,8 @@ with [`get5_backup_system_enabled`](../configuration/#get5_backup_system_enabled
 ### How does it work? {: #how-to }
 
 Every time a round starts, CS:GO automatically writes a round backup file into the root of the `csgo` directory based on
-the value of `mp_backup_round_file`, which Get5 will automatically adjust
-to [prevent file collisions](../configuration/#get5_server_id). Get5 reads this file, copies it into its
+the value of [`mp_backup_round_file`](https://totalcsgo.com/command/mpbackuproundfile), which Get5 will [automatically
+adjust to prevent file collisions](../configuration/#get5_server_id). Get5 reads this file, copies it into its
 own file called `get5_backup%d_match%s_map%d_round%d.cfg`, where the arguments
 are [`get5_server_id`](..configuration/#get5_server_id), `matchid`, `mapnumber` and `roundnumber`, respectively, and
 then deletes the original backup file. A special backup
@@ -27,26 +27,26 @@ of the map, before the knife round.
 When in a match, you can call [`get5_listbackups`](../commands/#get5_listbackups) to view all backups for the current
 match. Note that all rounds and map numbers start at 0.
 
-They print in the format `filepath date time team1 team2 map team1_score team2_score`.
+They print in the format `filepath timestamp team1 team2 map team1_score team2_score`.
 
 ```
 > get5_listbackups
-get5_backup_match1844_map0_prelive.cfg 2022-07-26 18:51:25 "Team A" "Team B"
-get5_backup_match1844_map0_round30.cfg 2022-07-26 19:13:41 "Team A" "Team B" de_dust2 2 28
-get5_backup_match1844_map0_round4.cfg 2022-07-26 18:55:01 "Team A" "Team B" de_dust2 2 2
-get5_backup_match1844_map0_round10.cfg 2022-07-26 18:59:25 "Team A" "Team B" de_dust2 2 8
-get5_backup_match1844_map0_round23.cfg 2022-07-26 19:08:13 "Team A" "Team B" de_dust2 2 21
-get5_backup_match1844_map0_round12.cfg 2022-07-26 19:00:26 "Team A" "Team B" de_dust2 2 10
-get5_backup_match1844_map0_round17.cfg 2022-07-26 19:03:39 "Team A" "Team B" de_dust2 2 15
+get5_backup_4_match1844_map0_prelive.cfg 2022-07-26 18:51:25 "Team A" "Team B"
+get5_backup_4_match1844_map0_round30.cfg 2022-07-26 19:13:41 "Team A" "Team B" de_dust2 2 28
+get5_backup_4_match1844_map0_round4.cfg 2022-07-26 18:55:01 "Team A" "Team B" de_dust2 2 2
+get5_backup_4_match1844_map0_round10.cfg 2022-07-26 18:59:25 "Team A" "Team B" de_dust2 2 8
+get5_backup_4_match1844_map0_round23.cfg 2022-07-26 19:08:13 "Team A" "Team B" de_dust2 2 21
+get5_backup_4_match1844_map0_round12.cfg 2022-07-26 19:00:26 "Team A" "Team B" de_dust2 2 10
+get5_backup_4_match1844_map0_round17.cfg 2022-07-26 19:03:39 "Team A" "Team B" de_dust2 2 15
 ...
 ```
 
-!!! example
+!!! example "Loading a backup"
 
-    To load at the beginning of round 13 of the first map of match ID 1844,
-    run [`get5_loadbackup`](../commands/#get5_loadbackup):
+    To load at the beginning of round 13 of the first map of match ID 1844 from a backup created on a
+    [server with ID 4](../configuration/#get5_server_id), run [`get5_loadbackup`](../commands/#get5_loadbackup):
 
-    `get5_loadbackup get5_backup_match1844_map0_round12.cfg`.
+    `get5_loadbackup get5_backup_4_match1844_map0_round12.cfg`
 
 After loading a backup, the game state is restored and the game is [paused](../pausing/#backup). Both teams
 must [`!unpause`](../commands/#unpause) to continue.

--- a/documentation/docs/backup.md
+++ b/documentation/docs/backup.md
@@ -16,10 +16,11 @@ with [`get5_backup_system_enabled`](../configuration/#get5_backup_system_enabled
 Every time a round starts, CS:GO automatically writes a round backup file into the root of the `csgo` directory based on
 the value of `mp_backup_round_file`, which Get5 will automatically adjust
 to [prevent file collisions](../configuration/#get5_server_id). Get5 reads this file, copies it into its
-own file called `get5_backup_match%s_map%d_round%d.cfg`, where the arguments are `matchid`, `mapnumber`
-and `roundnumber`, respectively, and then deletes the original backup file. A special backup
-called `get5_backup_match%s_map%d_prelive.cfg` is created and should be used if you want to restore to the beginning of
-the map, before the knife round.
+own file called `get5_backup%d_match%s_map%d_round%d.cfg`, where the arguments
+are [`get5_server_id`](..configuration/#get5_server_id), `matchid`, `mapnumber` and `roundnumber`, respectively, and
+then deletes the original backup file. A special backup
+called `get5_backup%d_match%s_map%d_prelive.cfg` is created and should be used if you want to restore to the beginning
+of the map, before the knife round.
 
 ### Example
 

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -58,8 +58,15 @@ cfg/get5/live.cfg # (3)
 ## Server Setup
 
 ####`get5_server_id`
-:   Integer that identifies your server. This is used in temp files to prevent collisions. Defines the
-[`{SERVERID}`](#tag-serverid) substitution and the return value of the `Get5_GetServerID` native.<br>**`Default: 0`**
+:   Integer that identifies your server. This is used in temporary and backup files to prevent collisions. You should
+set this if you run multiple servers off the same storage, such as if using [Docker](https://www.docker.com/). This also
+defines the [`{SERVERID}`](#tag-serverid) substitution and the return value of the `Get5_GetServerID`
+native.<br>**`Default: 0`**
+
+!!! tip "Server ID could be port number"
+
+    A good candidate for `get5_server_id` would be the port number the server is bound to, since it uniquely identifies
+    a server instance on a host and ensures that no two instances run with the same server ID at the same time.
 
 ####`get5_kick_immunity`
 :   Whether [admins](../installation/#administrators) will be immune to kicks from

--- a/scripting/get5/backups.sp
+++ b/scripting/get5/backups.sp
@@ -538,10 +538,8 @@ void DeleteOldBackups() {
   if (files != null) {
     LogDebug("Searching '%s' for expired backups...", path);
     char filename[PLATFORM_MAX_PATH];
-    char searchPattern[PLATFORM_MAX_PATH];
-    FormatEx(searchPattern, sizeof(searchPattern), "get5_backup%d_", Get5_GetServerID());
     while (files.GetNext(filename, sizeof(filename))) {
-      if (StrContains(filename, searchPattern) == 0) {
+      if (StrContains(filename, "get5_backup") == 0) {
         Format(filename, sizeof(filename), "%s%s", path, filename);
         if (GetTime() - GetFileTime(filename, FileTime_LastChange) >= maxTimeDifference) {
           if (DeleteFileIfExists(filename)) {

--- a/scripting/get5/backups.sp
+++ b/scripting/get5/backups.sp
@@ -50,7 +50,7 @@ Action Command_ListBackups(int client, int args) {
   if (files != null) {
     char backupInfo[256];
     char pattern[PLATFORM_MAX_PATH];
-    FormatEx(pattern, sizeof(pattern), "get5_backup_match%s", matchID);
+    FormatEx(pattern, sizeof(pattern), "get5_backup%d_match%s", Get5_GetServerID(), matchID);
 
     char filename[PLATFORM_MAX_PATH];
     while (files.GetNext(filename, sizeof(filename))) {
@@ -174,10 +174,10 @@ void WriteBackup() {
 
   char path[PLATFORM_MAX_PATH];
   if (g_GameState == Get5State_Live) {
-    FormatEx(path, sizeof(path), "%sget5_backup_match%s_map%d_round%d.cfg", folder, g_MatchID,
+    FormatEx(path, sizeof(path), "%sget5_backup%d_match%s_map%d_round%d.cfg", folder, Get5_GetServerID(), g_MatchID,
            g_MapNumber, g_RoundNumber);
   } else {
-    FormatEx(path, sizeof(path), "%sget5_backup_match%s_map%d_prelive.cfg", folder, g_MatchID,
+    FormatEx(path, sizeof(path), "%sget5_backup%d_match%s_map%d_prelive.cfg", folder, Get5_GetServerID(), g_MatchID,
            g_MapNumber);
   }
   LogDebug("Writing backup to %s", path);
@@ -538,8 +538,10 @@ void DeleteOldBackups() {
   if (files != null) {
     LogDebug("Searching '%s' for expired backups...", path);
     char filename[PLATFORM_MAX_PATH];
+    char searchPattern[PLATFORM_MAX_PATH];
+    FormatEx(searchPattern, sizeof(searchPattern), "get5_backup%d_", Get5_GetServerID());
     while (files.GetNext(filename, sizeof(filename))) {
-      if (StrContains(filename, "get5_backup_") == 0) {
+      if (StrContains(filename, searchPattern) == 0) {
         Format(filename, sizeof(filename), "%s%s", path, filename);
         if (GetTime() - GetFileTime(filename, FileTime_LastChange) >= maxTimeDifference) {
           if (DeleteFileIfExists(filename)) {

--- a/scripting/get5/backups.sp
+++ b/scripting/get5/backups.sp
@@ -256,6 +256,7 @@ static void WriteBackupStructure(const char[] path) {
         kv.JumpToKey("valve_backup", true);
         KvCopySubkeys(valveBackup, kv);
         kv.GoBack();
+        DeleteFile(lastBackup);
       }
       delete valveBackup;
     }

--- a/scripting/get5/matchconfig.sp
+++ b/scripting/get5/matchconfig.sp
@@ -130,6 +130,9 @@ bool LoadMatchConfig(const char[] config, bool restoreBackup = false) {
   AddTeamLogosToDownloadTable();
   SetStartingTeams();
 
+  // Set mp_backup_round_file to prevent backup file collisions
+  ServerCommand("mp_backup_round_file backup_%d", Get5_GetServerID());
+
   if (!restoreBackup) {
     ExecCfg(g_WarmupCfgCvar);
     StartWarmup();


### PR DESCRIPTION
If you run a containerized system, you may have collisions in the built-in backup files the game produces on its own.

This sets the `mp_backup_round_file` to `backup_%d`, instead of the default `backup`, so that `get5_server_id` can be used to suffix an integer to these files. A file called `backup_round00.txt` would then be `backup_4_round00.txt` instead.

Also, the original backup files are now deleted after Get5 copies them into its own backup file.