### PR TITLE
Always handle GOTV memory leak problem, remove feature to toggle fix

### DIFF
--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -419,17 +419,6 @@ added automatically). If you do not include the [`{TIME}`](#tag-time) tag, you w
 if restoring a game from a backup. Note that the [`{MAPNUMBER}`](#tag-mapnumber)variable is not zero-indexed. Set to
 empty string to disable recording demos.<br>**`Default: "{TIME}_{MATCHID}_map{MAPNUMBER}_{MAPNAME}"`**
 
-####`get5_demo_postpone_stop`
-:   If enabled, the [demo recording](gotv.md#demos) will stop right before the GOTV finishes broadcasting the match,
-instead of shortly after the match ends (Get5 default). Some servers may experience lockups/freezes of the GOTV
-broadcast when the demo recording is being flushed to disk, so waiting to do this until the entire match has been
-broadcast mitigates this issue. You should only enable this if you encounter this problem.<br>**`Default: 0`**
-
-!!! warning "Longer demo files"
-
-    Enabling `get5_demo_postpone_stop` will extend the length of your demo files by the duration of your GOTV delay, but
-    with no meaningful content at the end.
-
 ## Events
 
 ####`get5_remote_log_url`

--- a/documentation/docs/gotv.md
+++ b/documentation/docs/gotv.md
@@ -25,15 +25,15 @@ Get5 can be configured to automatically record matches. This is enabled by defau
 of [`get5_demo_name_format`](../configuration/#get5_demo_name_format) and can be disabled by setting that parameter to
 an empty string.
 
-Demo recording starts once all teams have readied up and ends shortly following a map result. When a demo file is
-written to disk, the [`Get5_OnDemoFinished`](events_and_forwards.md) forward is called shortly after. The filename can
-also be found in the map-section of the [KeyValue stats system](../stats_system/#keyvalue).
+Demo recording starts once all teams have readied up and ends following a map result. When a demo file is written to
+disk, the [`Get5_OnDemoFinished`](events_and_forwards.md) forward is called shortly after. The filename can also be
+found in the map-section of the [KeyValue stats system](../stats_system/#keyvalue).
 
-!!! danger "GOTV lockup on flush to disk"
+!!! info "Broadcast delay on GOTV recording"
 
-    Some servers experience lockups of the GOTV broadcast while the demo file is being flushed to disk, which may take
-    up to 10 seconds in some cases. If your server suffers from this problem and you cannot fix it, you can enable
-    [`get5_demo_postpone_stop`](../configuration/#get5_demo_postpone_stop).
+    When the GOTV recording stops, the server will flush its framebuffer to disk. This may cause a lag spike or a
+    complete freeze of the GOTV broadcast if you have a substantial `tv_delay`, so Get5 will wait until the entire match
+    has been broadcast before it stops recording the demo.
 
 ## Automatic Upload {: #upload }
 

--- a/scripting/get5/recording.sp
+++ b/scripting/get5/recording.sp
@@ -57,9 +57,9 @@ static void StopRecordingCallback(const char[] matchId, const int mapNumber,
     LogDebug("Demo was not recorded by Get5; not firing Get5_OnDemoFinished()");
     return;
   }
-  // We delay this by 10 seconds to allow the server to flush to the file before firing the event.
-  // For some servers, this take a pretty long time.
-  CreateTimer(10.0, Timer_FireStopRecordingEvent,
+  // We delay this by 15 seconds to allow the server to flush to the file before firing the event.
+  // For some servers, this take a pretty long time (up to 8-9 seconds, so 15 for grace).
+  CreateTimer(15.0, Timer_FireStopRecordingEvent,
               GetDemoInfoDataPack(matchId, mapNumber, demoFileName));
 }
 


### PR DESCRIPTION
I do not like the `get5_demo_postpone_stop` option that I added. I think it's better to default to handling this gracefully instead of forcing users to "find out if it works or not".

This way, we always wait with stopping the demo recording until GOTV has broadcast, an add another 10 seconds of grace-period if there is a `tv_delay` (which causes the bug; flushing to disk does not freeze GOTV with no delay). With no delay or GOTV enabled, the recording still stops 15 seconds after the match ends, like it did before.

I have confirmed the freeze/memory leak bug also on my own server by playing a 10 minute game with 9 bots using:

`tv_delay 120`
`tv_snapshotrate 128`

This is the result when the demo is stopped:

```
Completed GOTV demo "2022-10-26_02-02-26_scrim_map1_de_dust2.dem", recording time 757.9
StopRecording: 7680 frames flushed in 3.48 seconds
```

During those 3.48 seconds, the server does not respond and presumably this is what also freezes GOTV. The memory consumption of the `srcds` process also goes up to around 2.5GB from around 700MB. `sm_dump_handles` gives a total SourceMod consumption of around 200MB before and after this operation, so it's definitely a bug in the game and not Get5, which seems to have been there for a long time: https://forums.alliedmods.net/archive/index.php/t-262232.html. We likely can't do anything about this. The memory consumption doesn't come down again, not by changing the map or doing `tv_stop` to entirely disable GOTV. It must be rebooted.

Also got rid of a constant that was only used in one place.