### PR TITLE
Always use ready-up if loading non-live backup

### DIFF
--- a/scripting/get5/recording.sp
+++ b/scripting/get5/recording.sp
@@ -42,7 +42,8 @@ bool StartRecording() {
 
 void StopRecording(float delay = 0.0) {
   if (StrEqual("", g_DemoFilePath)) {
-    LogDebug("Demo was not recorded by Get5; not firing Get5_OnDemoFinished() or stopping recording.");
+    LogDebug("Demo was not recorded by Get5; not firing Get5_OnDemoFinished().");
+    ServerCommand("tv_stoprecord");
     return;
   }
   char uploadUrl[1024];


### PR DESCRIPTION
There is a problem on 0.11 and 0.12 prerelease currently, where loading a backup while not in live mode, but for the same map the server is currently on, will immediately just load the backup instead of putting the game into "ready up for backup" mode, which it should.

This would be a problem if you restored a backup on a server the players are not yet on, such as if switching to a different server, but where the map to play is the same as the one already loaded on the server.