### PR TITLE
Avoid restarting demo recording if restoring to the same match/map

### DIFF
--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -969,7 +969,7 @@ static Action Timer_CheckReady(Handle timer) {
     // We don't wait for spectators when restoring backups
     if (IsTeamsReady()) {
       LogDebug("Timer_CheckReady: restoring from backup");
-      RestoreGet5Backup();
+      RestoreGet5Backup(true);
     }
   } else if (g_GameState == Get5State_Warmup) {
     // Handle ready checks for warmup, provided we are not waiting for a map change
@@ -1236,7 +1236,7 @@ void RestoreLastRound(int client) {
   char lastBackup[PLATFORM_MAX_PATH];
   g_LastGet5BackupCvar.GetString(lastBackup, sizeof(lastBackup));
   if (!StrEqual(lastBackup, "")) {
-    if (RestoreFromBackup(lastBackup, false)) {
+    if (RestoreFromBackup(lastBackup)) {
       Get5_MessageToAll("%t", "BackupLoadedInfoMessage", lastBackup);
       // Fix the last backup cvar since it gets reset.
       g_LastGet5BackupCvar.SetString(lastBackup);


### PR DESCRIPTION
This requires a bit more than immediately apparent, as recordings **must** be both stopped and restarted if restoring to a different map and match, but should otherwise just record into one file.

To clarify:
1. If we don't stop the recording when loading a backup for a different match/map, Get5 won't fire `Get5_OnDemoFinished`, and the file is potentially not uploaded. It is automatically stopped if changing the map (if we don't do it), and stopping it requires that we restart it in all cases. This means we need to know what match and map number the backup contains.
2. When restoring from a backup on a different map/match, we **must** call `StartRecording()` for Get5 to properly track the file it is recording to, **but** we can't just call this if the game is already recording, i.e. if we load a backup on the same match/map, as the file Get5 thinks it's recording to then won't match what's actually being recorded to.
3. I've attempted to work around this by storing the `mapnumber` in backups and then check if we're restoring to the same match and map number from a live state, in which case we do not restart the recording. Any other case, we still do.
4. If we restore to prelive on the same match/map, the recording is still stopped and restarted, as the game is essentially completely reset and the first demo can be entirely discarded, however `Get5_OnDemoFinished` is still fired for that file.
