### PR TITLE
Cleaned up remote match load logic

### DIFF
--- a/documentation/docs/commands.md
+++ b/documentation/docs/commands.md
@@ -110,11 +110,18 @@ time a backup file is written. Empty string if no backup was written.
 :   Loads a [team section of a match configuration](../match_schema) from a file into a team relative to the `csgo`
 directory. The file must contain a `Get5MatchTeam` object.
 
-####`get5_loadmatch_url <url> [headername] [headervalue]` {: #get5_loadmatch_url }
+####`get5_loadmatch_url <url> [header name] [header value]` {: #get5_loadmatch_url }
 :   Loads a remote (JSON-formatted) [match configuration](../match_schema) by sending an HTTP(S) `GET` to the given URL.
-You should put the `url` argument inside quotation marks (`""`). You may optionally provide an HTTP header and value
-pair using the `headername` and `headervalue` arguments. For example, if you wanted to authenticate your request with a
-Bearer token, you could do: `get5_loadmatch_url "https://example.com" "Authorization" "Bearer <token>"`.
+You may optionally provide an HTTP header and value pair using the `header name` and `header value` arguments. You
+should put all arguments inside quotation marks (`""`).
+
+!!! example
+    
+    With `Authorization`:<br>
+    `get5_loadmatch_url "https://example.com/match_config.json" "Authorization" "Bearer <token>"`
+
+    Without custom headers:<br>
+    `get5_loadmatch_url "https://example.com/match_config.json"`
 
 !!! warning "SteamWorks required"
 


### PR DESCRIPTION
This cleans up the implementation of remote loading of match configurations.

1. Reuse the HTTP "client" from `http.sp`.
2. Remove `g_LoadedConfigUrl` global variable and use HTTP context datapack.
3. Giver better feedback on errors, such as missing quotes around URLs.
4. Early return where applicable.
5. Remove unnecessary `stock` modifier.
6. Delete temporary local match configuration files *if* they load successfully; let them remain if not for debugging.
7. Remove duplicate SteamWorks dependency check.
8. Consistently use `MatchConfigFail` instead of `LogError` in this context.
9. Validate the input for the `get5_loadmatch_url` command before rejecting it due to already loaded config.
10. Only set `g_LoadedConfigFile` to the loaded URL if the config successfully loads.

Tested and works fine. Tested invalid parameters, invalid URL, request timeout, 404 (non-200 range), invalid match config file, successful load etc.