### PR TITLE
Fix problems with knife swap/stay command timing

### DIFF
--- a/cfg/get5/knife.cfg
+++ b/cfg/get5/knife.cfg
@@ -10,3 +10,4 @@ mp_roundtime 1.92
 mp_roundtime_defuse 1.92
 mp_roundtime_hostage 1.92
 mp_t_default_secondary ""
+mp_round_restart_delay 3

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -117,7 +117,8 @@ in [scrim mode](../getting_started/#scrims), put on `team2`. **`Default: 1`**
 
 ####`get5_time_to_make_knife_decision`
 :   Time (in seconds) a team has to make a [`!stay`](../commands/#stay) or [`!swap`](../commands/#swap)
-decision after winning knife round, 0 = unlimited. **`Default: 60`**
+decision after winning knife round. Cannot be set lower than 10 if non-zero. Set to zero to remove
+limit.<br>**`Default: 60`**
 
 ####`get5_veto_countdown`
 :   Time (in seconds) to countdown before veto process commences. **`Default: 5`**

--- a/scripting/get5/kniferounds.sp
+++ b/scripting/get5/kniferounds.sp
@@ -1,8 +1,11 @@
 Action StartKnifeRound(Handle timer) {
   g_HasKnifeRoundStarted = false;
-
-  // Removes ready tags
-  SetMatchTeamCvars();
+  if (g_KnifeChangedCvars != INVALID_HANDLE) {
+    CloseCvarStorage(g_KnifeChangedCvars);
+  }
+  char knifeConfig[PLATFORM_MAX_PATH];
+  g_KnifeCfgCvar.GetString(knifeConfig, sizeof(knifeConfig));
+  g_KnifeChangedCvars = ExecuteAndSaveCvars(knifeConfig);
 
   Get5_MessageToAll("%t", "KnifeIn5SecInfoMessage");
   if (InWarmup()) {
@@ -31,6 +34,30 @@ static Action Timer_AnnounceKnife(Handle timer) {
 
   g_HasKnifeRoundStarted = true;
   return Plugin_Handled;
+}
+
+void StartKnifeTimer() {
+  float knifeDecisionTime = g_TeamTimeToKnifeDecisionCvar.FloatValue;
+  if (knifeDecisionTime > 0.0) {
+    if (knifeDecisionTime < 10.0) {
+      knifeDecisionTime = 10.0;
+    }
+    g_KnifeDecisionTimer = CreateTimer(knifeDecisionTime, Timer_ForceKnifeDecision);
+  }
+}
+
+void PromptForKnifeDecision() {
+  if (g_KnifeWinnerTeam == Get5Team_None) {
+    // Handle waiting for knife decision. Also check g_KnifeWinnerTeam as there is a small delay between
+    // selecting a side and the game state changing, during which this message should not be printed.
+    return;
+  }
+  char formattedStayCommand[64];
+  FormatChatCommand(formattedStayCommand, sizeof(formattedStayCommand), "!stay");
+  char formattedSwapCommand[64];
+  FormatChatCommand(formattedSwapCommand, sizeof(formattedSwapCommand), "!swap");
+  Get5_MessageToAll("%t", "WaitingForEnemySwapInfoMessage",
+    g_FormattedTeamNames[g_KnifeWinnerTeam], formattedStayCommand, formattedSwapCommand);
 }
 
 static void PerformSideSwap(bool swap) {
@@ -151,7 +178,7 @@ Action Command_T(int client, int args) {
   return Plugin_Handled;
 }
 
-Action Timer_ForceKnifeDecision(Handle timer) {
+static Action Timer_ForceKnifeDecision(Handle timer) {
   g_KnifeDecisionTimer = INVALID_HANDLE;
   if (g_GameState == Get5State_WaitingForKnifeRoundDecision && g_KnifeWinnerTeam != Get5Team_None) {
     Get5_MessageToAll("%t", "TeamLostTimeToDecideInfoMessage",

--- a/scripting/get5/matchconfig.sp
+++ b/scripting/get5/matchconfig.sp
@@ -39,6 +39,7 @@ bool LoadMatchConfig(const char[] config, bool restoreBackup = false) {
   g_MatchID = "";
   g_ReadyTimeWaitingUsed = 0;
   g_HasKnifeRoundStarted = false;
+  g_KnifeWinnerTeam = Get5Team_None;
   g_MapChangePending = false;
   g_MapNumber = 0;
   g_NumberOfMapsInSeries = 0;


### PR DESCRIPTION
It seems there are still some rare problems with `!stay` and `!swap` being called at **the exact wrong time** causing the game to misbehave and sometimes skip the live countdown entirely.

This PR disables the ability to choose a side until the knife-round has completely ended, removing the race-condition window that would cause this bug.

It also reduces info message interval from 29 to 20, but instead restarts the timer on each round start to avoid double-printing messages, such as the "Team X won the knife round, waiting for them to type swap/stay", which is also triggered when the knife round ends.

Added `mp_round_restart_delay 3` to the default knife config as you now can't do swap/stay until the round ends, so 5 seconds is a bit much.

Deduplicate logic for the knife-decision chat message

Remove round-end-fun-fact override hack; it was buggy.

I would like to merge this to 0.10 and release as 0.10.4 (with https://github.com/splewis/get5/pull/887), as this is potentially game-breaking and 0.11 is still not ready.