### PR TITLE
Fix hostname issues + add score tags

### DIFF
--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -313,9 +313,9 @@ exist.<br>**`Default: ""`**
 disable.<br>**`Default: "get5_matchstats_{MATCHID}.cfg"`**
 
 ####`get5_hostname_format`
-:   The hostname to apply to the server when a match configuration is loaded.
-[State substitutes](#state-substitutes) can be used. Leave blank to disable changing the hostname.<br>
-**`Default: "Get5: {TEAM1} vs {TEAM2}"`**
+:   The hostname to apply to the server. [State substitutes](#state-substitutes) can be used. Set to an empty string to
+disable changing the hostname. This is updated on every round start to allow for the use of team score
+substitutes.<br>**`Default: "Get5: {TEAM1} vs {TEAM2}"`**
 
 ####`get5_message_prefix`
 :   The tag applied before plugin messages. Note that at least one character must come before
@@ -384,8 +384,14 @@ must **end with a slash**. Required folders will be created if they do not exist
 ####`get5_demo_name_format`
 :   Format to use for demo files when [recording matches](../gotv#demos). Do not include a file extension (`.dem` is
 added automatically). If you do not include the [`{TIME}`](#tag-time) tag, you will have problems with duplicate files
-if restoring a game from a backup. Note that the [`{MAPNUMBER}`](#tag-mapnumber)variable is not zero-indexed. Set to
+if restoring a game from a backup. Note that the [`{MAPNUMBER}`](#tag-mapnumber) variable is not zero-indexed. Set to
 empty string to disable recording demos.<br>**`Default: "{TIME}_{MATCHID}_map{MAPNUMBER}_{MAPNAME}"`**
+
+!!! info "Team score is always zero"
+
+    While it may be tempting to use the [`{TEAM1_SCORE}`](#tag-team1-score) and [`{TEAM2_SCORE}`](#tag-team2-score)
+    variables in the demo name; note that this file is created as the match begins, so the score will always be zero at
+    that stage.
 
 ## Events
 
@@ -432,6 +438,12 @@ placeholder strings that will be replaced by meaningful values when printed. Not
 
 ####`{TEAM2}` {: #tag-team2}
 :   The name of `team2`.
+
+####`{TEAM1_SCORE}` {: #tag-team1-score }
+:   The score of `team1` on the current map.
+
+####`{TEAM2_SCORE}` {: #tag-team2-score }
+:   The score of `team2` on the current map.
 
 ####`{MATCHTITLE}` {: #tag-matchtitle}
 :   The title of the current match.

--- a/scripting/get5/util.sp
+++ b/scripting/get5/util.sp
@@ -235,10 +235,7 @@ stock void SetTeamInfo(int csTeam, const char[] name, const char[] flag = "", co
   SetConVarStringSafe(flagCvarName, flag);
   SetConVarStringSafe(logoCvarName, logo);
   SetConVarStringSafe(textCvarName, matchstat);
-
-  if (g_MapsToWin > 1) {
-    SetConVarIntSafe(scoreCvarName, series_score);
-  }
+  SetConVarIntSafe(scoreCvarName, g_MapsToWin > 1 ? series_score : 0);
 }
 
 stock void SetConVarIntSafe(const char[] name, int value) {

--- a/scripting/get5/version.sp
+++ b/scripting/get5/version.sp
@@ -1,6 +1,6 @@
 #tryinclude "manual_version.sp"
 #if !defined PLUGIN_VERSION
-#define PLUGIN_VERSION "0.11.0-dev"
+#define PLUGIN_VERSION "0.12.0-dev"
 #endif
 
 // This MUST be the latest version in x.y.z semver format followed by -dev.


### PR DESCRIPTION
This fixes 5 issues:

1. Fix https://github.com/splewis/get5/issues/509
2. Fix https://github.com/splewis/get5/issues/438
3. `mp_teamscore_max` is now being properly reset if going from Bo3/5 to Bo1.
4. You can now include `{TEAM1_SCORE}` and `{TEAM2_SCORE}` in your hostname (or anywhere else these tags can be used), and hostname will update on each round start.
5. Spaces in team names are no longer replaced by underscore in hostname.