### PR TITLE
Prevent multiple calls to !stop or the use of it during backup pause

### DIFF
--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -1123,7 +1123,10 @@ static Action Command_Stop(int client, int args) {
     return Plugin_Handled;
   }
 
-  if (g_GameState != Get5State_Live || g_PendingSideSwap == true) {
+  // Because a live restore to the same match does not change get5 state to warmup, we have to make sure
+  // that successive calls to !stop (spammed by players) does not reload multiple backups.
+  if (g_GameState != Get5State_Live || InHalftimePhase() || g_DoingBackupRestoreNow
+    || g_PauseType == Get5PauseType_Backup) {
     return Plugin_Handled;
   }
 
@@ -1139,6 +1142,9 @@ static Action Command_Stop(int client, int args) {
   }
 
   Get5Team team = GetClientMatchTeam(client);
+  if (!IsPlayerTeam(team)) {
+    return Plugin_Handled;
+  }
   g_TeamGivenStopCommand[team] = true;
 
   char stopCommandFormatted[64];


### PR DESCRIPTION
If players spam `!stop` during a live round, the game restores to the beginning of the current round, which does not change the game-state from live, meaning successive calls to `!stop` might trigger double restores, which messes up the game state. This prevents this from happening.

We also don't want to be able to call `!stop` while the game is still pending unpause from a restore.