### PR TITLE
Missing set `Player` property in `Get5PlayerSayEvent`

### DIFF
--- a/scripting/include/get5.inc
+++ b/scripting/include/get5.inc
@@ -1104,6 +1104,7 @@ methodmap Get5PlayerSayEvent < Get5PlayerTimedRoundEvent {
     self.MapNumber = mapNumber;
     self.RoundNumber = roundNumber;
     self.RoundTime = roundTime;
+    self.Player = player;
     self.SetCommand(command);
     self.SetMessage(message);
     return self;


### PR DESCRIPTION
Oversigt. This property was never set even though the documentation insists it is there and it is being delivered correctly to the object's constructor.