### PR TITLE
Fix problems/inconsistencies with team loading

### DIFF
--- a/documentation/docs/match_schema.md
+++ b/documentation/docs/match_schema.md
@@ -51,8 +51,9 @@ interface Get5Match {
     "spectators": { // (10)
         "name": string | undefined // (29)
         "players": Get5PlayerSet | undefined // (30)
+        "fromfile": string | undefined // (34)
     } | undefined,
-    "maplist": [string] // (13)
+    "maplist": string[] // (13)
     "favored_percentage_team1": number | undefined // (14)
     "favored_percentage_text": string | undefined // (15)
     "team1": Get5MatchTeam | Get5MatchTeamFromFile // (20)
@@ -128,9 +129,8 @@ interface Get5Match {
     cvars.<br><br>**`Default: ""`**
 28. Match teams can also be loaded from a separate file, allowing you to easily re-use a match configuration for
     different sets of teams. A `fromfile` value could be `"addons/sourcemod/configs/get5/team_nip.json"`, and is always
-    relative to the `csgo` directory. The file should contain a valid `Get5MatchTeam` object. Note that the file you
-    point to must be in the same format as the main file, so pointing to a `.cfg` file when the main file is `.json`
-    will **not** work.
+    relative to the `csgo` directory. The file should contain a valid `Get5MatchTeam` object. You **are** allowed to mix
+    filetypes, so a JSON file can point to a `fromfile` that's a KeyValue file and vice-versa.
 29. _Optional_<br>The name of the spectator team.<br><br>**`Default: "casters"`**
 30. _Optional_<br>The spectator/caster Steam IDs and names. Setting a Steam ID as spectator takes precedence over being
     set as a player or coach.
@@ -140,6 +140,7 @@ interface Get5Match {
 32. _Optional_<br>If `false`, the entire map list will be played, regardless of score. If `true`, a series will be won
     when the series score for a team exceeds the number of maps divided by two.<br><br>**`Default: true`**
 33. _Optional_<br>Determines if coaches must also [`!ready`](../commands#ready).<br><br>**`Default: false`**
+34. _Optional_<br>Similarly to teams, spectators may also be loaded from another file.
 
 !!! info "Team assignment priority"
 
@@ -382,6 +383,7 @@ These examples are identical in the way they would work if loaded.
     ```
     `fromfile` example:
     ```cfg title="addons/sourcemod/get5/team_navi.cfg"
+    Team
     { 
         "name"		"Natus Vincere"
     	"tag"		"NaVi"

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -37,7 +37,7 @@
 
 #define DEBUG_CVAR      "get5_debug"
 #define MATCH_ID_LENGTH 64
-#define MAX_CVAR_LENGTH 513 // 512 + 1 for buffers
+#define MAX_CVAR_LENGTH 513  // 512 + 1 for buffers
 
 #define TEAM1_STARTING_SIDE CS_TEAM_CT
 #define TEAM2_STARTING_SIDE CS_TEAM_T

--- a/scripting/get5/recording.sp
+++ b/scripting/get5/recording.sp
@@ -133,7 +133,8 @@ static void UploadDemoToServer(const char[] demoFileName, const char[] matchId, 
   }
 
   if (!LibraryExists("SteamWorks")) {
-    LogError("Get5 cannot upload demos to a web server without the SteamWorks extension. Set get5_demo_upload_url to an empty string to remove this message.");
+    LogError(
+      "Get5 cannot upload demos to a web server without the SteamWorks extension. Set get5_demo_upload_url to an empty string to remove this message.");
     return;
   }
 
@@ -254,7 +255,7 @@ void SetCurrentMatchRestartDelay(float delay) {
 }
 
 static void DemoRequestCallback(Handle request, bool failure, bool requestSuccessful, EHTTPStatusCode statusCode,
-                               DataPack pack) {
+                                DataPack pack) {
   char matchId[MATCH_ID_LENGTH];
   char demoFileName[PLATFORM_MAX_PATH];
   int mapNumber;

--- a/scripting/get5/stats.sp
+++ b/scripting/get5/stats.sp
@@ -620,16 +620,16 @@ static Action Stats_PlayerDeathEvent(Event event, const char[] name, bool dontBr
     return;
   }
   int attacker = GetClientOfUserId(event.GetInt("attacker"));
+  int victim = GetClientOfUserId(event.GetInt("userid"));
 
   if (g_GameState != Get5State_Live) {
-    if (g_AutoReadyActivePlayersCvar.BoolValue && IsAuthedPlayer(attacker)) {
+    if (attacker != victim && g_AutoReadyActivePlayersCvar.BoolValue && IsAuthedPlayer(attacker)) {
       // HandleReadyCommand checks for game state, so we don't need to do that here as well.
       HandleReadyCommand(attacker, true);
     }
     return;
   }
 
-  int victim = GetClientOfUserId(event.GetInt("userid"));
   int assister = GetClientOfUserId(event.GetInt("assister"));
 
   bool validAttacker = IsValidClient(attacker);


### PR DESCRIPTION
A couple of things fixed here:

1. `get5_loadteam` would allow you to load coaches into the spectator team.
2. Prevents recursion in `fromfile` when loading teams.
3. Properly use `MatchConfigFail` event when there are problems loading teams.
4. Allow `get5_loadteam` to read JSON team files (as it should).
5. Prevent using `get5_loadteam` for `team2` in scrim mode.
6. Update teams (move players) after using `get5_loadteam`.
7. Prevent suicide/team swap during warmup from readying up players if `get5_auto_ready_active_players` is enabled.
8. Allow `spectators` in match config to also use `fromfile` similarly to teams.
9. Fix `string[]` vs `[string]` for `maplist` in docs. (@thelitlej)
10. Add `"Team"` header to `fromfile` example, as that seems to be required for KV to work (Closes https://github.com/splewis/get5/issues/942)
11. Allow mixing `fromfile` file types, i.e. loading a JSON team file from within a KV match config and vice-versa.