### PR TITLE
Fix "CTs win" callout before knife round + Prevent connecting users from joining teams too early

### DIFF
--- a/scripting/get5/kniferounds.sp
+++ b/scripting/get5/kniferounds.sp
@@ -8,13 +8,8 @@ Action StartKnifeRound(Handle timer) {
   g_KnifeChangedCvars = ExecuteAndSaveCvars(knifeConfig);
 
   Get5_MessageToAll("%t", "KnifeIn5SecInfoMessage");
-  if (InWarmup()) {
-    EndWarmup(5);
-  } else {
-    RestartGame(5);
-  }
-
-  g_KnifeCountdownTimer = CreateTimer(10.0, Timer_AnnounceKnife);
+  StartWarmup(5);
+  g_KnifeCountdownTimer = CreateTimer(15.0, Timer_AnnounceKnife);
   return Plugin_Handled;
 }
 

--- a/scripting/get5/matchconfig.sp
+++ b/scripting/get5/matchconfig.sp
@@ -169,7 +169,7 @@ bool LoadMatchConfig(const char[] config, bool restoreBackup = false) {
     // When the match is loaded, we do not want to assign players on no team, as they may be in the
     // process of joining the server, which is the reason for the timer callback. This has caused
     // problems with players getting stuck on no team when using match config autoload, essentially
-    // recreating the "coaching bug". Adding a second seems to solve this problem. We cannot just
+    // recreating the "coaching bug". Adding a few seconds seems to solve this problem. We cannot just
     // skip team none, as players may also just be on the team selection menu when the match is
     // loaded, meaning they will never have a joingame hook, as it already happened, and we still
     // want those players placed.
@@ -177,7 +177,7 @@ bool LoadMatchConfig(const char[] config, bool restoreBackup = false) {
       LOOP_CLIENTS(i) {
         if (IsPlayer(i)) {
           if (GetClientTeam(i) == CS_TEAM_NONE) {
-            CreateTimer(1.0, Timer_PlacePlayerFromTeamNone, i, TIMER_FLAG_NO_MAPCHANGE);
+            CreateTimer(2.0, Timer_PlacePlayerFromTeamNone, i, TIMER_FLAG_NO_MAPCHANGE);
           } else {
             CheckClientTeam(i);
           }

--- a/scripting/get5/teamlogic.sp
+++ b/scripting/get5/teamlogic.sp
@@ -27,6 +27,7 @@ static Action Timer_PlacePlayerOnJoin(Handle timer, int userId) {
 
 // Assumes client IsPlayer().
 void CheckClientTeam(int client) {
+  g_ClientPendingTeamCheck[client] = false;
   Get5Team correctTeam = GetClientMatchTeam(client);
   if (correctTeam == Get5Team_None) {
     RememberAndKickClient(client, "%t", "YouAreNotAPlayerInfoMessage");
@@ -88,7 +89,8 @@ void CheckClientTeam(int client) {
 
 static void PlacePlayerOnTeam(int client) {
   if (g_PendingSideSwap || InHalftimePhase()) {
-    LogDebug("Blocking attempt to join a team due to halftime or pending team swap.");
+    LogDebug("Blocking attempt to join a team for client %d due to halftime or pending team swap.", client);
+    g_ClientPendingTeamCheck[client] = true;
     return;
   }
   CheckClientTeam(client);

--- a/scripting/get5/util.sp
+++ b/scripting/get5/util.sp
@@ -179,9 +179,7 @@ stock bool InFreezeTime() {
 stock void StartWarmup(int warmupTime = 0) {
   ServerCommand("mp_do_warmup_period 1");
   ServerCommand("mp_warmuptime_all_players_connected 0");
-  if (!InWarmup()) {
-    ServerCommand("mp_warmup_start");
-  }
+  ServerCommand("mp_warmup_start");
   if (warmupTime < 1) {
     LogDebug("Setting indefinite warmup.");
     // Setting mp_warmuptime to anything less than 7 triggers the countdown to restart regardless of
@@ -191,15 +189,6 @@ stock void StartWarmup(int warmupTime = 0) {
     ServerCommand("mp_warmup_pausetimer 1");
   } else {
     ServerCommand("mp_warmuptime %d", warmupTime);
-    ServerCommand("mp_warmup_pausetimer 0");
-  }
-}
-
-stock void EndWarmup(int time = 0) {
-  if (time == 0) {
-    ServerCommand("mp_warmup_end");
-  } else {
-    ServerCommand("mp_warmuptime %d", time);
     ServerCommand("mp_warmup_pausetimer 0");
   }
 }


### PR DESCRIPTION
A hard-to-reproduce bug has been in Get5 for a while. What happens is this:

1. Match config is loaded
2. Players join the server
3. Players run around for x amount of seconds in warmup
4. 10-second round-end warning music starts playing randomly (?)
5. Players ready up
6. Warmup counter starts to count down to knife
7. "Counter Terrorists win!" panel + sound callout
8. "Match restarts in 3..2..1"
9. All players get sent back to warmup/arena
10. Announce "Knife!" in chat
11. Players stuck in warmup forever

I've been working with OmegaSkid and the SCL league in trying to narrow down exactly why and when this problem occurs, as I have been entirely unable to reproduce it on my own server. I suspect it may be related to hibernation or servers sitting in idle for too long.

I've tried to fix it here by adding two more calls to `RestartGame` in attempt to reset the game state once a player is on the server **or** when a match config is loaded. I don't know if this works, but we'll test it tomorrow across 20 matches that have been struggling a lot with this bug. If this fixes it, I will merge it.