### PR TITLE
Clean up cvar list/flags

### DIFF
--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -14,6 +14,12 @@ cfg/sourcemod/get5.cfg
 You can either set the below parameters in that file, or in the `cvars` section of a match config. As mentioned in
 the explanation of the [match schema](../match_schema), that section will override all other settings.
 
+!!! warning "512 and no more"
+
+    Note that the maximum length of any config parameter is *less than* 512 characters. Depending on where these
+    parameters are set, being close to this limit may cause problems. This applies to things like URLs or HTTP headers,
+    so beware of long strings in these cases.
+
 ### Phase Configuration Files
 
 You should also have three config files. These can be edited, but we recommend not

--- a/scripting/get5/matchconfig.sp
+++ b/scripting/get5/matchconfig.sp
@@ -416,9 +416,9 @@ void WriteMatchToKv(KeyValues kv) {
   kv.GoBack();
 
   kv.JumpToKey("cvars", true);
+  char cvarName[MAX_CVAR_LENGTH];
+  char cvarValue[MAX_CVAR_LENGTH];
   for (int i = 0; i < g_CvarNames.Length; i++) {
-    char cvarName[MAX_CVAR_LENGTH];
-    char cvarValue[MAX_CVAR_LENGTH];
     g_CvarNames.GetString(i, cvarName, sizeof(cvarName));
     g_CvarValues.GetString(i, cvarValue, sizeof(cvarValue));
     kv.SetString(cvarName, strlen(cvarValue) == 0 ? KEYVALUE_STRING_PLACEHOLDER : cvarValue);
@@ -531,9 +531,9 @@ static bool LoadMatchFromKv(KeyValues kv) {
   }
 
   if (kv.JumpToKey("cvars")) {
+    char name[MAX_CVAR_LENGTH];
+    char value[MAX_CVAR_LENGTH];
     if (kv.GotoFirstSubKey(false)) {
-      char name[MAX_CVAR_LENGTH];
-      char value[MAX_CVAR_LENGTH];
       do {
         kv.GetSectionName(name, sizeof(name));
         ReadEmptyStringInsteadOfPlaceholder(kv, value, sizeof(value));
@@ -1219,8 +1219,8 @@ Action Command_CreateScrim(int client, int args) {
 
   // Also ensure empty string values in cvars get printed to the match config.
   if (kv.JumpToKey("cvars")) {
+    char cVarValue[MAX_CVAR_LENGTH];
     if (kv.GotoFirstSubKey(false)) {
-      char cVarValue[MAX_CVAR_LENGTH];
       do {
         WritePlaceholderInsteadOfEmptyString(kv, cVarValue, sizeof(cVarValue));
       } while (kv.GotoNextKey(false));

--- a/scripting/get5/readysystem.sp
+++ b/scripting/get5/readysystem.sp
@@ -226,7 +226,7 @@ Action Command_ForceReadyClient(int client, int args) {
     char cVarName[MAX_CVAR_LENGTH];
     g_AllowForceReadyCvar.GetName(cVarName, sizeof(cVarName));
     FormatCvarName(cVarName, sizeof(cVarName), cVarName);
-    char forceReadyCommand[MAX_CVAR_LENGTH];
+    char forceReadyCommand[64];
     FormatChatCommand(forceReadyCommand, sizeof(forceReadyCommand), "!forceready");
     Get5_Message(client, "%t", "ForceReadyDisabled", forceReadyCommand, cVarName);
     return;


### PR DESCRIPTION
Alphabetizes (based on cvar name, not variable) list of cvars.

Adds `FCVAR_DONTRECORD` and/or `FCVAR_PROTECTED` where applicable, such as to custom header values for Authorization. 

Groups them by feature/category.

Reduces "extra documentation" in cvar descriptions, as this should be in the web documentation. These should only explain the cvars themselves, not various nice-to-knows. Having too much text here increases the burden when making changes.

Also; defaults to enabling chat damage report.