### PR TITLE
Add more event data

### DIFF
--- a/documentation/docs/event_schema.yml
+++ b/documentation/docs/event_schema.yml
@@ -261,6 +261,14 @@ paths:
                     SourceMod.
                 winner:
                   $ref: "#/components/schemas/Get5Winner"
+                time_until_restore:
+                  type: integer
+                  minimum: 0
+                  example: 45
+                  description: |
+                    The number of seconds until Get5 restores any changed ConVars after the series has ended. This is
+                    the GOTV broadcast delay plus a few seconds. If you use this event to relinquish a server instance,
+                    you should wait until this time has passed before starting a new match or shutting down the server.
       responses: { }
   "/Get5_OnKnifeRoundStarted":
     post:
@@ -519,17 +527,33 @@ paths:
             schema:
               title: Get5DemoFinishedEvent
               allOf:
-                - "$ref": "#/components/schemas/Get5MapEvent"
+                - "$ref": "#/components/schemas/Get5DemoFileEvent"
               properties:
                 event:
                   enum:
                     - demo_finished
-                filename:
-                  type: string
-                  example: "1324_map_0_de_nuke.dem"
-                  description: |
-                    The name of the file containing the GOTV recording of the map. The format is determined by the
-                    `get5_demo_name_format` parameter.
+      responses: { }
+  "/Get5_OnDemoUploadEnded":
+    post:
+      tags:
+        - Series Flow
+      description: |
+        Fired when the request to upload a demo ends, regardless if it succeeds or fails. If you upload demos, you
+        should not shut down a server until this event has fired.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              title: Get5DemoUploadEndedEvent
+              allOf:
+                - "$ref": "#/components/schemas/Get5DemoFileEvent"
+              properties:
+                event:
+                  enum:
+                    - demo_upload_ended
+                success:
+                  type: boolean
+                  description: Whether the upload was successful. `Success` in SourceMod.
       responses: { }
   "/Get5_OnPlayerBecameMVP":
     post:
@@ -869,6 +893,16 @@ components:
           example: 0
           description: The map number in the series, starting at 0. `MapNumber` in
             SourceMod.
+    Get5DemoFileEvent:
+      allOf:
+        - "$ref": "#/components/schemas/Get5MapEvent"
+      properties:
+        filename:
+          type: string
+          example: "1324_map_0_de_nuke.dem"
+          description: |
+            The name of the file containing the GOTV recording of the map. The format is determined by the
+            `get5_demo_name_format` parameter.
     Get5MapSelectionEvent:
       allOf:
         - "$ref": "#/components/schemas/Get5MatchTeamEvent"

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -269,6 +269,7 @@ Handle g_OnBombDefused = INVALID_HANDLE;
 Handle g_OnBombExploded = INVALID_HANDLE;
 Handle g_OnBombPlanted = INVALID_HANDLE;
 Handle g_OnDemoFinished = INVALID_HANDLE;
+Handle g_OnDemoUploadEnded = INVALID_HANDLE;
 Handle g_OnEvent = INVALID_HANDLE;
 Handle g_OnFlashbangDetonated = INVALID_HANDLE;
 Handle g_OnHEGrenadeDetonated = INVALID_HANDLE;
@@ -661,6 +662,7 @@ public void OnPluginStart() {
   /** Create forwards **/
   g_OnBackupRestore = CreateGlobalForward("Get5_OnBackupRestore", ET_Ignore, Param_Cell);
   g_OnDemoFinished = CreateGlobalForward("Get5_OnDemoFinished", ET_Ignore, Param_Cell);
+  g_OnDemoUploadEnded = CreateGlobalForward("Get5_OnDemoUploadEnded", ET_Ignore, Param_Cell);
   g_OnEvent = CreateGlobalForward("Get5_OnEvent", ET_Ignore, Param_Cell, Param_String);
   g_OnFlashbangDetonated = CreateGlobalForward("Get5_OnFlashbangDetonated", ET_Ignore, Param_Cell);
   g_OnHEGrenadeDetonated = CreateGlobalForward("Get5_OnHEGrenadeDetonated", ET_Ignore, Param_Cell);
@@ -1427,7 +1429,7 @@ void EndSeries(Get5Team winningTeam, bool printWinnerMessage, float restoreDelay
 
   Get5SeriesResultEvent event = new Get5SeriesResultEvent(
       g_MatchID, new Get5Winner(winningTeam, view_as<Get5Side>(Get5TeamToCSTeam(winningTeam))),
-      g_TeamSeriesScores[Get5Team_1], g_TeamSeriesScores[Get5Team_2]);
+      g_TeamSeriesScores[Get5Team_1], g_TeamSeriesScores[Get5Team_2], RoundToFloor(restoreDelay));
 
   LogDebug("Calling Get5_OnSeriesResult()");
 

--- a/scripting/include/get5.inc
+++ b/scripting/include/get5.inc
@@ -550,6 +550,15 @@ methodmap Get5PlayerTimedRoundEvent < Get5TimedRoundEvent {
 
 methodmap Get5SeriesResultEvent < Get5MatchEvent {
 
+  property int TimeUntilRestore {
+    public get() {
+      return this.GetInt("time_until_restore");
+    }
+    public set(int time) {
+      this.SetInt("time_until_restore", time);
+    }
+  }
+
   property Get5Winner Winner {
     public get() {
       return view_as<Get5Winner>(this.GetObject("winner"));
@@ -577,13 +586,14 @@ methodmap Get5SeriesResultEvent < Get5MatchEvent {
     }
   }
 
-  public Get5SeriesResultEvent(const char[] matchId, const Get5Winner winner, const int team1Score, const int team2Score) {
+  public Get5SeriesResultEvent(const char[] matchId, const Get5Winner winner, const int team1Score, const int team2Score, const int timeUntilRestore) {
     Get5SeriesResultEvent self = view_as<Get5SeriesResultEvent>(new JSON_Object());
     self.SetEvent("series_end");
     self.SetMatchId(matchId);
     self.Winner = winner;
     self.Team1SeriesScore = team1Score;
     self.Team2SeriesScore = team2Score;
+    self.TimeUntilRestore = timeUntilRestore;
     return self;
   }
 }
@@ -820,7 +830,7 @@ methodmap Get5RoundStatsUpdatedEvent < Get5RoundEvent {
   }
 }
 
-methodmap Get5DemoFinishedEvent < Get5MapEvent {
+methodmap Get5DemoFileEvent < Get5MapEvent {
 
   public bool SetFileName(const char[] filename) {
     return this.SetString("filename", filename);
@@ -828,6 +838,9 @@ methodmap Get5DemoFinishedEvent < Get5MapEvent {
   public bool GetFileName(char[] buffer, const int maxSize) {
     return this.GetString("filename", buffer, maxSize);
   }
+}
+
+methodmap Get5DemoFinishedEvent < Get5DemoFileEvent {
 
   public Get5DemoFinishedEvent(const char[] matchId, const int mapNumber, const char[] filename) {
     Get5DemoFinishedEvent self = view_as<Get5DemoFinishedEvent>(new JSON_Object());
@@ -835,6 +848,28 @@ methodmap Get5DemoFinishedEvent < Get5MapEvent {
     self.SetMatchId(matchId);
     self.MapNumber = mapNumber;
     self.SetFileName(filename);
+    return self;
+  }
+}
+
+methodmap Get5DemoUploadEndedEvent < Get5DemoFileEvent {
+
+  property bool Success {
+    public get() {
+      return this.GetBool("success");
+    }
+    public set(bool success) {
+      this.SetBool("success", success);
+    }
+  }
+
+  public Get5DemoUploadEndedEvent(const char[] matchId, const int mapNumber, const char[] filename, const bool success) {
+    Get5DemoUploadEndedEvent self = view_as<Get5DemoUploadEndedEvent>(new JSON_Object());
+    self.SetEvent("demo_upload_ended");
+    self.SetMatchId(matchId);
+    self.MapNumber = mapNumber;
+    self.SetFileName(filename);
+    self.Success = success;
     return self;
   }
 }
@@ -1787,6 +1822,9 @@ forward void Get5_OnSidePicked(const Get5SidePickedEvent event);
 
 // Called when a demo finishes recording.
 forward void Get5_OnDemoFinished(const Get5DemoFinishedEvent event);
+
+// Called when a demo upload attempt ends.
+forward void Get5_OnDemoUploadEnded(const Get5DemoUploadEndedEvent event);
 
 // Called when a match is paused.
 forward void Get5_OnMatchPaused(const Get5MatchPausedEvent event);


### PR DESCRIPTION
1. Adds `time_until_restore` to `Get5_OnSeriesResult`, so a server management system knows how long to wait until the server is available after a match ends.
2. Adds `Get5_OnDemoUploadEnded` which fires when the demo upload either fails or succeeds, again letting a server management system know when this has completed so the server can be shut down.

Tested and works as expected.