### PR TITLE
Allow for custom chat aliases

### DIFF
--- a/configs/get5/commands.cfg
+++ b/configs/get5/commands.cfg
@@ -1,0 +1,6 @@
+"Commands"
+{
+    // See the documentation for a list of all the available commands you can map.
+    // The syntax is, as a key-value:
+    // "customalias" "command"
+}

--- a/documentation/docs/commands.md
+++ b/documentation/docs/commands.md
@@ -88,6 +88,40 @@ server, this stops that timer.
 menu buttons for starting a scrim, force-starting, force-ending, adding a ringer, and loading the most recent backup
 file.
 
+## Customizing Chat Commands {: #custom-chat-commands }
+
+Get5 allows you to customize the chat commands used by players. By default, all of the above commands can be used,
+but you can define your own set of commands by adding aliases to the file at
+`addons/sourcemod/configs/get5/commands.cfg`. This file is empty by default. When you add a new alias for a command,
+that alias will be the one Get5 uses when it references the command in chat.
+
+If you provide an invalid command (on the *right-hand side* in the config file), an error will be thrown. Avoid mapping
+already used commands to other functionality, as it will likely be confusing to players. You may add multiple aliases
+for a single command, but note that the **last** alias to be assigned to the command will be the one Get5 uses in chat.
+
+The chat alias file is only loaded once per plugin boot. If you want to reload it, you must reload Get5.
+
+!!! note "Valid Chat Commands"
+
+    The follwing strings are valid commands, and are all explained in the list of commands above:
+
+    [`ready`](#ready), [`unready`](#unready), [`forceready`](#forceready), [`tech`](#tech), [`pause`](#pause),
+    [`unpause`](#unpause), [`coach`](#coach), [`stay`](#stay), [`swap`](#swap), [`t`](#stay), [`ct`](#stay),
+    [`stop`](#stop), [`surrender`](#surrender), [`ffw`](#ffw), [`cancelffw`](#cancelffw)
+
+!!! example "Example: `addons/sourcemod/configs/get5/commands.cfg`"
+
+    This maps the French word *abandon* to the surrender command. Get5 will also print `!abandon` when it references the
+    surrender command in chat messages. The original commands ([`!surrender`](#surrender) and [`!gg`](#surrender)) will
+    still work. 
+
+    ```
+    "Commands"
+    {
+        "abandon" "surrender"
+    }
+    ```
+
 ## Server/Admin Commands
 
 Please note that these are meant to be used by *admins* in console. The definition is:

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -153,6 +153,7 @@ ArrayList g_MapPoolList;
 ArrayList g_TeamPlayers[MATCHTEAM_COUNT];
 ArrayList g_TeamCoaches[MATCHTEAM_COUNT];
 StringMap g_PlayerNames;
+StringMap g_ChatCommands;
 char g_TeamNames[MATCHTEAM_COUNT][MAX_CVAR_LENGTH];
 char g_TeamTags[MATCHTEAM_COUNT][MAX_CVAR_LENGTH];
 char g_FormattedTeamNames[MATCHTEAM_COUNT][MAX_CVAR_LENGTH];
@@ -483,26 +484,30 @@ public void OnPluginStart() {
   /** Client commands **/
   g_ChatAliases = new ArrayList(ByteCountToCells(ALIAS_LENGTH));
   g_ChatAliasesCommands = new ArrayList(ByteCountToCells(COMMAND_LENGTH));
-  AddAliasedCommand("r", Command_Ready, "Marks the client as ready");
-  AddAliasedCommand("ready", Command_Ready, "Marks the client as ready");
-  AddAliasedCommand("unready", Command_NotReady, "Marks the client as not ready");
-  AddAliasedCommand("notready", Command_NotReady, "Marks the client as not ready");
-  AddAliasedCommand("forceready", Command_ForceReadyClient, "Force marks clients team as ready");
-  AddAliasedCommand("tech", Command_TechPause, "Calls for a tech pause");
-  AddAliasedCommand("pause", Command_Pause, "Calls for a tactical pause");
-  AddAliasedCommand("tac", Command_Pause, "Alias of pause");
-  AddAliasedCommand("unpause", Command_Unpause, "Unpauses the game");
-  AddAliasedCommand("coach", Command_SmCoach, "Marks a client as a coach for their team");
-  AddAliasedCommand("stay", Command_Stay, "Elects to stay on the current team after winning a knife round");
-  AddAliasedCommand("swap", Command_Swap, "Elects to swap the current teams after winning a knife round");
-  AddAliasedCommand("switch", Command_Swap, "Elects to swap the current teams after winning a knife round");
-  AddAliasedCommand("t", Command_T, "Elects to start on T side after winning a knife round");
-  AddAliasedCommand("ct", Command_Ct, "Elects to start on CT side after winning a knife round");
-  AddAliasedCommand("stop", Command_Stop, "Elects to stop the game to reload a backup file");
-  AddAliasedCommand("surrender", Command_Surrender, "Starts a vote for surrendering for your team.");
-  AddAliasedCommand("gg", Command_Surrender, "Alias for surrender.");
-  AddAliasedCommand("ffw", Command_FFW, "Starts a countdown to win if a full team disconnects from the server.");
-  AddAliasedCommand("cancelffw", Command_CancelFFW, "Cancels a request to win by forfeit initiated with !ffw.");
+  g_ChatCommands = new StringMap();
+
+  // Default chat mappings.
+  MapChatCommand(Get5ChatCommand_Ready, "r");
+  MapChatCommand(Get5ChatCommand_Ready, "ready");
+  MapChatCommand(Get5ChatCommand_Unready, "notready");
+  MapChatCommand(Get5ChatCommand_Unready, "unready");
+  MapChatCommand(Get5ChatCommand_ForceReady, "forceready");
+  MapChatCommand(Get5ChatCommand_Pause, "tac");
+  MapChatCommand(Get5ChatCommand_Pause, "pause");
+  MapChatCommand(Get5ChatCommand_Unpause, "unpause");
+  MapChatCommand(Get5ChatCommand_Coach, "coach");
+  MapChatCommand(Get5ChatCommand_Stay, "stay");
+  MapChatCommand(Get5ChatCommand_Swap, "switch");
+  MapChatCommand(Get5ChatCommand_Swap, "swap");
+  MapChatCommand(Get5ChatCommand_T, "t");
+  MapChatCommand(Get5ChatCommand_CT, "ct");
+  MapChatCommand(Get5ChatCommand_Stop, "stop");
+  MapChatCommand(Get5ChatCommand_Surrender, "gg");
+  MapChatCommand(Get5ChatCommand_Surrender, "surrender");
+  MapChatCommand(Get5ChatCommand_FFW, "ffw");
+  MapChatCommand(Get5ChatCommand_CancelFFW, "cancelffw");
+
+  LoadCustomChatAliases("addons/sourcemod/configs/get5/commands.cfg");
 
   /** Admin/server commands **/
   RegAdminCmd("get5_loadmatch", Command_LoadMatch, ADMFLAG_CHANGEMAP,
@@ -640,11 +645,11 @@ static Action Timer_InfoMessages(Handle timer) {
   }
 
   char readyCommandFormatted[64];
-  FormatChatCommand(readyCommandFormatted, sizeof(readyCommandFormatted), "!ready");
+  GetChatAliasForCommand(Get5ChatCommand_Ready, readyCommandFormatted, sizeof(readyCommandFormatted), true);
   char unreadyCommandFormatted[64];
-  FormatChatCommand(unreadyCommandFormatted, sizeof(unreadyCommandFormatted), "!unready");
+  GetChatAliasForCommand(Get5ChatCommand_Unready, unreadyCommandFormatted, sizeof(unreadyCommandFormatted), true);
   char coachCommandFormatted[64];
-  FormatChatCommand(coachCommandFormatted, sizeof(coachCommandFormatted), "!coach");
+  GetChatAliasForCommand(Get5ChatCommand_Coach, coachCommandFormatted, sizeof(coachCommandFormatted), true);
 
   if (g_GameState == Get5State_PendingRestore) {
     if (!IsTeamsReady() && !IsDoingRestoreOrMapChange()) {
@@ -1129,7 +1134,7 @@ static Action Command_DumpStats(int client, int args) {
   }
 }
 
-static Action Command_Stop(int client, int args) {
+Action Command_Stop(int client, int args) {
   if (!g_StopCommandEnabledCvar.BoolValue) {
     Get5_MessageToAll("%t", "StopCommandNotEnabled");
     return Plugin_Handled;
@@ -1175,7 +1180,7 @@ static Action Command_Stop(int client, int args) {
   g_TeamGivenStopCommand[team] = true;
 
   char stopCommandFormatted[64];
-  FormatChatCommand(stopCommandFormatted, sizeof(stopCommandFormatted), "!stop");
+  GetChatAliasForCommand(Get5ChatCommand_Stop, stopCommandFormatted, sizeof(stopCommandFormatted), true);
   if (g_TeamGivenStopCommand[Get5Team_1] && !g_TeamGivenStopCommand[Get5Team_2]) {
     Get5_MessageToAll("%t", "TeamWantsToReloadCurrentRound", g_FormattedTeamNames[Get5Team_1],
                       g_FormattedTeamNames[Get5Team_2], stopCommandFormatted);

--- a/scripting/get5/chatcommands.sp
+++ b/scripting/get5/chatcommands.sp
@@ -16,6 +16,139 @@ static void AddChatAlias(const char[] alias, const char[] command) {
   }
 }
 
+void MapChatCommand(const Get5ChatCommand command, const char[] alias) {
+  switch (command)
+  {
+    case Get5ChatCommand_Ready:
+    {
+      AddAliasedCommand(alias, Command_Ready, "Marks the client as ready.");
+    }
+    case Get5ChatCommand_Unready:
+    {
+      AddAliasedCommand(alias, Command_NotReady, "Marks the client as not ready.");
+    }
+    case Get5ChatCommand_ForceReady:
+    {
+      AddAliasedCommand(alias, Command_ForceReadyClient, "Marks the client's entire team as ready.");
+    }
+    case Get5ChatCommand_Tech:
+    {
+      AddAliasedCommand(alias, Command_TechPause, "Calls for a technical pause.");
+    }
+    case Get5ChatCommand_Pause:
+    {
+      AddAliasedCommand(alias, Command_Pause, "Calls for a tactical pause.");
+    }
+    case Get5ChatCommand_Unpause:
+    {
+      AddAliasedCommand(alias, Command_Unpause, "Unpauses the game.");
+    }
+    case Get5ChatCommand_Coach:
+    {
+      AddAliasedCommand(alias, Command_SmCoach, "Requests to become a coach.");
+    }
+    case Get5ChatCommand_Stay:
+    {
+      AddAliasedCommand(alias, Command_Stay, "Elects to stay on the current side after winning a knife round.");
+    }
+    case Get5ChatCommand_Swap:
+    {
+      AddAliasedCommand(alias, Command_Swap, "Elects to swap to the other side after winning a knife round.");
+    }
+    case Get5ChatCommand_T:
+    {
+      AddAliasedCommand(alias, Command_T, "Elects to start on T side after winning a knife round.");
+    }
+    case Get5ChatCommand_CT:
+    {
+      AddAliasedCommand(alias, Command_Ct, "Elects to start on CT side after winning a knife round.");
+    }
+    case Get5ChatCommand_Stop:
+    {
+      AddAliasedCommand(alias, Command_Stop, "Elects to stop the game to reload a backup file for the current round.");
+    }
+    case Get5ChatCommand_Surrender:
+    {
+      AddAliasedCommand(alias, Command_Surrender, "Starts a vote for surrendering for your team.");
+    }
+    case Get5ChatCommand_FFW:
+    {
+      AddAliasedCommand(alias, Command_FFW, "Starts a countdown to win if a full team disconnects from the server.");
+    }
+    case Get5ChatCommand_CancelFFW:
+    {
+      AddAliasedCommand(alias, Command_CancelFFW, "Cancels a pending request to win by forfeit.");
+    }
+    default:
+    {
+      LogError("Failed to map Get5ChatCommand with value %d to a command. It is missing from MapChatCommand.", command);
+      return;
+    }
+  }
+
+  char commandAsString[64]; // "ready"; base command
+  char commandAliasFormatted[64]; // "!readyalias"; the alias to use, with ! in front
+  ChatCommandToString(command, commandAsString, sizeof(commandAsString));
+  FormatEx(commandAliasFormatted, sizeof(commandAliasFormatted), "!%s", alias);
+  g_ChatCommands.SetString(commandAsString, commandAliasFormatted); // maps ready -> !readyalias
+}
+
+void GetChatAliasForCommand(const Get5ChatCommand command, char[] buffer, int bufferSize, bool format) {
+  char commandAsString[64];
+  ChatCommandToString(command, commandAsString, sizeof(commandAsString));
+  g_ChatCommands.GetString(commandAsString, buffer, bufferSize);
+  if (format) {
+    FormatChatCommand(buffer, bufferSize, buffer);
+  }
+}
+
+int LoadCustomChatAliases(const char[] file) {
+  int loadedAliases = 0;
+  if (!FileExists(file)) {
+    LogDebug("Custom chat commands file not found at '%s'. Skipping.", file);
+    return loadedAliases;
+  }
+  char error[PLATFORM_MAX_PATH];
+  if (!CheckKeyValuesFile(file, error, sizeof(error))) {
+    LogError("Failed to parse custom chat command file. Error: %s", error);
+    return loadedAliases;
+  }
+
+  KeyValues chatAliases = new KeyValues("Commands");
+  if (!chatAliases.ImportFromFile(file)) {
+     LogError("Failed to read chat command aliases file at '%s'.", file);
+     delete chatAliases;
+     return loadedAliases;
+  }
+
+  if (chatAliases.GotoFirstSubKey(false))
+  {
+    char alias[255];
+    char command[255];
+    do
+    {
+      chatAliases.GetSectionName(alias, sizeof(alias));
+      chatAliases.GetString(NULL_STRING, command, sizeof(command));
+
+      Get5ChatCommand chatCommand = StringToChatCommand(command);
+      if (chatCommand == Get5ChatCommand_Unknown) {
+        LogError("Failed to alias unknown chat command '%s' to '%s'.", command, alias);
+        continue;
+      }
+      MapChatCommand(chatCommand, alias);
+      loadedAliases++;
+    } while (chatAliases.GotoNextKey(false));
+    if (loadedAliases > 0) {
+      LogMessage("Loaded %d custom chat alias(es).", loadedAliases);
+    }
+  } else {
+    // file is empty.
+    LogDebug("Custom alias file was empty.");
+  }
+  delete chatAliases;
+  return loadedAliases;
+}
+
 void CheckForChatAlias(int client, const char[] sArgs) {
   // No chat aliases are needed if the game isn't setup at all.
   if (g_GameState == Get5State_None) {

--- a/scripting/get5/kniferounds.sp
+++ b/scripting/get5/kniferounds.sp
@@ -50,9 +50,9 @@ void PromptForKnifeDecision() {
     return;
   }
   char formattedStayCommand[64];
-  FormatChatCommand(formattedStayCommand, sizeof(formattedStayCommand), "!stay");
+  GetChatAliasForCommand(Get5ChatCommand_Stay, formattedStayCommand, sizeof(formattedStayCommand), true);
   char formattedSwapCommand[64];
-  FormatChatCommand(formattedSwapCommand, sizeof(formattedSwapCommand), "!swap");
+  GetChatAliasForCommand(Get5ChatCommand_Swap, formattedSwapCommand, sizeof(formattedSwapCommand), true);
   Get5_MessageToAll("%t", "WaitingForEnemySwapInfoMessage", g_FormattedTeamNames[g_KnifeWinnerTeam],
                     formattedStayCommand, formattedSwapCommand);
 }

--- a/scripting/get5/mapveto.sp
+++ b/scripting/get5/mapveto.sp
@@ -43,7 +43,7 @@ static Action Timer_VetoCountdown(Handle timer) {
 static void AbortVeto() {
   Get5_MessageToAll("%t", "CaptainLeftOnVetoInfoMessage");
   char readyCommandFormatted[64];
-  FormatChatCommand(readyCommandFormatted, sizeof(readyCommandFormatted), "!ready");
+  GetChatAliasForCommand(Get5ChatCommand_Ready, readyCommandFormatted, sizeof(readyCommandFormatted), true);
   Get5_MessageToAll("%t", "ReadyToResumeVetoInfoMessage", readyCommandFormatted);
   ChangeState(Get5State_PreVeto);
   if (g_ActiveVetoMenu != null) {

--- a/scripting/get5/pausing.sp
+++ b/scripting/get5/pausing.sp
@@ -247,7 +247,7 @@ Action Command_Unpause(int client, int args) {
   }
 
   char formattedUnpauseCommand[64];
-  FormatChatCommand(formattedUnpauseCommand, sizeof(formattedUnpauseCommand), "!unpause");
+  GetChatAliasForCommand(Get5ChatCommand_Unpause, formattedUnpauseCommand, sizeof(formattedUnpauseCommand), true);
   if (g_TeamReadyForUnpause[Get5Team_1] && g_TeamReadyForUnpause[Get5Team_2]) {
     UnpauseGame(team);
     if (IsPlayer(client)) {
@@ -410,7 +410,7 @@ static Action Timer_PauseTimeCheck(Handle timer) {
           // unpause on their own. The PrintHintText below will inform users that they can now
           // unpause.
           char formattedUnpauseCommand[64];
-          FormatChatCommand(formattedUnpauseCommand, sizeof(formattedUnpauseCommand), "!unpause");
+          GetChatAliasForCommand(Get5ChatCommand_Unpause, formattedUnpauseCommand, sizeof(formattedUnpauseCommand), true);
           Get5_MessageToAll("%t", "TechPauseRunoutInfoMessage", formattedUnpauseCommand);
         }
       }

--- a/scripting/get5/readysystem.sp
+++ b/scripting/get5/readysystem.sp
@@ -227,7 +227,7 @@ Action Command_ForceReadyClient(int client, int args) {
     g_AllowForceReadyCvar.GetName(cVarName, sizeof(cVarName));
     FormatCvarName(cVarName, sizeof(cVarName), cVarName);
     char forceReadyCommand[64];
-    FormatChatCommand(forceReadyCommand, sizeof(forceReadyCommand), "!forceready");
+    GetChatAliasForCommand(Get5ChatCommand_ForceReady, forceReadyCommand, sizeof(forceReadyCommand), true);
     Get5_Message(client, "%t", "ForceReadyDisabled", forceReadyCommand, cVarName);
     return;
   }
@@ -300,7 +300,7 @@ static void MissingPlayerInfoMessageTeam(Get5Team team) {
 
   if (playerCount == readyCount && playerCount < playersPerTeam && readyCount >= minimumPlayersForForceReady) {
     char forceReadyFormatted[64];
-    FormatChatCommand(forceReadyFormatted, sizeof(forceReadyFormatted), "!forceready");
+    GetChatAliasForCommand(Get5ChatCommand_ForceReady, forceReadyFormatted, sizeof(forceReadyFormatted), true);
     Get5_MessageToTeam(team, "%t", "ForceReadyInfoMessage", forceReadyFormatted);
   }
 }

--- a/scripting/get5/surrender.sp
+++ b/scripting/get5/surrender.sp
@@ -176,8 +176,8 @@ Action Timer_DisconnectCheck(Handle timer) {
   }
 
   // One team is full, the other team left; announce that they can request to !ffw
-  char winCommandFormatted[32];
-  FormatChatCommand(winCommandFormatted, sizeof(winCommandFormatted), "!ffw");
+  char winCommandFormatted[64];
+  GetChatAliasForCommand(Get5ChatCommand_FFW, winCommandFormatted, sizeof(winCommandFormatted), true);
   Get5_MessageToAll("%t", "WinByForfeitAvailable", g_FormattedTeamNames[forfeitingTeam],
                     g_FormattedTeamNames[OtherMatchTeam(forfeitingTeam)], winCommandFormatted);
   return Plugin_Handled;
@@ -190,8 +190,7 @@ static void AnnounceRemainingForfeitTime(const int remainingSeconds, const Get5T
 
   if (forfeitingTeam != Get5Team_None) {
     char formattedCancelFFWCommand[64];
-    FormatChatCommand(formattedCancelFFWCommand, sizeof(formattedCancelFFWCommand), "!cancelffw");
-
+    GetChatAliasForCommand(Get5ChatCommand_CancelFFW, formattedCancelFFWCommand, sizeof(formattedCancelFFWCommand), true);
     Get5_MessageToAll("%t", "WinByForfeitCountdownStarted", g_FormattedTeamNames[OtherMatchTeam(forfeitingTeam)],
                       formattedTimeRemaining, g_FormattedTeamNames[forfeitingTeam], formattedCancelFFWCommand);
   } else {

--- a/scripting/get5/util.sp
+++ b/scripting/get5/util.sp
@@ -775,3 +775,110 @@ stock void ConvertSecondsToMinutesAndSeconds(int timeAsSeconds, char[] buffer, c
 stock bool IsDoingRestoreOrMapChange() {
   return g_DoingBackupRestoreNow || g_MapChangePending;
 }
+
+stock void ChatCommandToString(const Get5ChatCommand command, char[] buffer, const int bufferSize) {
+  switch (command)
+  {
+    case Get5ChatCommand_Ready:
+    {
+      FormatEx(buffer, bufferSize, "ready");
+    }
+    case Get5ChatCommand_Unready:
+    {
+      FormatEx(buffer, bufferSize, "unready");
+    }
+    case Get5ChatCommand_ForceReady:
+    {
+      FormatEx(buffer, bufferSize, "forceready");
+    }
+    case Get5ChatCommand_Tech:
+    {
+      FormatEx(buffer, bufferSize, "tech");
+    }
+    case Get5ChatCommand_Pause:
+    {
+      FormatEx(buffer, bufferSize, "pause");
+    }
+    case Get5ChatCommand_Unpause:
+    {
+      FormatEx(buffer, bufferSize, "unpause");
+    }
+    case Get5ChatCommand_Coach:
+    {
+      FormatEx(buffer, bufferSize, "coach");
+    }
+    case Get5ChatCommand_Stay:
+    {
+      FormatEx(buffer, bufferSize, "stay");
+    }
+    case Get5ChatCommand_Swap:
+    {
+      FormatEx(buffer, bufferSize, "swap");
+    }
+    case Get5ChatCommand_T:
+    {
+      FormatEx(buffer, bufferSize, "t");
+    }
+    case Get5ChatCommand_CT:
+    {
+      FormatEx(buffer, bufferSize, "ct");
+    }
+    case Get5ChatCommand_Stop:
+    {
+      FormatEx(buffer, bufferSize, "stop");
+    }
+    case Get5ChatCommand_Surrender:
+    {
+      FormatEx(buffer, bufferSize, "surrender");
+    }
+    case Get5ChatCommand_FFW:
+    {
+      FormatEx(buffer, bufferSize, "ffw");
+    }
+    case Get5ChatCommand_CancelFFW:
+    {
+      FormatEx(buffer, bufferSize, "cancelffw");
+    }
+    default:
+    {
+      LogError("Failed to map Get5ChatCommand with value %d to a string. It is missing from ChatCommandToString.", command);
+    }
+  }
+}
+
+stock Get5ChatCommand StringToChatCommand(const char[] string) {
+  if (strcmp(string, "ready") == 0) {
+    return Get5ChatCommand_Ready;
+  } else if (strcmp(string, "unready") == 0) {
+    return Get5ChatCommand_Unready;
+  } else if (strcmp(string, "forceready") == 0) {
+    return Get5ChatCommand_ForceReady;
+  } else if (strcmp(string, "tech") == 0) {
+    return Get5ChatCommand_Tech;
+  } else if (strcmp(string, "pause") == 0) {
+    return Get5ChatCommand_Pause;
+  } else if (strcmp(string, "unpause") == 0) {
+    return Get5ChatCommand_Unpause;
+  } else if (strcmp(string, "coach") == 0) {
+    return Get5ChatCommand_Coach;
+  } else if (strcmp(string, "stay") == 0) {
+    return Get5ChatCommand_Stay;
+  } else if (strcmp(string, "swap") == 0) {
+    return Get5ChatCommand_Swap;
+  } else if (strcmp(string, "t") == 0) {
+    return Get5ChatCommand_T;
+  } else if (strcmp(string, "ct") == 0) {
+    return Get5ChatCommand_CT;
+  } else if (strcmp(string, "stop") == 0) {
+    return Get5ChatCommand_Stop;
+  } else if (strcmp(string, "surrender") == 0) {
+    return Get5ChatCommand_Surrender;
+  } else if (strcmp(string, "ffw") == 0) {
+    return Get5ChatCommand_FFW;
+  } else if (strcmp(string, "cancelffw") == 0) {
+    return Get5ChatCommand_CancelFFW;
+  } else {
+    return Get5ChatCommand_Unknown;
+  }
+}
+

--- a/scripting/include/get5.inc
+++ b/scripting/include/get5.inc
@@ -50,6 +50,25 @@ enum Get5PauseType {
   Get5PauseType_Backup     // Special type for match pausing during backups.
 };
 
+enum Get5ChatCommand {
+  Get5ChatCommand_Unknown,
+  Get5ChatCommand_Ready,
+  Get5ChatCommand_Unready,
+  Get5ChatCommand_ForceReady,
+  Get5ChatCommand_Tech,
+  Get5ChatCommand_Pause,
+  Get5ChatCommand_Unpause,
+  Get5ChatCommand_Coach,
+  Get5ChatCommand_Stay,
+  Get5ChatCommand_Swap,
+  Get5ChatCommand_T,
+  Get5ChatCommand_CT,
+  Get5ChatCommand_Stop,
+  Get5ChatCommand_Surrender,
+  Get5ChatCommand_FFW,
+  Get5ChatCommand_CancelFFW,
+};
+
 enum MatchSideType {
   MatchSideType_Standard,     // Team that doesn't pick map gets side choice, leftovers go to knife rounds
   MatchSideType_AlwaysKnife,  // All maps use a knife round to pick sides


### PR DESCRIPTION
This allows users to set their own custom chat commands without modifying the get5 source files at all. This is done via a KeyValue file currently just placed at `addons/sourcemod/configs/get5/commands.cfg`, but this could also be a ConVar.

Setting a custom command will also override the output in the messages get5 prints, so if you set your `!ready` command to be `!start`, the message would instead be:

`Type !start when you are ready to begin.`

The way it currently works is just that the **last** command that was set determines the output, but they all work, hence this as the default:

```c
MapChatCommand(Get5ChatCommand_Ready, "r");
MapChatCommand(Get5ChatCommand_Ready, "ready");
```