### PR TITLE
Allow sending events to remote URL

### DIFF
--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -58,9 +58,10 @@ cfg/get5/live.cfg # (3)
 ## Server Setup
 
 ####`get5_server_id`
-:   Integer that identifies your server. This is used in temporary and backup files to prevent collisions. You should
-set this if you run multiple servers off the same storage, such as if using [Docker](https://www.docker.com/). This also
-defines the [`{SERVERID}`](#tag-serverid) substitution and the return value of the `Get5_GetServerID`
+:   Integer that identifies your server. This is used in temporary and backup files to prevent collisions and added as a
+header to [demo uploads](gotv.md#upload) and [event requests](events_and_forwards.md#http). You should set this if you
+run multiple servers off the same storage, such as if using [Docker](https://www.docker.com/). This also defines
+the [`{SERVERID}`](#tag-serverid) substitution and the return value of the `Get5_GetServerID`
 native.<br>**`Default: 0`**
 
 !!! tip "Server ID could be port number"
@@ -335,12 +336,12 @@ once a recording stops. If no protocol is provided, `http://` will be prepended 
 [SteamWorks](../installation/#steamworks) extension.<br>**`Default: ""`**
 
 ####`get5_demo_upload_header_key`
-:   If this **and** [`get5_demo_upload_header_value`](#get5_demo_upload_header_value) is defined, this header name and
+:   If this **and** [`get5_demo_upload_header_value`](#get5_demo_upload_header_value) are defined, this header name and
 value will be used for your [demo upload HTTP request](#get5_demo_upload_url).<br>**`Default: "Authorization"`**
 
 ####`get5_demo_upload_header_value`
-:   If this **and** [`get5_demo_upload_header_key`](#get5_demo_upload_header_key) is defined, this header name and value
-will be used for your [demo upload HTTP request](#get5_demo_upload_url).<br>**`Default: ""`**
+:   If this **and** [`get5_demo_upload_header_key`](#get5_demo_upload_header_key) are defined, this header name and
+value will be used for your [demo upload HTTP request](#get5_demo_upload_url).<br>**`Default: ""`**
 
 ####`get5_demo_delete_after_upload`
 :   Whether to delete the demo file from the game server after
@@ -357,6 +358,20 @@ must **end with a slash**.<br>**`Default: ""`**
 added automatically). If you do not include the [`{TIME}`](#tag-time) tag, you will have problems with duplicate files
 if restoring a game from a backup. Note that the [`{MAPNUMBER}`](#tag-mapnumber)variable is not zero-indexed. Set to
 empty string to disable recording demos.<br>**`Default: "{TIME}_{MATCHID}_map{MAPNUMBER}_{MAPNAME}"`**
+
+## Events
+
+####`get5_remote_log_url`
+:   The URL to send all [events](events_and_forwards.md#http) to. Requires the [SteamWorks](../installation/#steamworks)
+extension. Set to empty string to disable.<br>**`Default: ""`**
+
+####`get5_remote_log_header_key`
+:   If this **and** [`get5_remote_log_header_value`](#get5_remote_log_header_value) are defined, this
+header name and value will be used for your [event HTTP requests](events_and_forwards.md#http).<br>**`Default: "Authorization"`**
+
+####`get5_remote_log_header_value`
+:   If this **and** [`get5_remote_log_header_key`](#get5_remote_log_header_key) are defined, this header
+name and value will be used for your [event HTTP requests](events_and_forwards.md#http).<br>**`Default: ""`**
 
 ## Substitution Variables
 

--- a/documentation/docs/developers.md
+++ b/documentation/docs/developers.md
@@ -5,22 +5,20 @@
 1. You can write another SourceMod plugin that uses
    the [Get5 natives and forwards](https://github.com/splewis/get5/blob/master/scripting/include/get5.inc). This is
    exactly what the [get5_apistats](https://github.com/splewis/get5/blob/master/scripting/get5_apistats.sp)
-   and [get5_mysqlstats](https://github.com/splewis/get5/blob/master/scripting/get5_mysqlstats.sp) plugins do. Please
-   use these as a general guide/starting point. Don't fork this repository to make changes to these plugins alone, but
-   use these as a template and create a new repository for your plugin. All the events and forwards
-   are [thoroughly documented](./events_and_forwards.md).
+   and [get5_mysqlstats](https://github.com/splewis/get5/blob/master/scripting/get5_mysqlstats.sp) plugins do.
 
-2. You can read [event logs](./events_and_forwards.md) from a file on disk (set
-   by [`get5_event_log_format`](./configuration.md#get5_event_log_format)), through a RCON connection to the server
-   console since they are output there, or through another SourceMod plugin (see #1).
+2. You can read [event logs](events_and_forwards.md) from a file on disk (set
+   by [`get5_event_log_format`](../configuration/#get5_event_log_format)), through a RCON connection to the server
+   console since they are output there, or through another SourceMod plugin.
 
-3. You can read the [stats](./stats_system.md) Get5 collects from a file on disk (set
-   by [`get5_stats_path_format`](./configuration.md#get5_stats_path_format)), or through another SourceMod plugin (
-   see #1).
+3. You can [send all events to a web server over HTTP](../events_and_forwards/#http).
 
-4. You can execute the [`get5_loadmatch`](../commands/#get5_loadmatch) command
-   or [`get5_loadmatch_url`](../commands/#get5_loadmatch_url) commands via another plugin or via a RCON
-   to begin matches. Of course, you could execute any get5 command you want as well.
+4. You can read the [stats](stats_system.md) Get5 collects from a file on disk (set
+   by [`get5_stats_path_format`](../configuration/#get5_stats_path_format)).
+
+5. You can execute any [command](commands.md), such as [`get5_loadmatch`](../commands/#get5_loadmatch)
+   or [`get5_loadmatch_url`](../commands/#get5_loadmatch_url) via another plugin or
+   via [RCON](https://developer.valvesoftware.com/wiki/Source_RCON_Protocol).
 
 ## Building Get5 from source {: #build }
 

--- a/documentation/docs/event_schema.yml
+++ b/documentation/docs/event_schema.yml
@@ -5,7 +5,7 @@ info:
   version: ""
 paths:
   "/Get_OnEvent":
-    put:
+    post:
       tags:
         - All Events
       description: |
@@ -418,7 +418,7 @@ paths:
   "/Get5_OnRoundStart":
     post:
       tags:
-        - Map Flow
+        - Live
       description: |
         Fired when a round starts (when freezetime begins).
       requestBody:
@@ -436,7 +436,7 @@ paths:
   "/Get5_OnRoundEnd":
     post:
       tags:
-        - Map Flow
+        - Live
       description: |
         Fired when a round ends - when the result is in; not when the round stops. Game activity can occur after this.
       requestBody:
@@ -469,7 +469,7 @@ paths:
   "/Get5_OnRoundStatsUpdated":
     post:
       tags:
-        - Map Flow
+        - Live
       description: |
         Fired after the stats update on round end.
       requestBody:
@@ -534,7 +534,7 @@ paths:
   "/Get5_OnPlayerBecameMVP":
     post:
       tags:
-        - Map Flow
+        - Live
       description: |
         Fired when a player is elected the MVP of the round.
       requestBody:
@@ -556,7 +556,7 @@ paths:
   "/Get5_OnGrenadeThrown":
     post:
       tags:
-        - Client Actions
+        - Live
       description: |
         Fired whenever a grenade is thrown by a player. The `weapon` property reflects the grenade used.
       requestBody:
@@ -574,7 +574,7 @@ paths:
   "/Get5_OnPlayerDeath":
     post:
       tags:
-        - Client Actions
+        - Live
       description: |
         Fired when a player dies.
       requestBody:
@@ -664,7 +664,7 @@ paths:
   "/Get5_OnHEGrenadeDetonated":
     post:
       tags:
-        - Client Actions
+        - Live
       description: |
         Fired when an HE grenade detonates. `player` describes who threw the HE and `victims` who were affected.
         `weapon` is always an HE grenade.
@@ -683,7 +683,7 @@ paths:
   "/Get5_OnMolotovDetonated":
     post:
       tags:
-        - Client Actions
+        - Live
       description: |
         Fired when a molotov grenade expires. `player` describes
         who threw the molotov and `victims` who were affected. `weapon` is
@@ -704,7 +704,7 @@ paths:
   "/Get5_OnFlashbangDetonated":
     post:
       tags:
-        - Client Actions
+        - Live
       description: |
         Fired when a flash bang grenade detonates. `player` describes
         who threw the flash bang and `victims` who were affected. `weapon`
@@ -724,7 +724,7 @@ paths:
   "/Get5_OnSmokeGrenadeDetonated":
     post:
       tags:
-        - Client Actions
+        - Live
       description: |
         Fired when an smoke grenade expires. `player` describes
         who threw the grenade. `weapon` is always a smoke grenade.
@@ -747,7 +747,7 @@ paths:
   "/Get5_OnDecoyStarted":
     post:
       tags:
-        - Client Actions
+        - Live
       description: |
         Fired when a decoy starts making noise. `player` describes
         who threw the grenade. `weapon` is always a decoy grenade.
@@ -766,7 +766,7 @@ paths:
   "/Get5_OnBombPlanted":
     post:
       tags:
-        - Client Actions
+        - Live
       description: |
         Fired when the bomb is planted. `player` describes who planted the bomb.
       requestBody:
@@ -784,7 +784,7 @@ paths:
   "/Get5_OnBombDefused":
     post:
       tags:
-        - Client Actions
+        - Live
       description: |
         Fired when the bomb is defused. `player` describes who defused the bomb.
       requestBody:
@@ -808,7 +808,7 @@ paths:
   "/Get5_OnBombExploded":
     post:
       tags:
-        - Client Actions
+        - Live
       description: |
         Fired when the bomb explodes.
       requestBody:
@@ -1115,7 +1115,8 @@ tags:
   - name: Series Flow
     description: Events the occur in relation to setting up a match or series.
   - name: Map Flow
-    description: Events the occur in relation to a map pick or match-events on a map (pausing).
+    description: Events the occur in relation to a map pick or match-events on a map.
+  - name: Live
+    description: Events that only occur during live rounds (not during knife, veto or warmup).
   - name: Client Actions
-    description: Events that occur based on players' in-game activity.
-
+    description: Events that occur based on players' chat or connection activity.

--- a/documentation/docs/events_and_forwards.md
+++ b/documentation/docs/events_and_forwards.md
@@ -3,17 +3,29 @@
 Get5 contains an event-logging system that logs many client actions and what is happening in the game. These supplement
 the logs CS:GO makes on its own, but add a lot of additional information about the ongoing match.
 
-You should hook onto these forwards if creating extensions to Get5, such as a plugin to collect stats. You can also
-implement something similar to the `get5_apistats` plugin, which sends the data
-somewhere via HTTP or logs the events to a file.
+## HTTP {: #http }
 
-!!! help "Why are there HTTP methods?"
+To receive Get5 [events](#events) on a web server, define
+a [URL for event logging](../configuration/#get5_remote_log_url). Get5 will send all events to the URL as JSON over
+HTTP. You may add a [custom HTTP header](configuration.md#get5_remote_log_header_key) to authenticate your request.
+Get5 will also add a header called `Get5-ServerId` with the value of [`get5_server_id`](configuration.md#get5_server_id)
+**if** it is set to a positive integer.
 
-    The HTTP methods displayed here must be defined for the OpenAPI swagger documentation tool and have **no meaning**.
-    We use swagger because it allows us to document the structure of the
-    [event objects](https://github.com/splewis/get5/blob/master/scripting/include/get5.inc) and their inheritance 1:1 to
-    the JSON output you would see from each forward/event.
+!!! warning "Simple HTTP"
+
+    There is no deduplication or retry-logic for failed requests. It is assumed that a stable connection can be made
+    between your game server and the URL at all times.
+    HTTP [Keep-Alive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Keep-Alive) is **not** supported. HTTPS
+    **is** supported and encouraged if connection is made over a public network. Logging over HTTP requires
+    the [SteamWorks](installation.md#steamworks) extension on your server.
+
+## SourceMod Forwards {: #sourcemod-forwards }
+
+If you are writing your own SourceMod plugin, you can hook onto
+the Get5 [forwards](https://github.com/splewis/get5/blob/master/scripting/include/get5.inc). This is
+what `get5_apistats` and [`get5_mysqlstats`](../stats_system/#mysql) both do. The paths of the `POST` endpoints in the
+table below indicate the name of the forward in SourceMod.
+
+## Events
 
 <swagger-ui src="event_schema.yml"/>
-
-

--- a/documentation/docs/gotv.md
+++ b/documentation/docs/gotv.md
@@ -39,13 +39,14 @@ read the [headers](#headers) for file metadata.
 
 ### Headers {: #headers }
 
-Get5 will always add these three HTTP headers to its demo upload request:
+Get5 will add these HTTP headers to its demo upload request:
 
 1. `Get5-DemoName` is the name of the file as defined
    by [`get5_demo_name_format`](../configuration/#get5_demo_name_format),
    i.e. `2022-09-11_20-49-49_1564_map1_de_vertigo.dem`.
-2. `Get5-MatchId` is the [match ID](../match_schema/#schema) of the series.
-3. `Get5-MapNumber` is the zero-indexed map number in the series.
+2. `Get5-MapNumber` is the zero-indexed map number in the series.
+3. `Get5-MatchId` **if** the [match ID](../match_schema/#schema) is not an empty string.
+4. `Get5-ServerId` **if** [`get5_server_id`](configuration.md#get5_server_id) is set to a positive integer.
 
 #### Authorization {: #authorization }
 
@@ -70,16 +71,16 @@ read the demo upload request sent by Get5.
     and is only meant to demonstrate the key aspects of reading a potentially large POST request.
 
 ```js title="Node.js example"
-const express = require('express')
+const express = require('express');
 const fs = require('fs');
 const path = require("path");
-const app = express()
+const app = express();
 
 // Accept POST requests at http://domain.tld/upload-file
 app.post('/upload-file', function (req, res) {
 
    // Check that the authorization header configured in Get5 matches.
-   // Note that headers names are not case-sensitive.
+   // Note that header names are not case-sensitive.
    const authorization = req.header('Authorization');
    
    if (authorization !== 'super_secret_key') {
@@ -88,9 +89,11 @@ app.post('/upload-file', function (req, res) {
        return;
    }
 
-   // Read the Get5 headers to know what to do with the file.
+   // Read the Get5 headers to know what to do with the file and potentially identify the server.
    const filename = req.header('Get5-DemoName');
    const matchId = req.header('Get5-MatchId');
+   const mapNumber = req.header('Get5-MapNumber');
+   const serverId = req.header('Get5-ServerId');
 
    // Put all demos for the same match in a folder.
    const folder = path.join(__dirname, 'demos', matchId);

--- a/documentation/docs/installation.md
+++ b/documentation/docs/installation.md
@@ -50,9 +50,8 @@ so or can live with the potential consequences.
 ## SteamWorks (Recommended) {: #steamworks }
 
 SteamWorks is not required for Get5 to work on your game server, but it is required if you wish
-to [load match configs remotely](../commands#get5_loadmatch_url)
-, [automatically check for updates](../configuration#get5_print_update_notice) or [upload demos](../gotv/#upload) to a
-web server.
+to [load match configurations remotely](../commands#get5_loadmatch_url), [send events to a remote URL](../configuration#get5_remote_log_url), [check for updates](../configuration#get5_print_update_notice)
+or [upload demos](../gotv/#upload) to a web server.
 
 [:material-steam: Download SteamWorks](https://github.com/KyleSanderson/SteamWorks/releases/){ .md-button .md-button--primary }
 

--- a/scripting/get5/events.sp
+++ b/scripting/get5/events.sp
@@ -1,0 +1,61 @@
+void SendEventJSONToURL(const char[] event) {
+  const eventUrlSize = 1024;
+  static char eventUrl[eventUrlSize];
+  g_EventLogRemoteURLCvar.GetString(eventUrl, eventUrlSize);
+  if (strlen(eventUrl) == 0) {
+    return;
+  }
+
+  if (!LibraryExists("SteamWorks")) {
+    char cVarName[MAX_CVAR_LENGTH];
+    g_EventLogRemoteURLCvar.GetName(cVarName, sizeof(cVarName));
+    LogError("Cannot send HTTP events without the SteamWorks extension. Disabling %s.", cVarName);
+    g_EventLogRemoteURLCvar.SetString("");
+    return;
+  }
+
+  Handle eventRequest = CreateGet5HTTPRequest(k_EHTTPMethodPOST, eventUrl);
+  if (eventRequest == INVALID_HANDLE) {
+    return;
+  }
+
+  static char eventUrlHeaderKey[1024];
+  static char eventUrlHeaderValue[1024];
+
+  g_EventLogRemoteHeaderKeyCvar.GetString(eventUrlHeaderKey, sizeof(eventUrlHeaderKey));
+  g_EventLogRemoteHeaderValueCvar.GetString(eventUrlHeaderValue, sizeof(eventUrlHeaderValue));
+
+  if (strlen(eventUrlHeaderKey) > 0 && strlen(eventUrlHeaderValue) > 0) {
+    if (!SteamWorks_SetHTTPRequestHeaderValue(eventRequest, eventUrlHeaderKey, eventUrlHeaderValue)) {
+      LogError("Failed to add header '%s' with value '%s' to event HTTP request.", eventUrlHeaderKey, eventUrlHeaderValue);
+      delete eventRequest;
+      return;
+    }
+  }
+  SteamWorks_SetHTTPRequestRawPostBody(eventRequest, "application/json", event, strlen(event));
+  SteamWorks_SetHTTPRequestNetworkActivityTimeout(eventRequest, 15); // Default 60 is a bit much.
+  SteamWorks_SetHTTPCallbacks(eventRequest, EventRequestCallback);
+  SteamWorks_SendHTTPRequest(eventRequest);
+}
+
+static int EventRequestCallback(Handle request, bool failure, bool requestSuccessful,
+                               EHTTPStatusCode statusCode) {
+  if (failure || !requestSuccessful) {
+    LogError("Event HTTP request failed due to a network or configuration error.");
+    delete request;
+    return;
+  }
+  int status = view_as<int>(statusCode);
+  if (status >= 300 || status < 200) {
+    LogError("Event HTTP request failed with status code: %d.", statusCode);
+    int responseSize;
+    SteamWorks_GetHTTPResponseBodySize(request, responseSize);
+    char[] response = new char[responseSize];
+    if (SteamWorks_GetHTTPResponseBodyData(request, response, responseSize)) {
+      LogError("Response body: %s", response);
+    } else {
+      LogError("Failed to read response body.");
+    }
+  }
+  delete request;
+}

--- a/scripting/get5/http.sp
+++ b/scripting/get5/http.sp
@@ -1,0 +1,45 @@
+#define GET5_HEADER_MATCHID "Get5-MatchId"
+#define GET5_HEADER_MAPNUMBER "Get5-MapNumber"
+#define GET5_HEADER_SERVERID "Get5-ServerId"
+#define GET5_HEADER_DEMONAME "Get5-DemoName"
+
+Handle CreateGet5HTTPRequest(const EHTTPMethod method, const char[] url) {
+  static char formattedUrl[1024];
+  strcopy(formattedUrl, 1024, url);
+  PrependProtocolToURLIfRequired(formattedUrl, sizeof(formattedUrl));
+  Handle request = SteamWorks_CreateHTTPRequest(method, formattedUrl);
+  if (request == INVALID_HANDLE) {
+    LogError("Failed to create HTTP request for URL: %s", formattedUrl);
+    return INVALID_HANDLE;
+  }
+  SetGet5ServerIdHeader(request);
+  SetGet5UserAgent(request);
+  return request;
+}
+
+static void PrependProtocolToURLIfRequired(char[] url, const int urlSize) {
+  if (StrContains(url, "http", false) != 0) {
+    Format(url, urlSize, "http://%s", url);
+  }
+}
+
+static bool SetGet5UserAgent(const Handle request) {
+  static char userAgent[128];
+  static bool didWriteBuffer;
+  if (!didWriteBuffer) {
+    // Since this never changes during the lifetime of the plugin, we only need to format it once.
+    FormatEx(userAgent, 128, "SourceMod Get5 %s+https://%s", PLUGIN_VERSION, GET5_GITHUB_PAGE);
+    didWriteBuffer = true;
+  }
+  return SteamWorks_SetHTTPRequestUserAgentInfo(request, userAgent);
+}
+
+static bool SetGet5ServerIdHeader(const Handle request) {
+  char serverIdString[32];
+  int serverId = Get5_GetServerID();
+  if (serverId < 1) {
+    return true;
+  }
+  IntToString(serverId, serverIdString, sizeof(serverIdString));
+  return SteamWorks_SetHTTPRequestHeaderValue(request, GET5_HEADER_SERVERID, serverIdString);
+}


### PR DESCRIPTION
As the current event system is thoroughly documented as JSON, but requires SourceMod knowledge to actually use, as you would have to write your own plugin to hook onto events, I figured it would be a nice addition to Get5 if it could natively send all events somewhere over HTTP. This lets this happen.

No breaking changes, just 3 cvars:

`get5_remote_log_url` to enable logging.

`get5_remote_log_header_key` and `get5_remote_log_header_value` for authorization, if required.

Also moved some common code from the demo upload logic to an `http.sp` file.

Untested.