### PR TITLE
Clean up clutch logic and let bots participate

### DIFF
--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -1590,16 +1590,16 @@ static Action Event_RoundStart(Event event, const char[] name, bool dontBroadcas
 static Action Event_RoundWinPanel(Event event, const char[] name, bool dontBroadcast) {
   LogDebug("Event_RoundWinPanel");
   if (g_GameState == Get5State_KnifeRound && g_HasKnifeRoundStarted) {
-    int ctAlive = CountAlivePlayersOnTeam(CS_TEAM_CT);
-    int tAlive = CountAlivePlayersOnTeam(CS_TEAM_T);
+    int ctAlive = CountAlivePlayersOnTeam(Get5Side_CT);
+    int tAlive = CountAlivePlayersOnTeam(Get5Side_T);
     int winningCSTeam;
     if (ctAlive > tAlive) {
       winningCSTeam = CS_TEAM_CT;
     } else if (tAlive > ctAlive) {
       winningCSTeam = CS_TEAM_T;
     } else {
-      int ctHealth = SumHealthOfTeam(CS_TEAM_CT);
-      int tHealth = SumHealthOfTeam(CS_TEAM_T);
+      int ctHealth = SumHealthOfTeam(Get5Side_CT);
+      int tHealth = SumHealthOfTeam(Get5Side_T);
       if (ctHealth > tHealth) {
         winningCSTeam = CS_TEAM_CT;
       } else if (tHealth > ctHealth) {

--- a/scripting/get5/stats.sp
+++ b/scripting/get5/stats.sp
@@ -616,55 +616,41 @@ static Action Stats_GrenadeThrownEvent(Event event, const char[] name, bool dont
 }
 
 static Action Stats_PlayerDeathEvent(Event event, const char[] name, bool dontBroadcast) {
-  if (IsDoingRestoreOrMapChange()) {
-    return;
+  if (g_GameState == Get5State_None || IsDoingRestoreOrMapChange()) {
+    return Plugin_Continue;
   }
-  int attacker = GetClientOfUserId(event.GetInt("attacker"));
-  int victim = GetClientOfUserId(event.GetInt("userid"));
 
+  int victim = GetClientOfUserId(event.GetInt("userid"));
+  if (!IsValidClient(victim)) {
+    return Plugin_Continue;  // Not sure how this would happen, but it's not something we care about.
+  }
+  Get5Player victimPlayer = GetPlayerObject(victim);
+
+  int attacker = GetClientOfUserId(event.GetInt("attacker"));
+  Get5Player attackerPlayer = IsValidClient(attacker) ? GetPlayerObject(attacker) : null;
   if (g_GameState != Get5State_Live) {
-    if (attacker != victim && g_AutoReadyActivePlayersCvar.BoolValue && IsAuthedPlayer(attacker)) {
+    if (attacker != victim && g_AutoReadyActivePlayersCvar.BoolValue && attackerPlayer != null) {
       // HandleReadyCommand checks for game state, so we don't need to do that here as well.
       HandleReadyCommand(attacker, true);
     }
-    return;
+    return Plugin_Continue;
   }
 
-  int assister = GetClientOfUserId(event.GetInt("assister"));
-
-  bool validAttacker = IsValidClient(attacker);
-  bool validVictim = IsValidClient(victim);
-  bool validAssister = IsValidClient(assister);
-
-  if (!validVictim) {
-    return;  // Not sure how this would happen, but it's not something we care about.
-  }
+  Get5Side victimSide = victimPlayer.Side;
+  Get5Side attackerSide = attackerPlayer != null ? attackerPlayer.Side : Get5Side_None;
 
   // Update "clutch" (1vx) data structures to check if the clutcher wins the round
-  int tCount = CountAlivePlayersOnTeam(CS_TEAM_T);
-  int ctCount = CountAlivePlayersOnTeam(CS_TEAM_CT);
-
-  if (tCount == 1 && !g_SetTeamClutching[CS_TEAM_T]) {
-    g_SetTeamClutching[CS_TEAM_T] = true;
-    int clutcher = GetClutchingClient(CS_TEAM_T);
-    g_RoundClutchingEnemyCount[clutcher] = ctCount;
+  int victimSideInt = view_as<int>(victimSide);
+  if (!g_SetTeamClutching[victimSideInt] && CountAlivePlayersOnTeam(victimSide) == 1) {
+    g_SetTeamClutching[victimSideInt] = true;
+    // Don't use attackerSide here as attacker may be invalid, which should still count opposing team correctly.
+    g_RoundClutchingEnemyCount[GetClutchingClient(victimSide)] =
+      CountAlivePlayersOnTeam(victimSide == Get5Side_CT ? Get5Side_T : Get5Side_CT);
   }
-
-  if (ctCount == 1 && !g_SetTeamClutching[CS_TEAM_CT]) {
-    g_SetTeamClutching[CS_TEAM_CT] = true;
-    int clutcher = GetClutchingClient(CS_TEAM_CT);
-    g_RoundClutchingEnemyCount[clutcher] = tCount;
-  }
-
-  bool headshot = event.GetBool("headshot");
 
   char weapon[32];
   event.GetString("weapon", weapon, sizeof(weapon));
-
   CSWeaponID weaponId = CS_AliasToWeaponID(weapon);
-
-  int attackerTeam = validAttacker ? GetClientTeam(attacker) : 0;
-  int victimTeam = GetClientTeam(victim);
 
   // suicide (kill console) is attacker == victim, weapon id 0, weapon "world"
   // fall damage is weapon id 0, attacker 0, weapon "worldspawn"
@@ -675,7 +661,8 @@ static Action Stats_PlayerDeathEvent(Event event, const char[] name, bool dontBr
   // is unreliable. with those in mind, we can determine that suicide must be true if attacker is 0
   // or attacker == victim and it was **not** the bomb.
   bool killedByBomb = StrEqual("planted_c4", weapon);
-  bool isSuicide = (!validAttacker || attacker == victim) && !killedByBomb;
+  bool isSuicide = (attackerPlayer == null || attacker == victim) && !killedByBomb;
+  bool headshot = event.GetBool("headshot");
 
   IncrementPlayerStat(victim, STAT_DEATHS);
   // used for calculating round KAST
@@ -683,18 +670,18 @@ static Action Stats_PlayerDeathEvent(Event event, const char[] name, bool dontBr
 
   if (!g_FirstDeathDone) {
     g_FirstDeathDone = true;
-    IncrementPlayerStat(victim, (victimTeam == CS_TEAM_CT) ? STAT_FIRSTDEATH_CT : STAT_FIRSTDEATH_T);
+    IncrementPlayerStat(victim, victimSide == Get5Side_CT ? STAT_FIRSTDEATH_CT : STAT_FIRSTDEATH_T);
   }
 
   if (isSuicide) {
     IncrementPlayerStat(victim, STAT_SUICIDES);
   } else if (!killedByBomb) {
-    if (attackerTeam == victimTeam) {
+    if (attackerSide == victimSide) {
       IncrementPlayerStat(attacker, STAT_TEAMKILLS);
     } else {
       if (!g_FirstKillDone) {
         g_FirstKillDone = true;
-        IncrementPlayerStat(attacker, (attackerTeam == CS_TEAM_CT) ? STAT_FIRSTKILL_CT : STAT_FIRSTKILL_T);
+        IncrementPlayerStat(attacker, attackerSide == Get5Side_CT ? STAT_FIRSTKILL_CT : STAT_FIRSTKILL_T);
       }
 
       g_RoundKills[attacker]++;
@@ -721,20 +708,21 @@ static Action Stats_PlayerDeathEvent(Event event, const char[] name, bool dontBr
   }
 
   Get5PlayerDeathEvent playerDeathEvent = new Get5PlayerDeathEvent(
-    g_MatchID, g_MapNumber, g_RoundNumber, GetRoundTime(), GetPlayerObject(victim), new Get5Weapon(weapon, weaponId),
-    headshot, validAttacker ? attackerTeam == victimTeam : false, event.GetBool("thrusmoke"), event.GetBool("noscope"),
-    event.GetBool("attackerblind"), isSuicide, event.GetInt("penetrated"), killedByBomb);
+    g_MatchID, g_MapNumber, g_RoundNumber, GetRoundTime(), victimPlayer, new Get5Weapon(weapon, weaponId), headshot,
+    attackerSide == victimSide, event.GetBool("thrusmoke"), event.GetBool("noscope"), event.GetBool("attackerblind"),
+    isSuicide, event.GetInt("penetrated"), killedByBomb);
 
-  if (validAttacker) {
-    playerDeathEvent.Attacker = GetPlayerObject(attacker);
+  if (attackerPlayer != null) {
+    // Setter does not accept null.
+    playerDeathEvent.Attacker = attackerPlayer;
   }
 
-  if (validAssister) {
+  int assister = GetClientOfUserId(event.GetInt("assister"));
+  if (IsValidClient(assister)) {
+    Get5Player assisterPlayer = GetPlayerObject(assister);
+    bool friendlyFire = assisterPlayer.Side == victimSide;
     bool assistedFlash = event.GetBool("assistedflash");
-    bool friendlyFire = GetClientTeam(assister) == victimTeam;
-
-    playerDeathEvent.Assist = new Get5AssisterObject(GetPlayerObject(assister), assistedFlash, friendlyFire);
-
+    playerDeathEvent.Assist = new Get5AssisterObject(assisterPlayer, assistedFlash, friendlyFire);
     // Assists should only count towards opposite team
     if (!friendlyFire) {
       // You cannot flash-assist and regular-assist for the same kill.
@@ -756,6 +744,7 @@ static Action Stats_PlayerDeathEvent(Event event, const char[] name, bool dontBr
   Call_Finish();
 
   EventLogger_LogAndDeleteEvent(playerDeathEvent);
+  return Plugin_Continue;
 }
 
 static void UpdateTradeStat(int attacker, int victim) {
@@ -1040,21 +1029,14 @@ static void GoBackFromPlayer() {
   g_StatsKv.GoBack();
 }
 
-static int GetClutchingClient(int csTeam) {
-  int client = -1;
-  int count = 0;
+// Assumes the team has only one player left when called.
+static int GetClutchingClient(const Get5Side side) {
   LOOP_CLIENTS(i) {
-    if (IsPlayer(i) && IsPlayerAlive(i) && GetClientTeam(i) == csTeam) {
-      client = i;
-      count++;
+    if (IsValidClient(i) && IsPlayerAlive(i) && view_as<Get5Side>(GetClientTeam(i)) == side) {
+      return i;
     }
   }
-
-  if (count == 1) {
-    return client;
-  } else {
-    return -1;
-  }
+  return 0;
 }
 
 static void DumpToFile() {

--- a/scripting/get5/util.sp
+++ b/scripting/get5/util.sp
@@ -40,20 +40,20 @@ stock int GetNumHumansOnTeam(int team) {
   return count;
 }
 
-stock int CountAlivePlayersOnTeam(int csTeam) {
+stock int CountAlivePlayersOnTeam(const Get5Side side) {
   int count = 0;
   LOOP_CLIENTS(i) {
-    if (IsPlayer(i) && IsPlayerAlive(i) && GetClientTeam(i) == csTeam) {
+    if (IsValidClient(i) && IsPlayerAlive(i) && view_as<Get5Side>(GetClientTeam(i)) == side) {
       count++;
     }
   }
   return count;
 }
 
-stock int SumHealthOfTeam(int team) {
+stock int SumHealthOfTeam(Get5Side side) {
   int sum = 0;
   LOOP_CLIENTS(i) {
-    if (IsPlayer(i) && IsPlayerAlive(i) && GetClientTeam(i) == team) {
+    if (IsValidClient(i) && IsPlayerAlive(i) && view_as<Get5Side>(GetClientTeam(i)) == side) {
       sum += GetClientHealth(i);
     }
   }


### PR DESCRIPTION
1. Lets bots win the knife round.
2. Lets bots be clutchers and/or trigger 1vX clutch logic in the stats system.
3. Deduplicate some of the clutch detection logic.
4. Various cleanups.