### PR TITLE
Add option to postpone stopping the demo recording

### DIFF
--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -391,6 +391,17 @@ added automatically). If you do not include the [`{TIME}`](#tag-time) tag, you w
 if restoring a game from a backup. Note that the [`{MAPNUMBER}`](#tag-mapnumber)variable is not zero-indexed. Set to
 empty string to disable recording demos.<br>**`Default: "{TIME}_{MATCHID}_map{MAPNUMBER}_{MAPNAME}"`**
 
+####`get5_demo_postpone_stop`
+:   If enabled, the [demo recording](gotv.md#demos) will stop right before the GOTV finishes broadcasting the match,
+instead of shortly after the match ends (Get5 default). Some servers may experience lockups/freezes of the GOTV
+broadcast when the demo recording is being flushed to disk, so waiting to do this until the entire match has been
+broadcast mitigates this issue. You should only enable this if you encounter this problem.<br>**`Default: 0`**
+
+!!! warning "Longer demo files"
+
+    Enabling `get5_demo_postpone_stop` will extend the length of your demo files by the duration of your GOTV delay, but
+    with no meaningful content at the end.
+
 ## Events
 
 ####`get5_remote_log_url`

--- a/documentation/docs/gotv.md
+++ b/documentation/docs/gotv.md
@@ -25,10 +25,15 @@ Get5 can be configured to automatically record matches. This is enabled by defau
 of [`get5_demo_name_format`](../configuration/#get5_demo_name_format) and can be disabled by setting that parameter to
 an empty string.
 
-Demo recording starts once all teams have readied up and ends shortly following a map result or when
-the [`get5_loadbackup`](../commands/#get5_loadbackup) command is issued, which starts a new recording. When a demo file
-is written to disk, the [`Get5_OnDemoFinished`](events_and_forwards.md) forward is called. The filename can also be
-found in the map-section of the [KeyValue stats system](../stats_system/#keyvalue).
+Demo recording starts once all teams have readied up and ends shortly following a map result. When a demo file is
+written to disk, the [`Get5_OnDemoFinished`](events_and_forwards.md) forward is called shortly after. The filename can
+also be found in the map-section of the [KeyValue stats system](../stats_system/#keyvalue).
+
+!!! danger "GOTV lockup on flush to disk"
+
+    Some servers experience lockups of the GOTV broadcast while the demo file is being flushed to disk, which may take
+    up to 10 seconds in some cases. If your server suffers from this problem and you cannot fix it, you can enable
+    [`get5_demo_postpone_stop`](../configuration/#get5_demo_postpone_stop).
 
 ## Automatic Upload {: #upload }
 

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -38,7 +38,7 @@
 #define DEBUG_CVAR "get5_debug"
 #define MATCH_ID_LENGTH 64
 #define MAX_CVAR_LENGTH 128
-#define MATCH_END_DELAY_AFTER_TV 15
+#define GOTV_RECORDING_STOP_DELAY 15.0 // default delay when the match ends, so GOTV can record scoreboard.
 
 #define TEAM1_STARTING_SIDE CS_TEAM_CT
 #define TEAM2_STARTING_SIDE CS_TEAM_T
@@ -119,6 +119,7 @@ ConVar g_DemoUploadHeaderKeyCvar;
 ConVar g_DemoUploadHeaderValueCvar;
 ConVar g_DemoUploadDeleteAfterCvar;
 ConVar g_DemoPathCvar;
+ConVar g_DemoPostponeStopCvar;
 
 // Autoset convars (not meant for users to set)
 ConVar g_GameStateCvar;
@@ -396,6 +397,9 @@ public void OnPluginStart() {
   g_DemoPathCvar = CreateConVar(
       "get5_demo_path", "",
       "The folder to save demo files in, relative to the csgo directory. If defined, it must not start with a slash and must end with a slash.");
+  g_DemoPostponeStopCvar = CreateConVar(
+      "get5_demo_postpone_stop", "0",
+      "If enabled, the demo recording will stop right before the GOTV finishes broadcasting the match, instead of shortly after the match ends.");
   g_DemoUploadHeaderValueCvar = CreateConVar(
       "get5_demo_upload_header_value", "",
       "If defined, it is the authorization value that is appended to the HTTP request. Requires SteamWorks.");
@@ -1276,14 +1280,15 @@ static Action Event_MatchOver(Event event, const char[] name, bool dontBroadcast
   // This ensures that the mp_match_restart_delay is not shorter
   // than what is required for the GOTV recording to finish.
   float restartDelay = GetCurrentMatchRestartDelay();
-  float requiredDelay = float(GetTvDelay() + MATCH_END_DELAY_AFTER_TV);
+  float requiredDelay = float(GetTvDelay()) + GOTV_RECORDING_STOP_DELAY;
   if (requiredDelay > restartDelay) {
     LogDebug("Extended mp_match_restart_delay from %f to %f to ensure GOTV broadcast can finish.",
              restartDelay, requiredDelay);
     SetCurrentMatchRestartDelay(requiredDelay);
     restartDelay = requiredDelay;  // reassigned because we reuse the variable below.
   }
-  StopRecording(float(MATCH_END_DELAY_AFTER_TV));
+  // -0.5 to make sure it actually stops before the match ends.
+  StopRecording((g_DemoPostponeStopCvar.BoolValue ? requiredDelay : GOTV_RECORDING_STOP_DELAY) - 0.5);
 
   if (g_GameState == Get5State_Live) {
     // If someone called for a pause in the last round; cancel it.

--- a/scripting/get5/recording.sp
+++ b/scripting/get5/recording.sp
@@ -57,8 +57,9 @@ static void StopRecordingCallback(const char[] matchId, const int mapNumber,
     LogDebug("Demo was not recorded by Get5; not firing Get5_OnDemoFinished()");
     return;
   }
-  // We delay this by 3 seconds to allow the server to flush to the file before firing the event.
-  CreateTimer(3.0, Timer_FireStopRecordingEvent,
+  // We delay this by 10 seconds to allow the server to flush to the file before firing the event.
+  // For some servers, this take a pretty long time.
+  CreateTimer(10.0, Timer_FireStopRecordingEvent,
               GetDemoInfoDataPack(matchId, mapNumber, demoFileName));
 }
 
@@ -210,7 +211,17 @@ static bool IsTVEnabled() {
 
 int GetTvDelay() {
   if (IsTVEnabled()) {
-    return GetCvarIntSafe("tv_delay");
+    bool tvEnable1 = GetCvarIntSafe("tv_enable1") > 0;
+    int tvDelay = GetCvarIntSafe("tv_delay");
+    if (!tvEnable1) {
+      return tvDelay;
+    }
+    int tvDelay1 = GetCvarIntSafe("tv_delay1");
+    if (tvDelay < tvDelay1) {
+      LogDebug("tv_delay1 is longer than the default tv_delay; using that.");
+      return tvDelay1;
+    }
+    return tvDelay;
   }
   return 0;
 }

--- a/scripting/get5/surrender.sp
+++ b/scripting/get5/surrender.sp
@@ -333,6 +333,7 @@ static Action Timer_ForfeitCountdownCheck(Handle timer) {
   g_ForfeitTimer = INVALID_HANDLE;
 
   LogDebug("Forfeit timer expired. Ending series with %d as forfeiting team.", g_ForfeitingTeam);
+  // TODO: We can probably remove this StopRecording call, as Get5 should not be recording at this time?
   StopRecording(5.0); // add 5 seconds to include announcement, so players know why they are potentially kicked.
   Get5Team winningTeam = Get5Team_None;
   if (g_ForfeitingTeam != Get5Team_None) {


### PR DESCRIPTION
It seems that some servers cannot handle doing GOTV broadcast **and** flushing demos at the same time. This adds an option to extend the delay on flushing demos on round end, allowing for the full match to be broadcast on GOTV before the demo is stopped, even with a long delay.