### PR TITLE
Use SteamWorks_SetHTTPRequestContextValue to pass demo file name

### DIFF
--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -249,7 +249,6 @@ ArrayList g_ChatAliasesCommands;
 
 /** Map-game state not related to the actual gameplay. **/
 char g_DemoFileName[PLATFORM_MAX_PATH];
-char g_DemoFileNameLastStartedUpload[PLATFORM_MAX_PATH];
 bool g_MapChangePending = false;
 bool g_PendingSideSwap = false;
 Handle g_PendingMapChangeTimer = INVALID_HANDLE;

--- a/scripting/get5/debug.sp
+++ b/scripting/get5/debug.sp
@@ -128,7 +128,6 @@ static void AddGlobalStateInfo(File f) {
   f.WriteLine("g_PauseType = %d", g_PauseType);
   f.WriteLine("g_LatestPauseDuration = %d", g_LatestPauseDuration);
   f.WriteLine("g_PendingSurrenderTeam = %d", g_PendingSurrenderTeam);
-  f.WriteLine("g_DemoFileNameLastStartedUpload = %s", g_DemoFileNameLastStartedUpload);
 
   LOOP_TEAMS(team) {
     GetTeamString(team, buffer, sizeof(buffer));


### PR DESCRIPTION
Instead of `g_DemoFileNameLastStartedUpload`, this allows us to associate the filename with the request without introducing any global state.