### PR TITLE
Add custom veto logic support + Rename VETO to BAN

### DIFF
--- a/configs/get5/tests/custom_veto.json
+++ b/configs/get5/tests/custom_veto.json
@@ -1,0 +1,42 @@
+{
+  "matchid": "test_match_valid_custom_veto",
+  "num_maps": 3,
+  "maplist": [
+    "de_dust2",
+    "de_mirage",
+    "de_inferno",
+    "de_ancient",
+    "de_vertigo"
+  ],
+  "veto_mode": [
+    "team1_ban",
+    "team2_ban",
+    "team1_pick",
+    "team2_pick",
+    "team1_pick",
+    "team2_pick"
+  ],
+  "map_sides": [
+    "team2_ct",
+    "team1_ct",
+    "knife"
+  ],
+  "team1": {
+    "name": "Team A Default",
+    "players": {
+      "76561197996413459": "PlayerAName1"
+    },
+    "coaches": {
+      "76561197996426735": "CoachAName1"
+    }
+  },
+  "team2": {
+    "name": "Team B Default",
+    "players": {
+      "76561197996413459": "PlayerBName1"
+    },
+    "coaches": {
+      "76561197996426735": "CoachBName1"
+    }
+  }
+}

--- a/configs/get5/tests/custom_veto_invalid.json
+++ b/configs/get5/tests/custom_veto_invalid.json
@@ -1,0 +1,42 @@
+{
+  "matchid": "test_match_valid_custom_veto",
+  "num_maps": 3,
+  "maplist": [
+    "de_dust2",
+    "de_mirage",
+    "de_inferno",
+    "de_ancient",
+    "de_vertigo"
+  ],
+  "veto_mode": [
+    "team1_ban",
+    "team2_ban",
+    "team1_ban",
+    "team2_ban",
+    "team1_pick",
+    "team2_pick"
+  ],
+  "map_sides": [
+    "team2_ct",
+    "team1_ct",
+    "knife"
+  ],
+  "team1": {
+    "name": "Team A Default",
+    "players": {
+      "76561197996413459": "PlayerAName1"
+    },
+    "coaches": {
+      "76561197996426735": "CoachAName1"
+    }
+  },
+  "team2": {
+    "name": "Team B Default",
+    "players": {
+      "76561197996413459": "PlayerBName1"
+    },
+    "coaches": {
+      "76561197996426735": "CoachBName1"
+    }
+  }
+}

--- a/configs/get5/tests/fromfile_maplist_valid.cfg
+++ b/configs/get5/tests/fromfile_maplist_valid.cfg
@@ -1,6 +1,7 @@
 "Match"
 {
     "num_maps"        "3"
+    "skip_veto"       "1"
     "maplist"
     {
         "fromfile" "addons/sourcemod/configs/get5/tests/maplist_valid.cfg"

--- a/configs/get5/tests/fromfile_maplist_valid.json
+++ b/configs/get5/tests/fromfile_maplist_valid.json
@@ -1,5 +1,6 @@
 {
   "num_maps": 3,
+  "skip_veto": true,
   "maplist": {
     "fromfile": "addons/sourcemod/configs/get5/tests/maplist_valid.json"
   },

--- a/configs/get5/tests/maplist_valid.cfg
+++ b/configs/get5/tests/maplist_valid.cfg
@@ -1,6 +1,6 @@
 "maplist"
 {
-  "de_ancient"     ""
+  "de_dust2"       ""
   "de_overpass"    ""
   "de_inferno"     ""
 }

--- a/configs/get5/tests/maplist_valid.json
+++ b/configs/get5/tests/maplist_valid.json
@@ -1,5 +1,5 @@
 [
-  "de_ancient",
+  "de_dust2",
   "de_overpass",
   "de_inferno"
 ]

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -13,7 +13,7 @@ Highlights of Get5 include:
 
 - [Locking players to their correct team and side by their Steam ID](./match_schema)
 - Automatically setting team names/logos/match text values for spectator/GOTV clients
-- [In-game map-veto](./veto) support from the match's list of maps
+- [In-game map-selection](./veto) support from the match's list of maps
 - Support for multi-map series (Bo1, Bo2, Bo3, Bo5, etc.)
 - Warmup and [`!ready`](./commands#ready)-system for each team
 - [Automatic GOTV demo recording](./gotv)

--- a/documentation/docs/match_schema.md
+++ b/documentation/docs/match_schema.md
@@ -47,6 +47,8 @@ interface Get5Match {
     "min_spectators_to_ready": number | undefined // (6)
     "skip_veto": boolean | undefined // (7)
     "veto_first": "team1" | "team2" | "random" | undefined // (11)
+    "veto_mode": ['team1_ban' | 'team2_ban'
+        | 'team1_pick' | 'team2_pick'] | undefined // (36)
     "side_type": "standard" | "always_knife" | "never_knife" | undefined // (12)
     "map_sides": ["team1_ct" | "team1_t" | "knife"] | undefined // (31)
     "spectators": { // (10)
@@ -142,13 +144,15 @@ interface Get5Match {
 30. _Optional_<br>The spectator/caster Steam IDs and names. Setting a Steam ID as spectator takes precedence over being
     set as a player or coach.
 31. _Optional_<br>Determines the starting sides for each map. If this array is shorter than `num_maps`, `side_type` will
-    determine the side-behavior of the remaining maps. Ignored if `skip_veto` is `false`.
+    determine the side-behavior of the remaining maps.
     <br><br>**`Default: undefined`**
 32. _Optional_<br>If `false`, the entire map list will be played, regardless of score. If `true`, a series will be won
     when the series score for a team exceeds the number of maps divided by two.<br><br>**`Default: true`**
 33. _Optional_<br>Determines if coaches must also [`!ready`](../commands#ready).<br><br>**`Default: false`**
 34. _Optional_<br>Similarly to teams and map list, spectators may also be loaded from another file.
 35. _Required_<br>Similarly to teams and spectators, a map list may also be loaded from another file.
+36. _Optional_<br>Allows for a [custom configuration](../veto#custom) of map picks/bans. This must be an array of
+    strings consisting of any valid combination of `team1_ban`, `team2_ban`, `team1_pick` and `team2_pick`.
 
 !!! info "Team assignment priority"
 

--- a/documentation/docs/match_schema.md
+++ b/documentation/docs/match_schema.md
@@ -79,8 +79,8 @@ interface Get5Match {
    themselves.<br><br>**`Default: 0`**
 6. _Optional_<br>The minimum number of spectators that must be [`!ready`](../commands#ready) for the game to
    begin.<br><br>**`Default: 0`**
-7. _Optional_<br>Whether to skip the [veto](../veto) phase. If `true`, `num_maps` are played in the order they appear
-   in `maplist`.<br><br>**`Default: false`**
+7. _Optional_<br>Whether to skip the [map selection](../veto) phase. If `true`, `num_maps` are simply played in the
+   order they appear in `maplist`, and no map selection is performed by players in-game.<br><br>**`Default: false`**
 8. A player's :material-steam: Steam ID. This can be in any format, but we recommend a string representation of SteamID
    64, i.e. `"76561197987713664"`.
 9. Players are represented each with a mapping of `SteamID -> PlayerName` as a key-value dictionary. The name
@@ -88,16 +88,15 @@ interface Get5Match {
    string array of `SteamID` disable name-locking.
 10. _Optional_<br>The spectators to allow into the game. If not defined, spectators cannot join the
     game.<br><br>**`Default: undefined`**
-11. _Optional_<br>The team that [vetoes](../veto) first.<br><br>**`Default: "team1"`**
-12. _Optional_<br>The method used to determine sides when [vetoing](../veto).<br><br>`standard` means that the team that
-    doesn't pick a map gets the side choice (only if `skip_veto` is `false`).<br><br>`always_knife` means that sides are
-    always determined by a knife-round.<br><br>`never_knife` means that `team1` always starts on CT.<br><br>This
-    parameter is ignored if `map_sides` is set for all maps. `standard` and `always_knife` behave similarly (knife)
+11. _Optional_<br>The team that makes the first [map selection](../veto) choice.<br><br>**`Default: "team1"`**
+12. _Optional_<br>The method used to determine sides during [map selection](../veto).<br><br>`standard` means that the
+    team that doesn't pick a map gets the side choice (only if `skip_veto` is `false`).<br><br>`always_knife` means that
+    sides are always determined by a knife-round.<br><br>`never_knife` means that `team1` always starts on CT.<br><br>
+    This parameter is ignored if `map_sides` is set for all maps. `standard` and `always_knife` behave similarly (knife)
     when `skip_veto` is `true`.<br><br>**`Default: "standard"`**
 13. _Required_<br>The map pool to pick from, as an array of strings (`["de_dust2", "de_nuke"]` etc.), or if `skip_veto`
-    is `true`, the order of maps played (limited by `num_maps`). **This should always be odd-sized if using the in-game
-    [veto system](../veto).** Similarly to teams, you can set this to an object with a `fromfile` property to load a map
-    list from a separate file.
+    is `true`, the order of maps played (limited by `num_maps`). Similarly to teams, you can set this to an object
+    with a `fromfile` property to load a map list from a separate file.
 14. _Optional_<br>Wrapper for the server's `mp_teamprediction_pct`. This determines the chances of `team1`
     winning.<br><br>**`Default: 0`**
 15. _Optional_<br>Wrapper for the server's `mp_teamprediction_txt`.<br><br>**`Default: ""`**

--- a/documentation/docs/match_schema.md
+++ b/documentation/docs/match_schema.md
@@ -77,8 +77,8 @@ interface Get5Match {
    themselves.<br><br>**`Default: 0`**
 6. _Optional_<br>The minimum number of spectators that must be [`!ready`](../commands#ready) for the game to
    begin.<br><br>**`Default: 0`**
-7. _Optional_<br>Whether to skip the [veto](../veto) phase. When skipping veto, `map_sides` determines sides, and
-   if `map_sides` is not set, sides are determined by `side_type`.<br><br>**`Default: false`**
+7. _Optional_<br>Whether to skip the [veto](../veto) phase. If `true`, `num_maps` are played in the order they appear
+   in `maplist`.<br><br>**`Default: false`**
 8. A player's :material-steam: Steam ID. This can be in any format, but we recommend a string representation of SteamID
    64, i.e. `"76561197987713664"`.
 9. Players are represented each with a mapping of `SteamID -> PlayerName` as a key-value dictionary. The name
@@ -87,11 +87,11 @@ interface Get5Match {
 10. _Optional_<br>The spectators to allow into the game. If not defined, spectators cannot join the
     game.<br><br>**`Default: undefined`**
 11. _Optional_<br>The team that [vetoes](../veto) first.<br><br>**`Default: "team1"`**
-12. _Optional_<br>The method used to determine sides when [vetoing](../veto) **or** if veto is disabled and `map_sides`
-    are not set.<br><br>`standard` means that the team that doesn't pick a map gets the side choice (only if `skip_veto`
-    is `false`).<br><br>`always_knife` means that sides are always determined by a knife-round.<br><br>`never_knife`
-    means that `team1` always starts on CT.<br><br>This parameter is ignored if `map_sides` is set for all
-    maps. `standard` and `always_knife` behave similarly when `skip_veto` is `true`.<br><br>**`Default: "standard"`**
+12. _Optional_<br>The method used to determine sides when [vetoing](../veto).<br><br>`standard` means that the team that
+    doesn't pick a map gets the side choice (only if `skip_veto` is `false`).<br><br>`always_knife` means that sides are
+    always determined by a knife-round.<br><br>`never_knife` means that `team1` always starts on CT.<br><br>This
+    parameter is ignored if `map_sides` is set for all maps. `standard` and `always_knife` behave similarly (knife)
+    when `skip_veto` is `true`.<br><br>**`Default: "standard"`**
 13. _Required_<br>The map pool to pick from, as an array of strings (`["de_dust2", "de_nuke"]` etc.), or if `skip_veto`
     is `true`, the order of maps played (limited by `num_maps`). **This should always be odd-sized if using the in-game
     [veto system](../veto).** Similarly to teams, you can set this to an object with a `fromfile` property to load a map

--- a/documentation/docs/translations.md
+++ b/documentation/docs/translations.md
@@ -21,7 +21,7 @@ entire language file**.
 !!! example "translations/get5.phrases.txt"
 
     ```yaml
-    "TeamPickedMapInfoMessage"
+    "TeamPickedMap"
     {
         "#format"  "{1:s},{2:s},{3:d}" # (1)
         "en"       "{1} picked {2} as map {3}." # (2)
@@ -35,12 +35,12 @@ entire language file**.
     2. Use the English strings and the [reference](#reference) below to determine how to translate the string.
 
 As the string implies, this example is used when a team picks a map, and the output is printed to chat and looks like
-this: `Team A picked de_dust2 as map 2.` The French translation file for this string looks like this:
+this: `Team A picked Dust II as map 2.` The French translation file for this string looks like this:
 
 !!! example "translations/fr/get5.phrases.txt"
 
     ```yaml
-    "TeamPickedMapInfoMessage"
+    "TeamPickedMap"
     {
         "fr"  "{1} a choisi {2} comme map {3}."
     }
@@ -79,7 +79,7 @@ end with a full stop as this is added automatically.
 | String                                      | Example                                                                                                                                                                  | Type       |
 |---------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------|
 | `WaitingForCastersReadyInfoMessage`         | Waiting for _Team A_ to type _!ready_ to begin.                                                                                                                          | Chat       |
-| `ReadyToVetoInfoMessage`                    | Type _!ready_ when your team is ready to veto.                                                                                                                           | Chat       |
+| `ReadyForMapSelectionInfoMessage`           | Type _!ready_ when your team is ready for map selection.                                                                                                                 | Chat       |
 | `ReadyToRestoreBackupInfoMessage`           | Type _!ready_ when you are ready to restore the match backup.                                                                                                            | Chat       |
 | `ReadyToKnifeInfoMessage`                   | Type _!ready_ when you are ready to knife.                                                                                                                               | Chat       |
 | `ReadyToStartInfoMessage`                   | Type _!ready_ when you are ready to begin.                                                                                                                               | Chat       |
@@ -88,8 +88,8 @@ end with a full stop as this is added automatically.
 | `TypeUnreadyIfNotReady`                     | Type _!unready_ if you are not ready.                                                                                                                                    | Chat       |
 | `YouAreNotReady`                            | You have been marked as NOT ready.                                                                                                                                       | Chat       |
 | `WaitingForEnemySwapInfoMessage`            | _Team A_ won the knife round. Waiting for them to type _!stay_ or _!swap_.                                                                                               | Chat       |
-| `WaitingForGOTVBrodcastEndingInfoMessage`   | The map will change once the GOTV broadcast has ended.                                                                                                                   | Chat       |
-| `WaitingForGOTVVetoInfoMessage`             | The map will change once the GOTV broadcast has displayed the map vetoes.                                                                                                | Chat       |
+| `WaitingForGOTVBroadcastEnding`             | The map will change once GOTV has finished broadcasting.                                                                                                                 | Chat       |
+| `WaitingForGOTVMapSelection`                | The map will change once GOTV has broadcast the map selection.                                                                                                           | Chat       |
 | `NoMatchSetupInfoMessage`                   | No match was set up                                                                                                                                                      | KickedNote |
 | `YouAreNotAPlayerInfoMessage`               | You are not a player in this match                                                                                                                                       | KickedNote |
 | `TeamIsFullInfoMessage`                     | Your team is full                                                                                                                                                        | KickedNote |
@@ -125,11 +125,11 @@ end with a full stop as this is added automatically.
 | `WaitingForUnpauseInfoMessage`              | _Team A_ wants to unpause, waiting for Team B to type _!unpause_.                                                                                                        | Chat       |
 | `PausesLeftInfoMessage`                     | Tactical pauses remaining for _Team A_: _3_                                                                                                                              | Chat       |
 | `TeamFailToReadyMinPlayerCheck`             | You must have at least _3_ player(s) on the server to ready up.                                                                                                          | Chat       |
-| `TeamReadyToVetoInfoMessage`                | _Team A_ is ready to veto.                                                                                                                                               | Chat       |
-| `TeamReadyToRestoreBackupInfoMessage`       | _Team A_ is ready to restore the match backup.                                                                                                                           | Chat       |
-| `TeamReadyToKnifeInfoMessage`               | _Team A_ is ready to knife for sides.                                                                                                                                    | Chat       |
-| `TeamReadyToBeginInfoMessage`               | _Team A_ is ready to begin the match.                                                                                                                                    | Chat       |
-| `TeamNotReadyInfoMessage`                   | _Team A_ is no longer ready.                                                                                                                                             | Chat       |
+| `TeamIsReadyForMapSelection`                | _Team A_ is ready for map selection.                                                                                                                                     | Chat       |
+| `TeamIsReadyToRestoreBackup`                | _Team A_ is ready to restore the match backup.                                                                                                                           | Chat       |
+| `TeamIsReadyToKnife`                        | _Team A_ is ready to knife for sides.                                                                                                                                    | Chat       |
+| `TeamIsReadyToBegin`                        | _Team A_ is ready to begin the match.                                                                                                                                    | Chat       |
+| `TeamIsNoLongerReady`                       | _Team A_ is no longer ready.                                                                                                                                             | Chat       |
 | `ForceReadyInfoMessage`                     | You may type _!forceready_ to force-ready your team.                                                                                                                     | Chat       |
 | `ForceReadyDisabled`                        | The _!forceready_ command is disabled, but can enabled with _get5_allow_force_ready_.                                                                                    | Chat       |
 | `TeammateForceReadied`                      | Your team was force-readied by _PlayerName_.                                                                                                                             | Chat       |
@@ -156,12 +156,12 @@ end with a full stop as this is added automatically.
 | `TeamLostTimeToDecideInfoMessage`           | _Team A_ will stay since they did not make a decision in time.                                                                                                           | Chat       |
 | `ChangingMapInfoMessage`                    | Changing map to _de_nuke_...                                                                                                                                             | Chat       |
 | `MapDecidedInfoMessage`                     | The maps have been decided:                                                                                                                                              | Chat       |
-| `MapIsInfoMessage`                          | Map _1_: _de_nuke_.                                                                                                                                                      | Chat       |
-| `TeamPickedMapInfoMessage`                  | _Team A_ picked _de_nuke_ as map _2_.                                                                                                                                    | Chat       |
-| `TeamSelectSideInfoMessage`                 | _Team A_ has selected to start on _CT_ on _de_nuke_.                                                                                                                     | Chat       |
-| `TeamVetoedMapInfoMessage`                  | _Team A_ vetoed _de_nuke_.                                                                                                                                               | Chat       |
-| `CaptainLeftOnVetoInfoMessage`              | A captain left during the veto, pausing the veto.                                                                                                                        | Chat       |
-| `ReadyToResumeVetoInfoMessage`              | Type _!ready_ when you are ready to resume the veto.                                                                                                                     | Chat       |
+| `MapIsInfoMessage`                          | Map _1_: _Nuke_.                                                                                                                                                         | Chat       |
+| `TeamPickedMap`                             | _Team A_ picked _Nuke_ as map _2_.                                                                                                                                       | Chat       |
+| `TeamSelectedSide`                          | _Team A_ has elected to start as _CT_ on _Nuke_.                                                                                                                         | Chat       |
+| `TeamBannedMap`                             | _Team A_ banned _Nuke_.                                                                                                                                                  | Chat       |
+| `CaptainLeftDuringMapSelection`             | A team captain left during map selection. Map selection is paused.                                                                                                       | Chat       |
+| `ReadyToResumeMapSelection`                 | Type _!ready_ when you are ready to resume map selection.                                                                                                                | Chat       |
 | `MatchConfigLoadedInfoMessage`              | Loaded match config.                                                                                                                                                     | Chat       |
 | `MoveToCoachInfoMessage`                    | You were moved to the coach position as your team is full.                                                                                                               | Chat       |
 | `ExitCoachSlotHelp`                         | Type _!coach_ to exit the coach slot.                                                                                                                                    | Chat       |
@@ -173,15 +173,15 @@ end with a full stop as this is added automatically.
 | `AllCoachSlotsFilledForTeam`                | All coach slots (_2_) are currently filled for your team.                                                                                                                | Chat       |
 | `ReadyTag`                                  | **[READY]** PlayerName: Hey, I'm ready...                                                                                                                                | Chat       |
 | `NotReadyTag`                               | **[NOT READY]** PlayerName: Hey, I'm not ready...                                                                                                                        | Chat       |
-| `MapVetoPickMenuText`                       | Select a map to PLAY:                                                                                                                                                    | Menu       |
-| `MapVetoPickConfirmMenuText`                | Confirm you want to PLAY _de_nuke_:                                                                                                                                      | Menu       |
-| `MapVetoBanMenuText`                        | Select a map to VETO:                                                                                                                                                    | Menu       |
-| `MapVetoBanConfirmMenuText`                 | Confirm you want to VETO _de_nuke_:                                                                                                                                      | Menu       |
-| `MapVetoSidePickMenuText`                   | Select a side for _de_nuke_:                                                                                                                                             | Menu       |
-| `MapVetoSidePickConfirmMenuText`            | Confirm you want to start _CT_:                                                                                                                                          | Menu       |
+| `MapSelectionPickMenuText`                  | Select a map to PLAY:                                                                                                                                                    | Menu       |
+| `MapSelectionPickConfirmMenuText`           | Confirm you want to PLAY _Nuke_:                                                                                                                                         | Menu       |
+| `MapSelectionBanMenuText`                   | Select a map to BAN:                                                                                                                                                     | Menu       |
+| `MapSelectionBanConfirmMenuText`            | Confirm you want to BAN _Nuke_:                                                                                                                                          | Menu       |
+| `MapSelectionSidePickMenuText`              | Select a side for _Nuke_:                                                                                                                                                | Menu       |
+| `MapSelectionSidePickConfirmMenuText`       | Confirm you want to start _CT_:                                                                                                                                          | Menu       |
 | `ConfirmPositiveOptionText`                 | Yes                                                                                                                                                                      | Menu       |
 | `ConfirmNegativeOptionText`                 | No                                                                                                                                                                       | Menu       |
-| `VetoCountdown`                             | Veto commencing in _3_ seconds.                                                                                                                                          | Chat       |
+| `MapSelectionCountdown`                     | Map selection commencing in _3_...                                                                                                                                       | Chat       |
 | `NewVersionAvailable`                       | A newer version of Get5 is available. Please visit _splewis.github.io/get5_ to update.                                                                                   | Chat       |
 | `PrereleaseVersionWarning`                  | You are running an unofficial version of Get5 (_0.9.0-c7af39a_) intended for development and testing only. This message can be disabled with _get5_print_update_notice_. | Chat       |
 | `SurrenderCommandNotEnabled`                | The surrender command is not enabled.                                                                                                                                    | Chat       |

--- a/documentation/docs/veto.md
+++ b/documentation/docs/veto.md
@@ -19,7 +19,7 @@ by default by being the last map standing, a knife round is used. This behavior 
 the [`side_type`](../match_schema#schema) parameter of your match configuration. Sides may also be predetermined using
 the [`map_sides`](../match_schema#schema) parameter.
 
-## Defaults {: #defaults }
+## Default Flow {: #default }
 
 If you don't provide a custom [`veto_mode`](../match_schema#schema), Get5 will create a suitable map selection flow
 depending on your series length ([`num_maps`](../match_schema#schema)) and map
@@ -29,7 +29,7 @@ the map list.
 
 !!! info "Legend"
 
-    To make the table easier to read, we'll use icons instead of strings to illustrate:
+    To make the table easier to read, we'll use icons instead of strings to illustrate.
 
     :one: :white_check_mark: :octicons-dash-16: `team1_pick`
    
@@ -40,6 +40,8 @@ the map list.
     :two: :no_entry: :octicons-dash-16: `team2_ban`
    
     :regional_indicator_x: :white_check_mark: :octicons-dash-16: played by default
+
+Note that these examples assume that [`veto_first`](../match_schema#schema) is set to `team1`.
 
 === "Single Map"
 
@@ -83,7 +85,7 @@ the map list.
 
         When the series length is even-sized, the last team to ban will have one map pick less than the other team.
 
-## Custom {: #custom }
+## Custom Flow {: #custom }
 
 You may provide a custom ban/pick order using the [`veto_mode`](../match_schema#schema) property of a match
 configuration. If you do this, any logically possible combination of picks/bans, number of maps to
@@ -91,7 +93,7 @@ play ([`num_maps`](../match_schema#schema)) and map pool size ([`maplist`](../ma
 
 The [`veto_mode`](../match_schema#schema) parameter accepts an array of strings:
 
-`team1_pick`, `team1_ban`, `team2_pick` and `team2_ban`, which are fairly self-explanatory.
+`team1_pick`, `team1_ban`, `team2_pick` and `team2_ban`.
 
 ### Rules {: #rules }
 
@@ -106,8 +108,9 @@ Your array of picks and bans **must** comply with these rules, or your match con
    only the first 3 picks would be evaluated and used.
 4. Which team you assign to pick or ban does not matter. If you wanted, you could have one team pick all the maps.
 5. Either:
-    1. If the number of picks is _equal to_ (or per rule 3, _exceed_) the series length, the picks can be positioned
+    1. If the number of picks is less than the series length, you must provide at least
+       "map pool size minus 1" number of options, i.e. no less than 6 options for a pool of 7 maps.
+    2. If the number of picks is _equal to_ (or per rule 3, _exceed_) the series length, the picks can be positioned
        before the map pool has been exhausted, and the total number of options can be less than the "map pool size minus
        1".
-    2. If the number of picks is less than the series length, you must provide at least
-       "map pool size minus 1" number of options, i.e. no less than 6 options for a pool of 7 maps.
+

--- a/documentation/docs/veto.md
+++ b/documentation/docs/veto.md
@@ -63,27 +63,29 @@ Note that these examples assume that [`veto_first`](../match_schema#schema) is s
     | 3-4           | :one: :white_check_mark: :octicons-dash-16: :two: :white_check_mark:                                                                         |
     | 5+            | :one: :no_entry: :octicons-dash-16: :two: :no_entry: :octicons-dash-16: :one: :white_check_mark: :octicons-dash-16: :two: :white_check_mark: |
 
-=== "Best-of-X (odd-sized series)"
+=== "Best-of-X"
 
-    Alternating bans until there are `num_maps` (i.e. 3) maps left, at which point teams alternate picking `num_maps-1` (i.e. 2) maps. The remaining map is played last by default.
+    If the map pool size is at least 2 larger than the number of maps to play (`num_maps`), teams alternate banning until there are `num_maps + 2` (i.e. 5) maps left, at which point teams alternate picking `num_maps - 1` (i.e. 2), then alternate banning until only one map remains. The remaining map is played last by default.
     
-    | Map Pool Size | Flow                                                                                                                                                                                                      |
-    |---------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-    | 4+ (even)     | :one: :no_entry: :octicons-dash-16: :two: :white_check_mark: :octicons-dash-16: :one: :white_check_mark: :octicons-dash-16: :regional_indicator_x: :white_check_mark:                                     |
-    | 5+ (odd)      | :one: :no_entry: :octicons-dash-16: :two: :no_entry: :octicons-dash-16: :one: :white_check_mark: :octicons-dash-16: :two: :white_check_mark: :octicons-dash-16: :regional_indicator_x: :white_check_mark: |
-
-=== "Best-of-X (even-sized series)"
-
-    Alternating bans until there are `num_maps` (i.e. 4) maps left, at which point teams alternate picking `num_maps-1` (i.e. 3) maps. The remaining map is played last by default.
-    
-    | Map Pool Size | Flow                                                                                                                                                                                                                                                  |
-    |---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-    | 5+ (odd)      | :one: :no_entry: :octicons-dash-16: :two: :white_check_mark: :octicons-dash-16: :one: :white_check_mark: :octicons-dash-16: :two: :white_check_mark: :octicons-dash-16: :regional_indicator_x: :white_check_mark:                                     |
-    | 6+ (even)     | :one: :no_entry: :octicons-dash-16: :two: :no_entry: :octicons-dash-16: :one: :white_check_mark: :octicons-dash-16: :two: :white_check_mark: :octicons-dash-16: :one: :white_check_mark: :octicons-dash-16: :regional_indicator_x: :white_check_mark: |
+    If the map pool is only 1 larger than the number of maps to play (`num_maps`), teams simply alternate picking until all maps are decided. The remaining map is ignored.
+        
+    | Map Pool Size | Maps | Flow                                                                                                                                                                                                                                                                                                                          |
+    |---------------|------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+    | 4             | 3    | :one: :white_check_mark: :octicons-dash-16: :two: :white_check_mark: :octicons-dash-16: :one: :white_check_mark:                                                                                                                                                                                                              |
+    | 5             | 3    | :one: :white_check_mark: :octicons-dash-16: :two: :white_check_mark: :octicons-dash-16: :one: :no_entry: :octicons-dash-16: :two: :no_entry: :octicons-dash-16: :regional_indicator_x: :white_check_mark:                                                                                                                     |
+    | 6             | 3    | :one: :no_entry: :octicons-dash-16: :two: :white_check_mark: :octicons-dash-16: :one: :white_check_mark: :octicons-dash-16: :two: :no_entry: :octicons-dash-16: :one: :no_entry: :octicons-dash-16: :regional_indicator_x: :white_check_mark:                                                                                 |
+    | 7             | 3    | :one: :no_entry: :octicons-dash-16: :two: :no_entry: :octicons-dash-16: :one: :white_check_mark: :octicons-dash-16: :two: :white_check_mark: :octicons-dash-16: :one: :no_entry: :octicons-dash-16: :two: :no_entry: :octicons-dash-16: :regional_indicator_x: :white_check_mark:                                             |
+    | 8             | 3    | :one: :no_entry: :octicons-dash-16: :two: :no_entry: :octicons-dash-16: :one: :no_entry: :octicons-dash-16: :two: :white_check_mark: :octicons-dash-16: :one: :white_check_mark: :octicons-dash-16: :two: :no_entry: :octicons-dash-16: :one: :no_entry: :octicons-dash-16: :regional_indicator_x: :white_check_mark:         |                                                                                                                                                                                                                                                                                                                               |
+    | 5             | 4    | :one: :white_check_mark: :octicons-dash-16: :two: :white_check_mark: :octicons-dash-16: :one: :white_check_mark: :octicons-dash-16: :two: :white_check_mark:                                                                                                                                                                  |
+    | 6             | 4    | :one: :white_check_mark: :octicons-dash-16: :two: :white_check_mark: :octicons-dash-16: :one: :no_entry: :octicons-dash-16: :two: :no_entry: :octicons-dash-16: :one: :white_check_mark: :octicons-dash-16: :regional_indicator_x: :white_check_mark:                                                                         |
+    | 7             | 4    | :one: :no_entry: :octicons-dash-16: :two: :no_entry: :octicons-dash-16: :one: :white_check_mark: :octicons-dash-16: :two: :white_check_mark: :octicons-dash-16: :one: :white_check_mark: :octicons-dash-16: :one: :no_entry: :octicons-dash-16: :regional_indicator_x: :white_check_mark:                                     |
+    | 8             | 4    | :one: :no_entry: :octicons-dash-16: :two: :no_entry: :octicons-dash-16: :one: :white_check_mark: :octicons-dash-16: :two: :white_check_mark: :octicons-dash-16: :one: :white_check_mark: :octicons-dash-16: :one: :no_entry: :octicons-dash-16: :two: :no_entry: :octicons-dash-16: :regional_indicator_x: :white_check_mark: |
 
     !!! warning "Life ain't fair"
 
-        When the series length is even-sized, the last team to ban will have one map pick less than the other team.
+        When the the numbers don't add up, one team may ban or pick one more time than the other. This is simply a
+        best-effort by Get5 to make any combination work without producing errors. It's up to you to provide reasonable
+        combinations of maps to play and map pool sizes.
 
 ## Custom Flow {: #custom }
 

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -44,7 +44,7 @@ nav:
   - Basics:
       - Getting Started: getting_started.md
       - Match Schema: match_schema.md
-      - Map Veto: veto.md
+      - Map Selection: veto.md
       - Commands: commands.md
       - Coaching: coaching.md
       - Pausing: pausing.md

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -685,7 +685,7 @@ static Action Timer_InfoMessages(Handle timer) {
             } else {
               Get5_Message(i, "%t",
                            g_GameState == Get5State_PreVeto
-                             ? "ReadyToVetoInfoMessage"
+                             ? "ReadyForMapSelectionInfoMessage"
                              : (knifeRound ? "ReadyToKnifeInfoMessage" : "ReadyToStartInfoMessage"),
                            readyCommandFormatted);
             }
@@ -703,13 +703,13 @@ static Action Timer_InfoMessages(Handle timer) {
       }
       MissingPlayerInfoMessage();
     } else if (g_GameState == Get5State_Warmup && g_DisplayGotvVetoCvar.BoolValue && GetTvDelay() > 0) {
-      Get5_MessageToAll("%t", "WaitingForGOTVVetoInfoMessage");
+      Get5_MessageToAll("%t", "WaitingForGOTVMapSelection");
     }
   } else if (g_GameState == Get5State_WaitingForKnifeRoundDecision) {
     PromptForKnifeDecision();
   } else if (g_GameState == Get5State_PostGame && GetTvDelay() > 0) {
     // Handle postgame
-    Get5_MessageToAll("%t", "WaitingForGOTVBrodcastEndingInfoMessage");
+    Get5_MessageToAll("%t", "WaitingForGOTVBroadcastEnding");
   }
 }
 

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -214,6 +214,7 @@ Get5State g_GameState = Get5State_None;
 ArrayList g_MapsToPlay;
 ArrayList g_MapSides;
 ArrayList g_MapsLeftInVetoPool;
+ArrayList g_MapBanOrder;
 Get5Team g_LastVetoTeam;
 Menu g_ActiveVetoMenu;
 Handle g_InfoTimer = INVALID_HANDLE;
@@ -587,6 +588,7 @@ public void OnPluginStart() {
   g_CvarNames = new ArrayList(MAX_CVAR_LENGTH);
   g_CvarValues = new ArrayList(MAX_CVAR_LENGTH);
   g_TeamScoresPerMap = new ArrayList(MATCHTEAM_COUNT);
+  g_MapBanOrder = new ArrayList();
 
   for (int i = 0; i < sizeof(g_TeamPlayers); i++) {
     g_TeamPlayers[i] = new ArrayList(AUTH_LENGTH);
@@ -1474,6 +1476,7 @@ void ResetMatchConfigVariables(bool backup = false) {
   g_MapPoolList.Clear();
   g_PlayerNames.Clear();
   g_MapsToPlay.Clear();
+  g_MapBanOrder.Clear();
   g_MapSides.Clear();
   g_MapsLeftInVetoPool.Clear();
   g_TeamScoresPerMap.Clear();

--- a/scripting/get5/backups.sp
+++ b/scripting/get5/backups.sp
@@ -213,11 +213,10 @@ void WriteBackup() {
 
   char filename[PLATFORM_MAX_PATH];
   if (g_GameState == Get5State_Live) {
-    FormatEx(filename, sizeof(filename), "get5_backup%s_match%s_map%d_round%d.cfg", serverId, g_MatchID,
-             g_MapNumber, g_RoundNumber);
+    FormatEx(filename, sizeof(filename), "get5_backup%s_match%s_map%d_round%d.cfg", serverId, g_MatchID, g_MapNumber,
+             g_RoundNumber);
   } else {
-    FormatEx(filename, sizeof(filename), "get5_backup%s_match%s_map%d_prelive.cfg", serverId, g_MatchID,
-             g_MapNumber);
+    FormatEx(filename, sizeof(filename), "get5_backup%s_match%s_map%d_prelive.cfg", serverId, g_MatchID, g_MapNumber);
   }
 
   char path[PLATFORM_MAX_PATH];

--- a/scripting/get5/mapveto.sp
+++ b/scripting/get5/mapveto.sp
@@ -3,13 +3,27 @@
  */
 
 #define CONFIRM_NEGATIVE_VALUE "_"
+#define TEAM1_PICK             "team1_pick"
+#define TEAM2_PICK             "team2_pick"
+#define TEAM1_BAN              "team1_ban"
+#define TEAM2_BAN              "team2_ban"
+
+Get5VetoType VetoStringToVetoType(const char[] veto, char[] error) {
+  if (strcmp(veto, TEAM1_PICK) == 0) {
+    return Get5VetoTypeTeam1Pick;
+  } else if (strcmp(veto, TEAM2_PICK) == 0) {
+    return Get5VetoTypeTeam2Pick;
+  } else if (strcmp(veto, TEAM1_BAN) == 0) {
+    return Get5VetoTypeTeam1Ban;
+  } else if (strcmp(veto, TEAM2_BAN) == 0) {
+    return Get5VetoTypeTeam2Ban;
+  }
+  FormatEx(error, PLATFORM_MAX_PATH, "Veto order type '%s' is invalid. Must be one of: '%s', '%s', '%s', '%s'.", veto,
+           TEAM1_PICK, TEAM2_PICK, TEAM1_BAN, TEAM2_BAN);
+  return Get5VetoTypeInvalid;
+}
 
 void CreateVeto() {
-  if (g_MapPoolList.Length % 2 == 0) {
-    LogError("Warning, the maplist is even number sized (%d maps), vetos may not function correctly!",
-             g_MapPoolList.Length);
-  }
-
   g_VetoCaptains[Get5Team_1] = GetTeamCaptain(Get5Team_1);
   g_VetoCaptains[Get5Team_2] = GetTeamCaptain(Get5Team_2);
   ResetReadyStatus();
@@ -27,17 +41,15 @@ static Action Timer_VetoCountdown(Handle timer) {
   }
   if (warningsPrinted >= g_VetoCountdownCvar.IntValue) {
     warningsPrinted = 0;
-    Get5Team startingTeam = OtherMatchTeam(g_LastVetoTeam);
-    VetoController(g_VetoCaptains[startingTeam]);
+    VetoController();
     return Plugin_Stop;
-  } else {
-    warningsPrinted++;
-    int secondsRemaining = g_VetoCountdownCvar.IntValue - warningsPrinted + 1;
-    char secondsFormatted[32];
-    FormatEx(secondsFormatted, sizeof(secondsFormatted), "{GREEN}%d{NORMAL}", secondsRemaining);
-    Get5_MessageToAll("%t", "VetoCountdown", secondsFormatted);
-    return Plugin_Continue;
   }
+  warningsPrinted++;
+  int secondsRemaining = g_VetoCountdownCvar.IntValue - warningsPrinted + 1;
+  char secondsFormatted[32];
+  FormatEx(secondsFormatted, sizeof(secondsFormatted), "{GREEN}%d{NORMAL}", secondsRemaining);
+  Get5_MessageToAll("%t", "VetoCountdown", secondsFormatted);
+  return Plugin_Continue;
 }
 
 static void AbortVeto() {
@@ -57,6 +69,7 @@ static void AbortVeto() {
 static void VetoFinished() {
   ChangeState(Get5State_Warmup);
   Get5_MessageToAll("%t", "MapDecidedInfoMessage");
+  g_MapsLeftInVetoPool.Clear();
 
   if (IsPaused()) {
     UnpauseGame(Get5Team_None);
@@ -86,123 +99,83 @@ static void VetoFinished() {
 
 // Main Veto Controller
 
-static void VetoController(int client) {
-  if (!IsPlayer(client) || GetClientMatchTeam(client) == Get5Team_Spec) {
-    AbortVeto();
-    return;
-  }
-
-  int mapsLeft = g_MapsLeftInVetoPool.Length;
-  int maxMaps = g_NumberOfMapsInSeries;
-
-  int mapsPicked = g_MapsToPlay.Length;
-  int sidesSet = g_MapSides.Length;
-
-  int seriesScore = g_TeamSeriesScores[Get5Team_1] + g_TeamSeriesScores[Get5Team_2];
-
-  // This is a dirty hack to get ban/ban/pick/pick/ban/ban
-  // instead of straight vetoing until the maplist is the length
-  // of the series.
-  // This only applies to a standard Bo3 in the 7-map pool.
-  // TODO: It should be written more generically.
-  bool bo3_hack = false;
-  if (maxMaps == 3 && (mapsLeft == 4 || mapsLeft == 5) && g_MapPoolList.Length == 7) {
-    bo3_hack = true;
-  }
-
-  // Yet another dirty hack to skip the last two bans if we are
-  // in a situation where one a team has map advantage.
-  bool bo3_last_veto_hack = false;
-  if (maxMaps == 3 && mapsLeft <= 3 && seriesScore > 0 && g_MapPoolList.Length == 7) {
-    bo3_last_veto_hack = true;
-  }
-
-  // This is also a bit hacky.
-  // The purpose is to force the veto process to take a
-  // ban/ban/ban/ban/pick/pick/last map unused process for BO2's.
-  bool bo2_hack = false;
-  if (g_NumberOfMapsInSeries == 2 && (mapsLeft == 3 || mapsLeft == 2)) {
-    bo2_hack = true;
-  }
-
-  if (sidesSet < mapsPicked) {
+static void VetoController() {
+  // As long as sides are not set for a map, either give side pick or auto-decide sides and recursively call this.
+  if (g_MapSides.Length < g_MapsToPlay.Length) {
     if (g_MatchSideType == MatchSideType_Standard) {
-      GiveSidePickMenu(client);
-
+      GiveSidePickMenu(g_VetoCaptains[OtherMatchTeam(g_LastVetoTeam)]);
     } else if (g_MatchSideType == MatchSideType_AlwaysKnife) {
       g_MapSides.Push(SideChoice_KnifeRound);
-      VetoController(client);
-
-    } else if (g_MatchSideType == MatchSideType_NeverKnife) {
+      VetoController();
+    } else {
       g_MapSides.Push(SideChoice_Team1CT);
-      VetoController(client);
+      VetoController();
     }
-
-  } else if (mapsLeft == seriesScore || bo3_last_veto_hack) {
-    // We have as many maps left as the total series score, or we can skip the last two
-    // bans in a bo3 which means some maps will be skipped (i.e. they have already been "won" by a
-    // team)
-    // If series score is 0 we won't get here
-
-    // Add maps to the front of the active maplist equal to the total series score, as these are the
-    // maps
-    // that will be skipped
-    char mapName[PLATFORM_MAX_PATH];
-    for (int i = 0; i < seriesScore; i++) {
-      // Get the next map in the veto pool
+  } else if (g_NumberOfMapsInSeries < g_MapsToPlay.Length) {
+    if (g_MapsLeftInVetoPool.Length == 1) {
+      // Only 1 map left in the pool, add it be deduction and determine knife logic.
+      char mapName[PLATFORM_MAX_PATH];
       g_MapsLeftInVetoPool.GetString(0, mapName, sizeof(mapName));
-      g_MapsLeftInVetoPool.Erase(0);
-
-      // Add it to the front of the active maplist
-      g_MapsToPlay.ShiftUp(0);
-      g_MapsToPlay.SetString(0, mapName);
-
-      // Add a side type to map sides too, so the sides don't come out of order
-      g_MapSides.ShiftUp(0);
-      g_MapSides.Set(0, SideChoice_KnifeRound);
-    }
-
-    // We're specifically not firing any events here, as the maps will be skipped anyway
-    // TODO: maybe we should?
-
-    VetoFinished();
-
-  } else if (mapsLeft == 1) {
-    if (g_NumberOfMapsInSeries == 2) {
-      // Terminate the veto since we've had ban-ban-ban-ban-pick-pick
+      PickMap(mapName, Get5Team_None);
+      if (g_MatchSideType == MatchSideType_Standard || g_MatchSideType == MatchSideType_AlwaysKnife) {
+        g_MapSides.Push(SideChoice_KnifeRound);
+      } else {
+        g_MapSides.Push(SideChoice_Team1CT);
+      }
       VetoFinished();
-      return;
+    } else {
+      // Number of banned maps must be: original pool - (current pool + picked);
+      // 7 - (4 + 2) = 1; if 4 are left and 2 were picked, 1 must have been banned.
+      int mapsBanned = g_MapPoolList.Length - (g_MapsLeftInVetoPool.Length + g_MapsToPlay.Length);
+      // More than 1 map in the pool and not all maps are picked; present choices as determine by config.
+      switch (g_MapBanOrder.Get(g_MapsToPlay.Length + mapsBanned)) {
+        case Get5VetoTypeTeam1Ban:
+          GiveMapVetoMenu(g_VetoCaptains[Get5Team_1]);
+        case Get5VetoTypeTeam2Ban:
+          GiveMapVetoMenu(g_VetoCaptains[Get5Team_2]);
+        case Get5VetoTypeTeam1Pick:
+          GiveMapPickMenu(g_VetoCaptains[Get5Team_1]);
+        case Get5VetoTypeTeam2Pick:
+          GiveMapPickMenu(g_VetoCaptains[Get5Team_2]);
+      }
     }
-
-    // Only 1 map left in the pool, add it directly to the active maplist.
-    char mapName[PLATFORM_MAX_PATH];
-    g_MapsLeftInVetoPool.GetString(0, mapName, sizeof(mapName));
-    g_MapsToPlay.PushString(mapName);
-
-    if (g_MatchSideType == MatchSideType_Standard) {
-      g_MapSides.Push(SideChoice_KnifeRound);
-    } else if (g_MatchSideType == MatchSideType_AlwaysKnife) {
-      g_MapSides.Push(SideChoice_KnifeRound);
-    } else if (g_MatchSideType == MatchSideType_NeverKnife) {
-      g_MapSides.Push(SideChoice_Team1CT);
-    }
-
-    Get5MapPickedEvent event = new Get5MapPickedEvent(g_MatchID, Get5Team_None, mapName, g_MapsToPlay.Length - 1);
-
-    LogDebug("Calling Get5_OnMapPicked()");
-
-    Call_StartForward(g_OnMapPicked);
-    Call_PushCell(event);
-    Call_Finish();
-
-    EventLogger_LogAndDeleteEvent(event);
-
-    VetoFinished();
-  } else if (mapsLeft + mapsPicked <= maxMaps || bo3_hack || bo2_hack) {
-    GiveMapPickMenu(client);
   } else {
-    GiveMapVetoMenu(client);
+    VetoFinished();
   }
+}
+
+static void PickMap(const char[] mapName, const Get5Team team) {
+  if (team != Get5Team_None) {
+    char mapNameFormatted[PLATFORM_MAX_PATH];
+    FormatMapName(mapName, mapNameFormatted, sizeof(mapNameFormatted), true, true);
+    Get5_MessageToAll("%t", "TeamPickedMapInfoMessage", g_FormattedTeamNames[team], mapNameFormatted,
+                      g_MapsToPlay.Length);
+  }
+  RemoveStringFromArray(g_MapsLeftInVetoPool, mapName);
+  g_MapsToPlay.PushString(mapName);
+
+  Get5MapPickedEvent event = new Get5MapPickedEvent(g_MatchID, team, mapName, g_MapsToPlay.Length - 1);
+  LogDebug("Calling Get5_OnMapPicked()");
+  Call_StartForward(g_OnMapPicked);
+  Call_PushCell(event);
+  Call_Finish();
+  EventLogger_LogAndDeleteEvent(event);
+}
+
+static void VetoMap(const char[] mapName, const Get5Team team) {
+  RemoveStringFromArray(g_MapsLeftInVetoPool, mapName);
+  char mapNameFormatted[PLATFORM_MAX_PATH];
+  FormatMapName(mapName, mapNameFormatted, sizeof(mapNameFormatted), true, false);
+  // Add color here as FormatMapName would make the color green.
+  Format(mapNameFormatted, sizeof(mapNameFormatted), "{LIGHT_RED}%s{NORMAL}", mapNameFormatted);
+  Get5_MessageToAll("%t", "TeamVetoedMapInfoMessage", g_FormattedTeamNames[team], mapNameFormatted);
+
+  Get5MapVetoedEvent event = new Get5MapVetoedEvent(g_MatchID, team, mapName);
+  LogDebug("Calling Get5_OnMapVetoed()");
+  Call_StartForward(g_OnMapVetoed);
+  Call_PushCell(event);
+  Call_Finish();
+  EventLogger_LogAndDeleteEvent(event);
 }
 
 // Confirmations
@@ -265,6 +238,11 @@ static bool ConfirmationNegative(const char[] choice) {
 // Map Vetos
 
 static void GiveMapVetoMenu(int client) {
+  if (!IsPlayer(client) || !IsPlayerTeam(GetClientMatchTeam(client))) {
+    AbortVeto();
+    return;
+  }
+
   Menu menu = new Menu(MapVetoMenuHandler);
   menu.SetTitle("%T", "MapVetoBanMenuText", client);
   menu.ExitButton = false;
@@ -305,26 +283,9 @@ static int MapVetoMenuHandler(Menu menu, MenuAction action, int param1, int para
       return;
     }
 
-    RemoveStringFromArray(g_MapsLeftInVetoPool, mapName);
-
-    char formattedMapName[PLATFORM_MAX_PATH];
-    FormatMapName(mapName, formattedMapName, sizeof(formattedMapName), true, false);
-    // Add color here as FormatMapName would make the color green.
-    Format(formattedMapName, sizeof(formattedMapName), "{LIGHT_RED}%s{NORMAL}", formattedMapName);
-    Get5_MessageToAll("%t", "TeamVetoedMapInfoMessage", g_FormattedTeamNames[team], formattedMapName);
-
-    Get5MapVetoedEvent event = new Get5MapVetoedEvent(g_MatchID, team, mapName);
-
-    LogDebug("Calling Get5_OnMapVetoed()");
-    Call_StartForward(g_OnMapVetoed);
-    Call_PushCell(event);
-    Call_Finish();
-
-    EventLogger_LogAndDeleteEvent(event);
-
-    VetoController(GetNextTeamCaptain(client));
+    VetoMap(mapName, team);
     g_LastVetoTeam = team;
-
+    VetoController();
   } else if (action == MenuAction_Cancel) {
     if (g_GameState == Get5State_Veto) {
       AbortVeto();
@@ -340,6 +301,10 @@ static int MapVetoMenuHandler(Menu menu, MenuAction action, int param1, int para
 // Map Picks
 
 static void GiveMapPickMenu(int client) {
+  if (!IsPlayer(client) || !IsPlayerTeam(GetClientMatchTeam(client))) {
+    AbortVeto();
+    return;
+  }
   Menu menu = new Menu(MapPickMenuHandler);
   menu.SetTitle("%T", "MapVetoPickMenuText", client);
   menu.ExitButton = false;
@@ -380,27 +345,9 @@ static int MapPickMenuHandler(Menu menu, MenuAction action, int param1, int para
       return;
     }
 
-    g_MapsToPlay.PushString(mapName);
-    RemoveStringFromArray(g_MapsLeftInVetoPool, mapName);
-
-    char mapNameFormatted[PLATFORM_MAX_PATH];
-    FormatMapName(mapName, mapNameFormatted, sizeof(mapNameFormatted), true, true);
-    Get5_MessageToAll("%t", "TeamPickedMapInfoMessage", g_FormattedTeamNames[team], mapNameFormatted,
-                      g_MapsToPlay.Length);
+    PickMap(mapName, team);
     g_LastVetoTeam = team;
-
-    Get5MapPickedEvent event = new Get5MapPickedEvent(g_MatchID, team, mapName, g_MapsToPlay.Length - 1);
-
-    LogDebug("Calling Get5_OnMapPicked()");
-
-    Call_StartForward(g_OnMapPicked);
-    Call_PushCell(event);
-    Call_Finish();
-
-    EventLogger_LogAndDeleteEvent(event);
-
-    VetoController(GetNextTeamCaptain(client));
-
+    VetoController();
   } else if (action == MenuAction_Cancel) {
     if (g_GameState == Get5State_Veto) {
       AbortVeto();
@@ -416,6 +363,10 @@ static int MapPickMenuHandler(Menu menu, MenuAction action, int param1, int para
 // Side Picks
 
 static void GiveSidePickMenu(int client) {
+  if (!IsPlayer(client) || !IsPlayerTeam(GetClientMatchTeam(client))) {
+    AbortVeto();
+    return;
+  }
   Menu menu = new Menu(SidePickMenuHandler);
   menu.ExitButton = false;
   char mapName[PLATFORM_MAX_PATH];
@@ -449,19 +400,13 @@ static int SidePickMenuHandler(Menu menu, MenuAction action, int param1, int par
       return;
     }
 
-    int selectedSide;
+    Get5Side selectedSide;
     if (StrEqual(choice, "CT")) {
-      selectedSide = CS_TEAM_CT;
-      if (team == Get5Team_1)
-        g_MapSides.Push(SideChoice_Team1CT);
-      else
-        g_MapSides.Push(SideChoice_Team1T);
+      selectedSide = Get5Side_CT;
+      g_MapSides.Push(team == Get5Team_1 ? SideChoice_Team1CT : SideChoice_Team1T);
     } else {
-      selectedSide = CS_TEAM_T;
-      if (team == Get5Team_1)
-        g_MapSides.Push(SideChoice_Team1T);
-      else
-        g_MapSides.Push(SideChoice_Team1CT);
+      selectedSide = Get5Side_T;
+      g_MapSides.Push(team == Get5Team_1 ? SideChoice_Team1T : SideChoice_Team1CT);
     }
 
     int mapNumber = g_MapsToPlay.Length - 1;
@@ -472,18 +417,15 @@ static int SidePickMenuHandler(Menu menu, MenuAction action, int param1, int par
     Format(choice, sizeof(choice), "{GREEN}%s{NORMAL}", choice);
     Get5_MessageToAll("%t", "TeamSelectSideInfoMessage", g_FormattedTeamNames[team], choice, mapName);
 
-    Get5SidePickedEvent event =
-      new Get5SidePickedEvent(g_MatchID, mapNumber, mapName, team, view_as<Get5Side>(selectedSide));
+    Get5SidePickedEvent event = new Get5SidePickedEvent(g_MatchID, mapNumber, mapName, team, selectedSide);
 
     LogDebug("Calling Get5_OnSidePicked()");
-
     Call_StartForward(g_OnSidePicked);
     Call_PushCell(event);
     Call_Finish();
-
     EventLogger_LogAndDeleteEvent(event);
 
-    VetoController(client);
+    VetoController();
 
   } else if (action == MenuAction_Cancel) {
     if (g_GameState == Get5State_Veto) {

--- a/scripting/get5/readysystem.sp
+++ b/scripting/get5/readysystem.sp
@@ -207,7 +207,7 @@ Action Command_NotReady(int client, int args) {
     Call_Finish();
 
     SetMatchTeamCvars();
-    Get5_MessageToAll("%t", "TeamNotReadyInfoMessage", g_FormattedTeamNames[team]);
+    Get5_MessageToAll("%t", "TeamIsNoLongerReady", g_FormattedTeamNames[team]);
   }
 
   return Plugin_Handled;
@@ -269,12 +269,12 @@ static void HandleReadyMessage(Get5Team team) {
   EventLogger_LogAndDeleteEvent(readyEvent);
 
   if (g_GameState == Get5State_PreVeto) {
-    Get5_MessageToAll("%t", "TeamReadyToVetoInfoMessage", g_FormattedTeamNames[team]);
+    Get5_MessageToAll("%t", "TeamIsReadyForMapSelection", g_FormattedTeamNames[team]);
   } else if (g_GameState == Get5State_PendingRestore) {
-    Get5_MessageToAll("%t", "TeamReadyToRestoreBackupInfoMessage", g_FormattedTeamNames[team]);
+    Get5_MessageToAll("%t", "TeamIsReadyToRestoreBackup", g_FormattedTeamNames[team]);
   } else if (g_GameState == Get5State_Warmup) {
     bool knifeRound = view_as<SideChoice>(g_MapSides.Get(g_MapNumber)) == SideChoice_KnifeRound;
-    Get5_MessageToAll("%t", knifeRound ? "TeamReadyToKnifeInfoMessage" : "TeamReadyToBeginInfoMessage",
+    Get5_MessageToAll("%t", knifeRound ? "TeamIsReadyToKnife" : "TeamIsReadyToBegin",
                       g_FormattedTeamNames[team]);
   }
 }

--- a/scripting/get5/readysystem.sp
+++ b/scripting/get5/readysystem.sp
@@ -274,8 +274,7 @@ static void HandleReadyMessage(Get5Team team) {
     Get5_MessageToAll("%t", "TeamIsReadyToRestoreBackup", g_FormattedTeamNames[team]);
   } else if (g_GameState == Get5State_Warmup) {
     bool knifeRound = view_as<SideChoice>(g_MapSides.Get(g_MapNumber)) == SideChoice_KnifeRound;
-    Get5_MessageToAll("%t", knifeRound ? "TeamIsReadyToKnife" : "TeamIsReadyToBegin",
-                      g_FormattedTeamNames[team]);
+    Get5_MessageToAll("%t", knifeRound ? "TeamIsReadyToKnife" : "TeamIsReadyToBegin", g_FormattedTeamNames[team]);
   }
 }
 

--- a/scripting/get5/teamlogic.sp
+++ b/scripting/get5/teamlogic.sp
@@ -396,14 +396,6 @@ int GetTeamCaptain(Get5Team team) {
   return -1;
 }
 
-int GetNextTeamCaptain(int client) {
-  if (client == g_VetoCaptains[Get5Team_1]) {
-    return g_VetoCaptains[Get5Team_2];
-  } else {
-    return g_VetoCaptains[Get5Team_1];
-  }
-}
-
 ArrayList GetTeamPlayers(Get5Team team) {
   return g_TeamPlayers[team];
 }

--- a/scripting/get5/tests.sp
+++ b/scripting/get5/tests.sp
@@ -92,24 +92,24 @@ static void MapVetoLogicTest() {
 
   ArrayList mapPool = GetMapPool(7);
   pickOrder = new ArrayList();
-  pickOrder.Push(Get5VetoTypeTeam1Ban);
-  pickOrder.Push(Get5VetoTypeTeam2Ban);
-  pickOrder.Push(Get5VetoTypeTeam1Pick);
-  pickOrder.Push(Get5VetoTypeTeam2Pick);
-  pickOrder.Push(Get5VetoTypeTeam1Ban);
-  pickOrder.Push(Get5VetoTypeTeam2Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team1Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team2Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team1Pick);
+  pickOrder.Push(Get5MapSelectionOption_Team2Pick);
+  pickOrder.Push(Get5MapSelectionOption_Team1Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team2Ban);
   success = ValidateMapBanLogic(mapPool, pickOrder, 3, error);
   delete mapPool;
   AssertTrue("Test valid map ban config, bo3 7 maps, 2 picks, 4 bans; last played", success);
 
   mapPool = GetMapPool(8);
   pickOrder.Clear();
-  pickOrder.Push(Get5VetoTypeTeam1Ban);
-  pickOrder.Push(Get5VetoTypeTeam2Ban);
-  pickOrder.Push(Get5VetoTypeTeam1Pick);
-  pickOrder.Push(Get5VetoTypeTeam2Pick);
-  pickOrder.Push(Get5VetoTypeTeam1Ban);
-  pickOrder.Push(Get5VetoTypeTeam2Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team1Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team2Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team1Pick);
+  pickOrder.Push(Get5MapSelectionOption_Team2Pick);
+  pickOrder.Push(Get5MapSelectionOption_Team1Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team2Ban);
   success = ValidateMapBanLogic(mapPool, pickOrder, 3, error);
   delete mapPool;
   AssertFalse("Test invalid map ban config, bo3 8 maps, 2 picks, 4 bans", success);
@@ -121,11 +121,11 @@ static void MapVetoLogicTest() {
   // Test pick count match; don't care about number of bans
   mapPool = GetMapPool(9);
   pickOrder.Clear();
-  pickOrder.Push(Get5VetoTypeTeam1Ban);
-  pickOrder.Push(Get5VetoTypeTeam1Pick);
-  pickOrder.Push(Get5VetoTypeTeam2Pick);
-  pickOrder.Push(Get5VetoTypeTeam1Pick);
-  pickOrder.Push(Get5VetoTypeTeam2Ban); // will be trimmed.
+  pickOrder.Push(Get5MapSelectionOption_Team1Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team1Pick);
+  pickOrder.Push(Get5MapSelectionOption_Team2Pick);
+  pickOrder.Push(Get5MapSelectionOption_Team1Pick);
+  pickOrder.Push(Get5MapSelectionOption_Team2Ban);  // will be trimmed.
   success = ValidateMapBanLogic(mapPool, pickOrder, 3, error);
   delete mapPool;
   AssertTrue("Test valid map ban config; bo3 9 maps, 3 picks, 2 bans", success);
@@ -133,21 +133,21 @@ static void MapVetoLogicTest() {
 
   mapPool = GetMapPool(7);
   pickOrder.Clear();
-  pickOrder.Push(Get5VetoTypeTeam1Ban);
-  pickOrder.Push(Get5VetoTypeTeam1Pick);
-  pickOrder.Push(Get5VetoTypeTeam1Ban);
-  pickOrder.Push(Get5VetoTypeTeam2Ban);
-  pickOrder.Push(Get5VetoTypeTeam2Pick);
-  pickOrder.Push(Get5VetoTypeTeam1Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team1Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team1Pick);
+  pickOrder.Push(Get5MapSelectionOption_Team1Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team2Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team2Pick);
+  pickOrder.Push(Get5MapSelectionOption_Team1Ban);
   success = ValidateMapBanLogic(mapPool, pickOrder, 3, error);
   delete mapPool;
   AssertTrue("Test valid map ban config; bo3 7 maps, 2 picks, 4 ban, 1 remaining", success);
 
   mapPool = GetMapPool(4);
   pickOrder.Clear();
-  pickOrder.Push(Get5VetoTypeTeam1Pick);
-  pickOrder.Push(Get5VetoTypeTeam1Pick);
-  pickOrder.Push(Get5VetoTypeTeam1Pick);
+  pickOrder.Push(Get5MapSelectionOption_Team1Pick);
+  pickOrder.Push(Get5MapSelectionOption_Team1Pick);
+  pickOrder.Push(Get5MapSelectionOption_Team1Pick);
   success = ValidateMapBanLogic(mapPool, pickOrder, 3, error);
   delete mapPool;
   AssertTrue("Test valid map ban config; bo3 4 maps, 3 picks, 1 remaining", success);
@@ -155,9 +155,9 @@ static void MapVetoLogicTest() {
 
   mapPool = GetMapPool(4);
   pickOrder.Clear();
-  pickOrder.Push(Get5VetoTypeTeam1Pick);
-  pickOrder.Push(Get5VetoTypeTeam1Pick);
-  pickOrder.Push(Get5VetoTypeTeam1Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team1Pick);
+  pickOrder.Push(Get5MapSelectionOption_Team1Pick);
+  pickOrder.Push(Get5MapSelectionOption_Team1Ban);
   success = ValidateMapBanLogic(mapPool, pickOrder, 3, error);
   delete mapPool;
   AssertTrue("Test valid map ban config; bo3 4 maps, 2 picks, 1 ban", success);
@@ -165,10 +165,10 @@ static void MapVetoLogicTest() {
 
   mapPool = GetMapPool(7);
   pickOrder.Clear();
-  pickOrder.Push(Get5VetoTypeTeam1Pick);
-  pickOrder.Push(Get5VetoTypeTeam2Pick);
-  pickOrder.Push(Get5VetoTypeTeam1Pick);
-  pickOrder.Push(Get5VetoTypeTeam2Pick); // removed
+  pickOrder.Push(Get5MapSelectionOption_Team1Pick);
+  pickOrder.Push(Get5MapSelectionOption_Team2Pick);
+  pickOrder.Push(Get5MapSelectionOption_Team1Pick);
+  pickOrder.Push(Get5MapSelectionOption_Team2Pick);  // removed
   success = ValidateMapBanLogic(mapPool, pickOrder, 3, error);
   delete mapPool;
   AssertTrue("Test valid map ban config; bo3 7 maps, 4 picks", success);
@@ -176,14 +176,14 @@ static void MapVetoLogicTest() {
 
   mapPool = GetMapPool(7);
   pickOrder.Clear();
-  pickOrder.Push(Get5VetoTypeTeam1Ban);
-  pickOrder.Push(Get5VetoTypeTeam2Pick);
-  pickOrder.Push(Get5VetoTypeTeam1Ban);
-  pickOrder.Push(Get5VetoTypeTeam2Pick);
-  pickOrder.Push(Get5VetoTypeTeam1Ban);
-  pickOrder.Push(Get5VetoTypeTeam2Pick);
-  pickOrder.Push(Get5VetoTypeTeam1Ban);
-  pickOrder.Push(Get5VetoTypeTeam2Pick);
+  pickOrder.Push(Get5MapSelectionOption_Team1Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team2Pick);
+  pickOrder.Push(Get5MapSelectionOption_Team1Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team2Pick);
+  pickOrder.Push(Get5MapSelectionOption_Team1Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team2Pick);
+  pickOrder.Push(Get5MapSelectionOption_Team1Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team2Pick);
   success = ValidateMapBanLogic(mapPool, pickOrder, 3, error);
   delete mapPool;
   AssertTrue("Test valid map ban config; bo3 7 maps, 4 picks 4 bans", success);
@@ -191,14 +191,14 @@ static void MapVetoLogicTest() {
 
   mapPool = GetMapPool(9);
   pickOrder.Clear();
-  pickOrder.Push(Get5VetoTypeTeam1Ban);
-  pickOrder.Push(Get5VetoTypeTeam2Ban);
-  pickOrder.Push(Get5VetoTypeTeam1Ban);
-  pickOrder.Push(Get5VetoTypeTeam2Pick);
-  pickOrder.Push(Get5VetoTypeTeam1Ban);
-  pickOrder.Push(Get5VetoTypeTeam2Pick);
-  pickOrder.Push(Get5VetoTypeTeam1Ban);
-  pickOrder.Push(Get5VetoTypeTeam2Pick);
+  pickOrder.Push(Get5MapSelectionOption_Team1Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team2Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team1Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team2Pick);
+  pickOrder.Push(Get5MapSelectionOption_Team1Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team2Pick);
+  pickOrder.Push(Get5MapSelectionOption_Team1Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team2Pick);
   success = ValidateMapBanLogic(mapPool, pickOrder, 3, error);
   delete mapPool;
   AssertTrue("Test valid map ban config; bo3 9 maps, 3 picks, 5 bans", success);
@@ -206,65 +206,185 @@ static void MapVetoLogicTest() {
 
   mapPool = GetMapPool(7);
   pickOrder.Clear();
-  pickOrder.Push(Get5VetoTypeTeam1Ban);
-  pickOrder.Push(Get5VetoTypeTeam2Pick);
-  pickOrder.Push(Get5VetoTypeTeam1Ban);
-  pickOrder.Push(Get5VetoTypeTeam2Pick);
-  pickOrder.Push(Get5VetoTypeTeam1Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team1Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team2Pick);
+  pickOrder.Push(Get5MapSelectionOption_Team1Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team2Pick);
+  pickOrder.Push(Get5MapSelectionOption_Team1Ban);
   success = ValidateMapBanLogic(mapPool, pickOrder, 3, error);
   delete mapPool;
   AssertFalse("Test invalid map ban config; bo3 7 maps, 2 picks, 3 bans; missing one pick or ban", success);
 
   mapPool = GetMapPool(7);
   pickOrder.Clear();
-  pickOrder.Push(Get5VetoTypeTeam1Ban);
-  pickOrder.Push(Get5VetoTypeTeam2Pick);
-  pickOrder.Push(Get5VetoTypeTeam1Ban);
-  pickOrder.Push(Get5VetoTypeTeam2Ban);
-  pickOrder.Push(Get5VetoTypeTeam1Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team1Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team2Pick);
+  pickOrder.Push(Get5MapSelectionOption_Team1Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team2Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team1Ban);
   success = ValidateMapBanLogic(mapPool, pickOrder, 3, error);
   delete mapPool;
   AssertFalse("Test invalid map ban config; bo3 7 maps, 1 pick, 4 bans; cannot randomly select remaining two", success);
 
   mapPool = GetMapPool(7);
   pickOrder.Clear();
-  pickOrder.Push(Get5VetoTypeTeam1Ban);
-  pickOrder.Push(Get5VetoTypeTeam2Ban);
-  pickOrder.Push(Get5VetoTypeTeam1Ban);
-  pickOrder.Push(Get5VetoTypeTeam2Ban);
-  pickOrder.Push(Get5VetoTypeTeam1Ban);
-  pickOrder.Push(Get5VetoTypeTeam2Pick);
+  pickOrder.Push(Get5MapSelectionOption_Team1Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team2Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team1Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team2Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team1Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team2Pick);
   success = ValidateMapBanLogic(mapPool, pickOrder, 1, error);
   delete mapPool;
   AssertTrue("Test valid map ban config; bo1 7 maps, 1 pick, 5 bans", success);
 
   mapPool = GetMapPool(7);
   pickOrder.Clear();
-  pickOrder.Push(Get5VetoTypeTeam1Ban);
-  pickOrder.Push(Get5VetoTypeTeam2Ban);
-  pickOrder.Push(Get5VetoTypeTeam1Ban);
-  pickOrder.Push(Get5VetoTypeTeam2Ban);
-  pickOrder.Push(Get5VetoTypeTeam1Ban);
-  pickOrder.Push(Get5VetoTypeTeam2Pick);
+  pickOrder.Push(Get5MapSelectionOption_Team1Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team2Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team1Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team2Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team1Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team2Pick);
   success = ValidateMapBanLogic(mapPool, pickOrder, 2, error);
   delete mapPool;
   AssertTrue("Test valid map ban config; bo2 7 maps, 5 bans 1 pick; last map played", success);
 
   mapPool = GetMapPool(7);
   pickOrder.Clear();
-  pickOrder.Push(Get5VetoTypeTeam1Ban);
-  pickOrder.Push(Get5VetoTypeTeam2Ban);
-  pickOrder.Push(Get5VetoTypeTeam1Ban);
-  pickOrder.Push(Get5VetoTypeTeam2Ban);
-  pickOrder.Push(Get5VetoTypeTeam1Ban);
-  pickOrder.Push(Get5VetoTypeTeam2Pick);
+  pickOrder.Push(Get5MapSelectionOption_Team1Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team2Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team1Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team2Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team1Ban);
+  pickOrder.Push(Get5MapSelectionOption_Team2Pick);
   success = ValidateMapBanLogic(mapPool, pickOrder, 3, error);
   delete mapPool;
   AssertFalse("Test invalid map ban config; bo3 7 maps, 5 bans 1 pick; not enough picks", success);
-  AssertStrEq(
-    "Test not enough picks error",
-    "In a series of 3 maps, at least 2 veto options must be picks. Found 1 pick(s).",
-    error);
+  AssertStrEq("Test not enough picks error",
+              "In a series of 3 maps, at least 2 veto options must be picks. Found 1 pick(s).", error);
+
+  mapPool = GetMapPool(7);
+  pickOrder.Clear();
+  GenerateDefaultVetoSetup(mapPool, pickOrder, 3, Get5Team_2);
+  AssertEq("Default pick ban length bo3, 7 maps", pickOrder.Length, 6);
+  for (int i = 0; i < pickOrder.Length; i++) {
+    int t = pickOrder.Get(i);
+    switch (i) {
+      case 0:
+        AssertEq("Check map pick/ban order value 0", t, view_as<int>(Get5MapSelectionOption_Team1Ban));
+      case 1:
+        AssertEq("Check map pick/ban order value 1", t, view_as<int>(Get5MapSelectionOption_Team2Ban));
+      case 2:
+        AssertEq("Check map pick/ban order value 2", t, view_as<int>(Get5MapSelectionOption_Team1Pick));
+      case 3:
+        AssertEq("Check map pick/ban order value 3", t, view_as<int>(Get5MapSelectionOption_Team2Pick));
+      case 4:
+        AssertEq("Check map pick/ban order value 4", t, view_as<int>(Get5MapSelectionOption_Team1Ban));
+      case 5:
+        AssertEq("Check map pick/ban order value 5", t, view_as<int>(Get5MapSelectionOption_Team2Ban));
+    }
+  }
+  AssertTrue("Validate default", ValidateMapBanLogic(mapPool, pickOrder, 3, error));
+  delete mapPool;
+
+  mapPool = GetMapPool(8);
+  pickOrder.Clear();
+  GenerateDefaultVetoSetup(mapPool, pickOrder, 3, Get5Team_2);
+  AssertEq("Default pick ban length bo3, 8 maps", pickOrder.Length, 7);
+  for (int i = 0; i < pickOrder.Length; i++) {
+    int t = pickOrder.Get(i);
+    switch (i) {
+      case 0:
+        AssertEq("Check map pick/ban order value 0", t, view_as<int>(Get5MapSelectionOption_Team1Ban));
+      case 1:
+        AssertEq("Check map pick/ban order value 1", t, view_as<int>(Get5MapSelectionOption_Team2Ban));
+      case 2:
+        AssertEq("Check map pick/ban order value 2", t, view_as<int>(Get5MapSelectionOption_Team1Ban));
+      case 3:
+        AssertEq("Check map pick/ban order value 3", t, view_as<int>(Get5MapSelectionOption_Team2Pick));
+      case 4:
+        AssertEq("Check map pick/ban order value 4", t, view_as<int>(Get5MapSelectionOption_Team1Pick));
+      case 5:
+        AssertEq("Check map pick/ban order value 5", t, view_as<int>(Get5MapSelectionOption_Team2Ban));
+      case 6:
+        AssertEq("Check map pick/ban order value 6", t, view_as<int>(Get5MapSelectionOption_Team1Ban));
+    }
+  }
+  AssertTrue("Validate default", ValidateMapBanLogic(mapPool, pickOrder, 3, error));
+  delete mapPool;
+
+  mapPool = GetMapPool(4);
+  pickOrder.Clear();
+  GenerateDefaultVetoSetup(mapPool, pickOrder, 3, Get5Team_2);
+  AssertEq("Default pick ban length bo3, 4 maps", pickOrder.Length, 3);
+  for (int i = 0; i < pickOrder.Length; i++) {
+    int t = pickOrder.Get(i);
+    switch (i) {
+      case 0:
+        AssertEq("Check map pick/ban order value 0", t, view_as<int>(Get5MapSelectionOption_Team1Pick));
+      case 1:
+        AssertEq("Check map pick/ban order value 1", t, view_as<int>(Get5MapSelectionOption_Team2Pick));
+      case 2:
+        AssertEq("Check map pick/ban order value 2", t, view_as<int>(Get5MapSelectionOption_Team1Pick));
+    }
+  }
+  AssertTrue("Validate default", ValidateMapBanLogic(mapPool, pickOrder, 3, error));
+  delete mapPool;
+
+  mapPool = GetMapPool(8);
+  pickOrder.Clear();
+  GenerateDefaultVetoSetup(mapPool, pickOrder, 2, Get5Team_2);
+  AssertEq("Default pick ban length bo2, 8 maps", pickOrder.Length, 4);
+  for (int i = 0; i < pickOrder.Length; i++) {
+    int t = pickOrder.Get(i);
+    switch (i) {
+      case 0:
+        AssertEq("Check map pick/ban order value 0", t, view_as<int>(Get5MapSelectionOption_Team1Ban));
+      case 1:
+        AssertEq("Check map pick/ban order value 1", t, view_as<int>(Get5MapSelectionOption_Team2Ban));
+      case 2:
+        AssertEq("Check map pick/ban order value 2", t, view_as<int>(Get5MapSelectionOption_Team1Pick));
+      case 3:
+        AssertEq("Check map pick/ban order value 3", t, view_as<int>(Get5MapSelectionOption_Team2Pick));
+    }
+  }
+  AssertTrue("Validate default", ValidateMapBanLogic(mapPool, pickOrder, 2, error));
+  delete mapPool;
+
+  mapPool = GetMapPool(3);
+  pickOrder.Clear();
+  GenerateDefaultVetoSetup(mapPool, pickOrder, 2, Get5Team_2);
+  AssertEq("Default pick ban length bo2, 3 maps", pickOrder.Length, 2);
+  for (int i = 0; i < pickOrder.Length; i++) {
+    int t = pickOrder.Get(i);
+    switch (i) {
+      case 0:
+        AssertEq("Check map pick/ban order value 0", t, view_as<int>(Get5MapSelectionOption_Team1Pick));
+      case 1:
+        AssertEq("Check map pick/ban order value 1", t, view_as<int>(Get5MapSelectionOption_Team2Pick));
+    }
+  }
+  AssertTrue("Validate default", ValidateMapBanLogic(mapPool, pickOrder, 3, error));
+  delete mapPool;
+
+  mapPool = GetMapPool(2);
+  pickOrder.Clear();
+  GenerateDefaultVetoSetup(mapPool, pickOrder, 2, Get5Team_2);
+  AssertEq("Default pick ban length bo2, 2 maps", pickOrder.Length, 2);
+  for (int i = 0; i < pickOrder.Length; i++) {
+    int t = pickOrder.Get(i);
+    switch (i) {
+      case 0:
+        AssertEq("Check map pick/ban order value 0", t, view_as<int>(Get5MapSelectionOption_Team1Pick));
+      case 1:
+        AssertEq("Check map pick/ban order value 1", t, view_as<int>(Get5MapSelectionOption_Team2Pick));
+    }
+  }
+  AssertTrue("Validate default", ValidateMapBanLogic(mapPool, pickOrder, 2, error));
+  delete mapPool;
+
+  delete pickOrder;
 }
 
 static void MissingPropertiesTest() {
@@ -428,13 +548,15 @@ static void CustomVetoConfigTest() {
   SetTestContext("CustomVetoConfigTest");
   char error[PLATFORM_MAX_PATH];
 
-  AssertTrue("Load match config custom veto", LoadMatchConfig("addons/sourcemod/configs/get5/tests/custom_veto.json", error));
+  AssertTrue("Load match config custom veto",
+             LoadMatchConfig("addons/sourcemod/configs/get5/tests/custom_veto.json", error));
   AssertEq("Map ban length after load", g_MapBanOrder.Length, 4);
   EndSeries(Get5Team_None, false, 0.0);
 
-  AssertFalse("Load match config invalid custom veto", LoadMatchConfig("addons/sourcemod/configs/get5/tests/custom_veto_invalid.json", error));
-  AssertStrEq("Load match config invalid custom veto error", "In a series of 3 maps, at least 2 veto options must be picks. Found 0 pick(s).", error);
-
+  AssertFalse("Load match config invalid custom veto",
+              LoadMatchConfig("addons/sourcemod/configs/get5/tests/custom_veto_invalid.json", error));
+  AssertStrEq("Load match config invalid custom veto error",
+              "In a series of 3 maps, at least 2 veto options must be picks. Found 0 pick(s).", error);
 }
 
 static void ValidMatchConfigTest(const char[] matchConfig) {

--- a/scripting/get5/tests.sp
+++ b/scripting/get5/tests.sp
@@ -37,6 +37,7 @@ static void Get5_Test() {
   ValidMatchConfigTest("addons/sourcemod/configs/get5/tests/default_valid.cfg");
 
   MatchConfigNotFoundTest();
+  CustomVetoConfigTest();
 
   InvalidMatchConfigFile("addons/sourcemod/configs/get5/tests/invalid_config.json");
   InvalidMatchConfigFile("addons/sourcemod/configs/get5/tests/invalid_config.cfg");
@@ -47,7 +48,223 @@ static void Get5_Test() {
   MissingPropertiesTest();
 
   Utils_Test();
+  MapVetoLogicTest();
   LogMessage("Tests complete!");
+}
+
+// Helper used to generate map list array of any size.
+static ArrayList GetMapPool(int size) {
+  ArrayList list = new ArrayList(PLATFORM_MAX_PATH);
+  int i = 0;
+  while (i < size) {
+    switch (i) {
+      case 0:
+        list.PushString("de_dust2");
+      case 1:
+        list.PushString("de_mirage");
+      case 2:
+        list.PushString("de_inferno");
+      case 3:
+        list.PushString("de_anubis");
+      case 4:
+        list.PushString("de_cache");
+      case 5:
+        list.PushString("de_train");
+      case 6:
+        list.PushString("de_vertigo");
+      case 7:
+        list.PushString("de_ancient");
+      case 8:
+        list.PushString("de_nuke");
+      case 9:
+        list.PushString("de_overpass");
+    }
+    i++;
+  }
+  return list;
+}
+
+static void MapVetoLogicTest() {
+  SetTestContext("MapVetoLogicTest");
+  char error[PLATFORM_MAX_PATH];
+  bool success;
+  ArrayList pickOrder;
+
+  ArrayList mapPool = GetMapPool(7);
+  pickOrder = new ArrayList();
+  pickOrder.Push(Get5VetoTypeTeam1Ban);
+  pickOrder.Push(Get5VetoTypeTeam2Ban);
+  pickOrder.Push(Get5VetoTypeTeam1Pick);
+  pickOrder.Push(Get5VetoTypeTeam2Pick);
+  pickOrder.Push(Get5VetoTypeTeam1Ban);
+  pickOrder.Push(Get5VetoTypeTeam2Ban);
+  success = ValidateMapBanLogic(mapPool, pickOrder, 3, error);
+  delete mapPool;
+  AssertTrue("Test valid map ban config, bo3 7 maps, 2 picks, 4 bans; last played", success);
+
+  mapPool = GetMapPool(8);
+  pickOrder.Clear();
+  pickOrder.Push(Get5VetoTypeTeam1Ban);
+  pickOrder.Push(Get5VetoTypeTeam2Ban);
+  pickOrder.Push(Get5VetoTypeTeam1Pick);
+  pickOrder.Push(Get5VetoTypeTeam2Pick);
+  pickOrder.Push(Get5VetoTypeTeam1Ban);
+  pickOrder.Push(Get5VetoTypeTeam2Ban);
+  success = ValidateMapBanLogic(mapPool, pickOrder, 3, error);
+  delete mapPool;
+  AssertFalse("Test invalid map ban config, bo3 8 maps, 2 picks, 4 bans", success);
+  AssertStrEq(
+    "Test map ban error ban/pick mismatch",
+    "The number of maps in the pool (8) must be one larger than the number of map picks/bans (6), unless the number of picks (2) matches the series length (3).",
+    error);
+
+  // Test pick count match; don't care about number of bans
+  mapPool = GetMapPool(9);
+  pickOrder.Clear();
+  pickOrder.Push(Get5VetoTypeTeam1Ban);
+  pickOrder.Push(Get5VetoTypeTeam1Pick);
+  pickOrder.Push(Get5VetoTypeTeam2Pick);
+  pickOrder.Push(Get5VetoTypeTeam1Pick);
+  pickOrder.Push(Get5VetoTypeTeam2Ban); // will be trimmed.
+  success = ValidateMapBanLogic(mapPool, pickOrder, 3, error);
+  delete mapPool;
+  AssertTrue("Test valid map ban config; bo3 9 maps, 3 picks, 2 bans", success);
+  AssertEq("Test pick order array resized to 4", 4, pickOrder.Length);
+
+  mapPool = GetMapPool(7);
+  pickOrder.Clear();
+  pickOrder.Push(Get5VetoTypeTeam1Ban);
+  pickOrder.Push(Get5VetoTypeTeam1Pick);
+  pickOrder.Push(Get5VetoTypeTeam1Ban);
+  pickOrder.Push(Get5VetoTypeTeam2Ban);
+  pickOrder.Push(Get5VetoTypeTeam2Pick);
+  pickOrder.Push(Get5VetoTypeTeam1Ban);
+  success = ValidateMapBanLogic(mapPool, pickOrder, 3, error);
+  delete mapPool;
+  AssertTrue("Test valid map ban config; bo3 7 maps, 2 picks, 4 ban, 1 remaining", success);
+
+  mapPool = GetMapPool(4);
+  pickOrder.Clear();
+  pickOrder.Push(Get5VetoTypeTeam1Pick);
+  pickOrder.Push(Get5VetoTypeTeam1Pick);
+  pickOrder.Push(Get5VetoTypeTeam1Pick);
+  success = ValidateMapBanLogic(mapPool, pickOrder, 3, error);
+  delete mapPool;
+  AssertTrue("Test valid map ban config; bo3 4 maps, 3 picks, 1 remaining", success);
+  AssertEq("Test pick order array remains at length 3", 3, pickOrder.Length);
+
+  mapPool = GetMapPool(4);
+  pickOrder.Clear();
+  pickOrder.Push(Get5VetoTypeTeam1Pick);
+  pickOrder.Push(Get5VetoTypeTeam1Pick);
+  pickOrder.Push(Get5VetoTypeTeam1Ban);
+  success = ValidateMapBanLogic(mapPool, pickOrder, 3, error);
+  delete mapPool;
+  AssertTrue("Test valid map ban config; bo3 4 maps, 2 picks, 1 ban", success);
+  AssertEq("Test pick order array remains at length 3 with ban", 3, pickOrder.Length);
+
+  mapPool = GetMapPool(7);
+  pickOrder.Clear();
+  pickOrder.Push(Get5VetoTypeTeam1Pick);
+  pickOrder.Push(Get5VetoTypeTeam2Pick);
+  pickOrder.Push(Get5VetoTypeTeam1Pick);
+  pickOrder.Push(Get5VetoTypeTeam2Pick); // removed
+  success = ValidateMapBanLogic(mapPool, pickOrder, 3, error);
+  delete mapPool;
+  AssertTrue("Test valid map ban config; bo3 7 maps, 4 picks", success);
+  AssertEq("Test pick order array trimmed to 3, 4th removed", 3, pickOrder.Length);
+
+  mapPool = GetMapPool(7);
+  pickOrder.Clear();
+  pickOrder.Push(Get5VetoTypeTeam1Ban);
+  pickOrder.Push(Get5VetoTypeTeam2Pick);
+  pickOrder.Push(Get5VetoTypeTeam1Ban);
+  pickOrder.Push(Get5VetoTypeTeam2Pick);
+  pickOrder.Push(Get5VetoTypeTeam1Ban);
+  pickOrder.Push(Get5VetoTypeTeam2Pick);
+  pickOrder.Push(Get5VetoTypeTeam1Ban);
+  pickOrder.Push(Get5VetoTypeTeam2Pick);
+  success = ValidateMapBanLogic(mapPool, pickOrder, 3, error);
+  delete mapPool;
+  AssertTrue("Test valid map ban config; bo3 7 maps, 4 picks 4 bans", success);
+  AssertEq("Test pick order array trimmed to 6 with bans", 6, pickOrder.Length);
+
+  mapPool = GetMapPool(9);
+  pickOrder.Clear();
+  pickOrder.Push(Get5VetoTypeTeam1Ban);
+  pickOrder.Push(Get5VetoTypeTeam2Ban);
+  pickOrder.Push(Get5VetoTypeTeam1Ban);
+  pickOrder.Push(Get5VetoTypeTeam2Pick);
+  pickOrder.Push(Get5VetoTypeTeam1Ban);
+  pickOrder.Push(Get5VetoTypeTeam2Pick);
+  pickOrder.Push(Get5VetoTypeTeam1Ban);
+  pickOrder.Push(Get5VetoTypeTeam2Pick);
+  success = ValidateMapBanLogic(mapPool, pickOrder, 3, error);
+  delete mapPool;
+  AssertTrue("Test valid map ban config; bo3 9 maps, 3 picks, 5 bans", success);
+  AssertEq("Test pick order array remains at size 8", 8, pickOrder.Length);
+
+  mapPool = GetMapPool(7);
+  pickOrder.Clear();
+  pickOrder.Push(Get5VetoTypeTeam1Ban);
+  pickOrder.Push(Get5VetoTypeTeam2Pick);
+  pickOrder.Push(Get5VetoTypeTeam1Ban);
+  pickOrder.Push(Get5VetoTypeTeam2Pick);
+  pickOrder.Push(Get5VetoTypeTeam1Ban);
+  success = ValidateMapBanLogic(mapPool, pickOrder, 3, error);
+  delete mapPool;
+  AssertFalse("Test invalid map ban config; bo3 7 maps, 2 picks, 3 bans; missing one pick or ban", success);
+
+  mapPool = GetMapPool(7);
+  pickOrder.Clear();
+  pickOrder.Push(Get5VetoTypeTeam1Ban);
+  pickOrder.Push(Get5VetoTypeTeam2Pick);
+  pickOrder.Push(Get5VetoTypeTeam1Ban);
+  pickOrder.Push(Get5VetoTypeTeam2Ban);
+  pickOrder.Push(Get5VetoTypeTeam1Ban);
+  success = ValidateMapBanLogic(mapPool, pickOrder, 3, error);
+  delete mapPool;
+  AssertFalse("Test invalid map ban config; bo3 7 maps, 1 pick, 4 bans; cannot randomly select remaining two", success);
+
+  mapPool = GetMapPool(7);
+  pickOrder.Clear();
+  pickOrder.Push(Get5VetoTypeTeam1Ban);
+  pickOrder.Push(Get5VetoTypeTeam2Ban);
+  pickOrder.Push(Get5VetoTypeTeam1Ban);
+  pickOrder.Push(Get5VetoTypeTeam2Ban);
+  pickOrder.Push(Get5VetoTypeTeam1Ban);
+  pickOrder.Push(Get5VetoTypeTeam2Pick);
+  success = ValidateMapBanLogic(mapPool, pickOrder, 1, error);
+  delete mapPool;
+  AssertTrue("Test valid map ban config; bo1 7 maps, 1 pick, 5 bans", success);
+
+  mapPool = GetMapPool(7);
+  pickOrder.Clear();
+  pickOrder.Push(Get5VetoTypeTeam1Ban);
+  pickOrder.Push(Get5VetoTypeTeam2Ban);
+  pickOrder.Push(Get5VetoTypeTeam1Ban);
+  pickOrder.Push(Get5VetoTypeTeam2Ban);
+  pickOrder.Push(Get5VetoTypeTeam1Ban);
+  pickOrder.Push(Get5VetoTypeTeam2Pick);
+  success = ValidateMapBanLogic(mapPool, pickOrder, 2, error);
+  delete mapPool;
+  AssertTrue("Test valid map ban config; bo2 7 maps, 5 bans 1 pick; last map played", success);
+
+  mapPool = GetMapPool(7);
+  pickOrder.Clear();
+  pickOrder.Push(Get5VetoTypeTeam1Ban);
+  pickOrder.Push(Get5VetoTypeTeam2Ban);
+  pickOrder.Push(Get5VetoTypeTeam1Ban);
+  pickOrder.Push(Get5VetoTypeTeam2Ban);
+  pickOrder.Push(Get5VetoTypeTeam1Ban);
+  pickOrder.Push(Get5VetoTypeTeam2Pick);
+  success = ValidateMapBanLogic(mapPool, pickOrder, 3, error);
+  delete mapPool;
+  AssertFalse("Test invalid map ban config; bo3 7 maps, 5 bans 1 pick; not enough picks", success);
+  AssertStrEq(
+    "Test not enough picks error",
+    "In a series of 3 maps, at least 2 veto options must be picks. Found 1 pick(s).",
+    error);
 }
 
 static void MissingPropertiesTest() {
@@ -135,7 +352,7 @@ static void MapListValid(const char[] file) {
   AssertTrue("Load valid fromfile maplist config", LoadMatchConfig(file, err));
   AssertEq("Map List Length", g_MapPoolList.Length, 3);
   g_MapPoolList.GetString(0, mapName, sizeof(mapName));
-  AssertStrEq("Map 1 Fromfile Name", mapName, "de_ancient");
+  AssertStrEq("Map 1 Fromfile Name", mapName, "de_dust2");
   g_MapPoolList.GetString(1, mapName, sizeof(mapName));
   AssertStrEq("Map 2 Fromfile Name", mapName, "de_overpass");
   g_MapPoolList.GetString(2, mapName, sizeof(mapName));
@@ -205,6 +422,19 @@ static void LoadTeamFromFileTest() {
   AssertEq("KV load team file invalid", StrContains(err, "Cannot read team config from KV file"), 0);
 
   EndSeries(Get5Team_None, false, 0.0);
+}
+
+static void CustomVetoConfigTest() {
+  SetTestContext("CustomVetoConfigTest");
+  char error[PLATFORM_MAX_PATH];
+
+  AssertTrue("Load match config custom veto", LoadMatchConfig("addons/sourcemod/configs/get5/tests/custom_veto.json", error));
+  AssertEq("Map ban length after load", g_MapBanOrder.Length, 4);
+  EndSeries(Get5Team_None, false, 0.0);
+
+  AssertFalse("Load match config invalid custom veto", LoadMatchConfig("addons/sourcemod/configs/get5/tests/custom_veto_invalid.json", error));
+  AssertStrEq("Load match config invalid custom veto error", "In a series of 3 maps, at least 2 veto options must be picks. Found 0 pick(s).", error);
+
 }
 
 static void ValidMatchConfigTest(const char[] matchConfig) {
@@ -469,3 +699,8 @@ static void AssertConVarEquals(const char[] conVarName, const char[] expectedVal
 static void AssertStrEq(const char[] text, const char[] value, const char[] expected) {
   AssertTrue(text, StrEqual(value, expected));
 }
+
+/*
+static void AssertStrContains(const char[] text, const char[] value, const char[] contains) {
+  AssertTrue(text, StrContains(value, contains));
+}*/

--- a/scripting/get5/util.sp
+++ b/scripting/get5/util.sp
@@ -331,6 +331,8 @@ stock void FormatMapName(const char[] mapName, char[] buffer, int len, bool clea
       strcopy(buffer, len, "Train");
     } else if (StrEqual(buffer, "de_cbble")) {
       strcopy(buffer, len, "Cobblestone");
+    } else if (StrEqual(buffer, "de_anubis")) {
+      strcopy(buffer, len, "Anubis");
     } else if (StrEqual(buffer, "de_overpass")) {
       strcopy(buffer, len, "Overpass");
     } else if (StrEqual(buffer, "de_nuke")) {
@@ -347,6 +349,16 @@ stock void FormatMapName(const char[] mapName, char[] buffer, int len, bool clea
       strcopy(buffer, len, "Grind");
     } else if (StrEqual(buffer, "de_mocha")) {
       strcopy(buffer, len, "Mocha");
+    } else if (StrEqual(buffer, "cs_militia")) {
+      strcopy(buffer, len, "Militia");
+    } else if (StrEqual(buffer, "cs_agency")) {
+      strcopy(buffer, len, "Agency");
+    } else if (StrEqual(buffer, "cs_office")) {
+      strcopy(buffer, len, "Office");
+    } else if (StrEqual(buffer, "cs_italy")) {
+      strcopy(buffer, len, "Italy");
+    } else if (StrEqual(buffer, "cs_assault")) {
+      strcopy(buffer, len, "Assault");
     }
   }
   if (color) {

--- a/scripting/get5/util.sp
+++ b/scripting/get5/util.sp
@@ -627,7 +627,7 @@ stock bool HelpfulAttack(int attacker, int victim) {
   return attacker != victim && GetClientTeam(attacker) != GetClientTeam(victim);
 }
 
-stock SideChoice SideTypeFromString(const char[] input) {
+stock SideChoice SideTypeFromString(const char[] input, char[] error) {
   if (StrEqual(input, "team1_ct", false) || StrEqual(input, "team2_t", false)) {
     return SideChoice_Team1CT;
   } else if (StrEqual(input, "team1_t", false) || StrEqual(input, "team2_ct", false)) {
@@ -635,8 +635,9 @@ stock SideChoice SideTypeFromString(const char[] input) {
   } else if (StrEqual(input, "knife", false)) {
     return SideChoice_KnifeRound;
   } else {
-    LogError("Invalid side choice \"%s\", falling back to knife round", input);
-    return SideChoice_KnifeRound;
+    FormatEx(error, PLATFORM_MAX_PATH,
+             "Invalid side choice '%s'. Must be one of 'team1_ct', 'team1_t', 'team2_ct', 'team2_t', 'knife'.", input);
+    return SideChoice_Invalid;
   }
 }
 

--- a/scripting/include/get5.inc
+++ b/scripting/include/get5.inc
@@ -19,12 +19,12 @@ enum Get5BombSite {
   Get5BombSite_B = 2
 };
 
-enum Get5VetoType {
-  Get5VetoTypeInvalid,
-  Get5VetoTypeTeam1Pick,
-  Get5VetoTypeTeam2Pick,
-  Get5VetoTypeTeam1Ban,
-  Get5VetoTypeTeam2Ban
+enum Get5MapSelectionOption {
+  Get5MapSelectionOption_Invalid,
+  Get5MapSelectionOption_Team1Pick,
+  Get5MapSelectionOption_Team2Pick,
+  Get5MapSelectionOption_Team1Ban,
+  Get5MapSelectionOption_Team2Ban
 }
 
 #define MATCHTEAM_COUNT 4

--- a/scripting/include/get5.inc
+++ b/scripting/include/get5.inc
@@ -19,6 +19,14 @@ enum Get5BombSite {
   Get5BombSite_B = 2
 };
 
+enum Get5VetoType {
+  Get5VetoTypeInvalid,
+  Get5VetoTypeTeam1Pick,
+  Get5VetoTypeTeam2Pick,
+  Get5VetoTypeTeam1Ban,
+  Get5VetoTypeTeam2Ban
+}
+
 #define MATCHTEAM_COUNT 4
 
 enum Get5Team {
@@ -79,6 +87,7 @@ enum SideChoice {
   SideChoice_Team1CT,     // Team 1 will start on CT
   SideChoice_Team1T,      // Team 1 will start on T
   SideChoice_KnifeRound,  // There will be a knife round to choose sides
+  SideChoice_Invalid
 };
 
 // Returns the current pug gamestate.

--- a/translations/chi/get5.phrases.txt
+++ b/translations/chi/get5.phrases.txt
@@ -1,6 +1,6 @@
 "Phrases"
 {
-    "ReadyToVetoInfoMessage"
+    "ReadyForMapSelectionInfoMessage"
     {
         "chi"            "当您的队伍准备好进行Veto(Ban图)时，请输入{1}。"
     }
@@ -32,7 +32,7 @@
     {
         "chi"            "{1}赢得刀局。等待他们输入{2}或是{3}来选择留下还是交换队伍。"
     }
-    "WaitingForGOTVBrodcastEndingInfoMessage"
+    "WaitingForGOTVBroadcastEnding"
     {
         "chi"            "当GOTV播放结束时，地图将被切换。"
     }
@@ -88,23 +88,23 @@
     {
         "chi"            "服务器上至少有{1}名玩家，您才能准备就绪。"
     }
-    "TeamReadyToVetoInfoMessage"
+    "TeamIsReadyForMapSelection"
     {
         "chi"            "{1}已准备好进行Veto(Ban图)。"
     }
-    "TeamReadyToRestoreBackupInfoMessage"
+    "TeamIsReadyToRestoreBackup"
     {
         "chi"            "{1}已准备好恢复比赛至备份档案。"
     }
-    "TeamReadyToKnifeInfoMessage"
+    "TeamIsReadyToKnife"
     {
         "chi"            "{1}已准备好拼刀选边。"
     }
-    "TeamReadyToBeginInfoMessage"
+    "TeamIsReadyToBegin"
     {
         "chi"            "{1}已准备好开始比赛。"
     }
-    "TeamNotReadyInfoMessage"
+    "TeamIsNoLongerReady"
     {
         "chi"            "{1}已不在准备就绪状态。"
     }
@@ -208,23 +208,23 @@
     {
         "chi"            "地图 {1}： {2}"
     }
-    "TeamPickedMapInfoMessage"
+    "TeamPickedMap"
     {
         "chi"            "{1}挑选了{2}作为地图 {3}"
     }
-    "TeamSelectSideInfoMessage"
+    "TeamSelectedSide"
     {
         "chi"            "{1}已选择在{2}开始 {3}"
     }
-    "TeamVetoedMapInfoMessage"
+    "TeamBannedMap"
     {
         "chi"            "{1}vetoed(Ban掉)了{2}"
     }
-    "CaptainLeftOnVetoInfoMessage"
+    "CaptainLeftDuringMapSelection"
     {
         "chi"            "一个队长在Veto(Ban图)期间离开，暂停Veto(Ban图)"
     }
-    "ReadyToResumeVetoInfoMessage"
+    "ReadyToResumeMapSelection"
     {
         "chi"            "当您准备好恢复Veto(Ban图)时，请输入{1}。"
     }
@@ -244,27 +244,27 @@
     {
         "chi"            "[未准备]"
     }
-    "MapVetoPickMenuText"
+    "MapSelectionPickMenuText"
     {
         "chi"        "请选择一张想玩的地图："
     }
-    "MapVetoPickConfirmMenuText"
+    "MapSelectionPickConfirmMenuText"
     {
         "chi"        "你确定想玩{1}："
     }
-    "MapVetoBanMenuText"
+    "MapSelectionBanMenuText"
     {
         "chi"        "请选择一张想VETO(Ban图)的地图："
     }
-    "MapVetoBanConfirmMenuText"
+    "MapSelectionBanConfirmMenuText"
     {
         "chi"        "你确定想VETO(Ban图){1}："
     }
-    "MapVetoSidePickMenuText"
+    "MapSelectionSidePickMenuText"
     {
         "chi"        "请为{1}选择队伍"
     }
-    "MapVetoSidePickConfirmMenuText"
+    "MapSelectionSidePickConfirmMenuText"
     {
         "chi"        "你确定想开始{1}："
     }
@@ -276,7 +276,7 @@
     {
         "chi"        "否"
     }
-    "VetoCountdown"
+    "MapSelectionCountdown"
     {
         "chi"        "Veto(Ban图)还剩{1}秒。"
     }

--- a/translations/da/get5.phrases.txt
+++ b/translations/da/get5.phrases.txt
@@ -1,8 +1,8 @@
 "Phrases"
 {
-    "ReadyToVetoInfoMessage"
+    "ReadyForMapSelectionInfoMessage"
     {
-        "da"            "Skriv {1} når dit hold er klar til at veto."
+        "da"            "Skriv {1}, når dit hold er klar til map-valg."
     }
     "WaitingForCastersReadyInfoMessage"
     {
@@ -40,13 +40,13 @@
     {
         "da"            "{1} vandt knife-runden. Venter på, at de skriver {2} eller {3}."
     }
-    "WaitingForGOTVBrodcastEndingInfoMessage"
+    "WaitingForGOTVBroadcastEnding"
     {
-        "da"            "Dette map vil skifte når nuværende GOTV broadcast er slut."
+        "da"            "Mappet skifter, når GOTV har vist kampen."
     }
-    "WaitingForGOTVVetoInfoMessage"
+    "WaitingForGOTVMapSelection"
     {
-        "da"            "Dette map vil skifte når nuværende GOTV broadcast har fået map vetos vist."
+        "da"            "Mappet skifter, når GOTV har vist map-valg."
     }
     "NoMatchSetupInfoMessage"
     {
@@ -180,23 +180,23 @@
     {
         "da"            "Der skal være minimum {1} spiller(e) på serveren for at gøre klar."
     }
-    "TeamReadyToVetoInfoMessage"
+    "TeamIsReadyForMapSelection"
     {
-        "da"            "{1} er klar til at veto."
+        "da"            "{1} er klar til map-valg."
     }
-    "TeamReadyToRestoreBackupInfoMessage"
+    "TeamIsReadyToRestoreBackup"
     {
-        "da"            "{1} er klar til at genoprette match fra backup."
+        "da"            "{1} er klar til at genoprette kampen fra backup."
     }
-    "TeamReadyToKnifeInfoMessage"
+    "TeamIsReadyToKnife"
     {
         "da"            "{1} er klar til at knife om side."
     }
-    "TeamReadyToBeginInfoMessage"
+    "TeamIsReadyToBegin"
     {
         "da"            "{1} er klar til at begynde kampen."
     }
-    "TeamNotReadyInfoMessage"
+    "TeamIsNoLongerReady"
     {
         "da"            "{1} er ikke længere klar."
     }
@@ -324,25 +324,25 @@
     {
         "da"            "Map {1}: {2}"
     }
-    "TeamPickedMapInfoMessage"
+    "TeamPickedMap"
     {
         "da"            "{1} valgte {2} som deres {3}. map."
     }
-    "TeamSelectSideInfoMessage"
+    "TeamSelectedSide"
     {
         "da"            "{1} har valgt at start som {2} på {3}."
     }
-    "TeamVetoedMapInfoMessage"
+    "TeamBannedMap"
     {
-        "da"            "{1} vetoed {2}."
+        "da"            "{1} bannede {2}."
     }
-    "CaptainLeftOnVetoInfoMessage"
+    "CaptainLeftDuringMapSelection"
     {
-        "da"            "En kaptajn forlod kampen under veto, pauser vetoen."
+        "da"            "En holdkaptajn forlod kampen under map-valg. Map-valg er på pause."
     }
-    "ReadyToResumeVetoInfoMessage"
+    "ReadyToResumeMapSelection"
     {
-        "da"            "Skriv {1}, når du er klar til at genoptage veto."
+        "da"            "Skriv {1}, når du er klar til at genoptage map-valg."
     }
     "MatchConfigLoadedInfoMessage"
     {
@@ -388,27 +388,27 @@
     {
         "da"            "[IKKE KLAR]"
     }
-    "MapVetoPickMenuText"
+    "MapSelectionPickMenuText"
     {
-        "da"        "Vælg et map at spille:"
+        "da"        "Vælg et map at SPILLE:"
     }
-    "MapVetoPickConfirmMenuText"
+    "MapSelectionPickConfirmMenuText"
     {
-        "da"        "Bekræft, at du vil spille {1}:"
+        "da"        "Bekræft, at du vil SPILLE {1}:"
     }
-    "MapVetoBanMenuText"
+    "MapSelectionBanMenuText"
     {
-        "da"        "Vælg et map at VETO:"
+        "da"        "Vælg et map at BANNE:"
     }
-    "MapVetoBanConfirmMenuText"
+    "MapSelectionBanConfirmMenuText"
     {
-        "da"        "Bekræft, at du vil VETO {1}:"
+        "da"        "Bekræft, at du vil BANNE {1}:"
     }
-    "MapVetoSidePickMenuText"
+    "MapSelectionSidePickMenuText"
     {
         "da"        "Vælg en side på {1}"
     }
-    "MapVetoSidePickConfirmMenuText"
+    "MapSelectionSidePickConfirmMenuText"
     {
         "da"        "Bekræft, at du vil starte {1}:"
     }
@@ -420,9 +420,9 @@
     {
         "da"        "Nej"
     }
-    "VetoCountdown"
+    "MapSelectionCountdown"
     {
-        "da"        "Veto begynder om {1} sekunder."
+        "da"        "Map-valg begynder om {1} sekunder."
     }
     "SurrenderCommandNotEnabled"
     {

--- a/translations/de/get5.phrases.txt
+++ b/translations/de/get5.phrases.txt
@@ -1,6 +1,6 @@
 "Phrases"
 {
-    "ReadyToVetoInfoMessage"
+    "ReadyForMapSelectionInfoMessage"
     {
         "de"            "Tippe {1} wenn dein Team bereit zum Abstimmen ist."
     }
@@ -40,11 +40,11 @@
     {
         "de"            "{1} hat die Messerrunde gewonnen und darf somit die Seite zum starten wählen. Dies muss durch die Eingabe von {2} oder {3} geschehen."
     }
-    "WaitingForGOTVBrodcastEndingInfoMessage"
+    "WaitingForGOTVBroadcastEnding"
     {
         "de"            "Die Map wird gewechselt sobald die GOTV Übertragung beendet ist."
     }
-    "WaitingForGOTVVetoInfoMessage"
+    "WaitingForGOTVMapSelection"
     {
         "de"            "Die Map wird gewechselt sobald die Map Vetos von GOTV übertragen wurden."
     }
@@ -180,23 +180,23 @@
     {
         "de"            "Du musst mindestens {1} Spieler im Team haben um das Team als bereit zu markieren."
     }
-    "TeamReadyToVetoInfoMessage"
+    "TeamIsReadyForMapSelection"
     {
         "de"            "{1} ist bereit für das Mapveto."
     }
-    "TeamReadyToRestoreBackupInfoMessage"
+    "TeamIsReadyToRestoreBackup"
     {
         "de"            "{1} ist bereit eine Spielsicherung wieder einzuspielen."
     }
-    "TeamReadyToKnifeInfoMessage"
+    "TeamIsReadyToKnife"
     {
         "de"            "{1} ist bereit für die Messerrunde."
     }
-    "TeamReadyToBeginInfoMessage"
+    "TeamIsReadyToBegin"
     {
         "de"            "{1} ist bereit das Spiel zu beginnen."
     }
-    "TeamNotReadyInfoMessage"
+    "TeamIsNoLongerReady"
     {
         "de"            "{1} ist nicht mehr bereit."
     }
@@ -324,23 +324,23 @@
     {
         "de"            "Map {1}: {2}"
     }
-    "TeamPickedMapInfoMessage"
+    "TeamPickedMap"
     {
         "de"            "{1} wählte {2} als Map aus {3}."
     }
-    "TeamSelectSideInfoMessage"
+    "TeamSelectedSide"
     {
         "de"            "{1} möchte auf {3} als {2} starten."
     }
-    "TeamVetoedMapInfoMessage"
+    "TeamBannedMap"
     {
         "de"            "{1} legte ein veto gegen {2} ein."
     }
-    "CaptainLeftOnVetoInfoMessage"
+    "CaptainLeftDuringMapSelection"
     {
         "de"            "Der Team Captian hat das Spiel während der Vetophase verlassen, daher wird das Veto pausiert."
     }
-    "ReadyToResumeVetoInfoMessage"
+    "ReadyToResumeMapSelection"
     {
         "de"            "Tippe {1} wenn ihr bereit seid mit der Vetophase fortzufahren."
     }
@@ -388,27 +388,27 @@
     {
         "de"            "[NICHT BEREIT]"
     }
-    "MapVetoPickMenuText"
+    "MapSelectionPickMenuText"
     {
         "de"            "Wähle eine Karte die GESPIELT werden soll:"
     }
-    "MapVetoPickConfirmMenuText"
+    "MapSelectionPickConfirmMenuText"
     {
         "de"            "Bestätige dass {1} GESPIELT werden soll:"
     }
-    "MapVetoBanMenuText"
+    "MapSelectionBanMenuText"
     {
         "de"            "Lege ein Veto gegen eine Karte ein:"
     }
-    "MapVetoBanConfirmMenuText"
+    "MapSelectionBanConfirmMenuText"
     {
         "de"            "Bestätige ein VETO gegen {1} eingelegt werden soll:"
     }
-    "MapVetoSidePickMenuText"
+    "MapSelectionSidePickMenuText"
     {
         "de"            "Wähle die Seite für {1}:"
     }
-    "MapVetoSidePickConfirmMenuText"
+    "MapSelectionSidePickConfirmMenuText"
     {
         "de"            "Bestätige dass ihr auf der Seite {1} starten wollt:"
     }
@@ -420,7 +420,7 @@
     {
         "de"            "Nein"
     }
-    "VetoCountdown"
+    "MapSelectionCountdown"
     {
         "de"            "Die Vetophase beginnt in {1} Sekunden."
     }

--- a/translations/es/get5.phrases.txt
+++ b/translations/es/get5.phrases.txt
@@ -1,6 +1,6 @@
 "Phrases"
 {
-    "ReadyToVetoInfoMessage"
+    "ReadyForMapSelectionInfoMessage"
     {
         "es"            "Teclee {1} cuando su equipo este listo para la ronda veto."
     }
@@ -32,11 +32,11 @@
     {
         "es"            "{1} ganó la ronda Knife. Esperando la elección entre {2} o {3}."
     }
-    "WaitingForGOTVBrodcastEndingInfoMessage"
+    "WaitingForGOTVBroadcastEnding"
     {
         "es"            "El mapa cambiara cuando termine la difusion GOTV en curso."
     }
-    "WaitingForGOTVVetoInfoMessage"
+    "WaitingForGOTVMapSelection"
     {
         "es"            "El mapa cambiara cuando termine la difusion GOTV de la ronda Knife."
     }
@@ -100,23 +100,23 @@
     {
         "es"            "Necesita por lo menos {1} jugadores en el servidor para declararse listo."
     }
-    "TeamReadyToVetoInfoMessage"
+    "TeamIsReadyForMapSelection"
     {
         "es"            "{1} está listo para la ronda."
     }
-    "TeamReadyToRestoreBackupInfoMessage"
+    "TeamIsReadyToRestoreBackup"
     {
         "es"            "{1} está listo para restaurar el backup de la partida."
     }
-    "TeamReadyToKnifeInfoMessage"
+    "TeamIsReadyToKnife"
     {
         "es"            "{1} está listo para la ronda Knife."
     }
-    "TeamReadyToBeginInfoMessage"
+    "TeamIsReadyToBegin"
     {
         "es"            "{1} está listo para empezar la partida."
     }
-    "TeamNotReadyInfoMessage"
+    "TeamIsNoLongerReady"
     {
         "es"            "{1} ya no esta listo."
     }
@@ -228,23 +228,23 @@
     {
         "es"            "Map {1}: {2}"
     }
-    "TeamPickedMapInfoMessage"
+    "TeamPickedMap"
     {
         "es"            "{1} eligió {2} de mapa {3}."
     }
-    "TeamSelectSideInfoMessage"
+    "TeamSelectedSide"
     {
         "es"            "{1} eligió empezar con {2} sobre {3}."
     }
-    "TeamVetoedMapInfoMessage"
+    "TeamBannedMap"
     {
         "es"            "{1} rechazó {2}."
     }
-    "CaptainLeftOnVetoInfoMessage"
+    "CaptainLeftDuringMapSelection"
     {
         "es"            "Un jefe de equipo se fue durante el veto, partida en pausa."
     }
-    "ReadyToResumeVetoInfoMessage"
+    "ReadyToResumeMapSelection"
     {
         "es"            "Teclee {1} cuando este listo para retomar la partida de veto."
     }
@@ -272,27 +272,27 @@
     {
         "es"            "[NO LISTO]"
     }
-    "MapVetoPickMenuText"
+    "MapSelectionPickMenuText"
     {
         "es"        "Seleccionar una mapa para el juego:"
     }
-    "MapVetoPickConfirmMenuText"
+    "MapSelectionPickConfirmMenuText"
     {
         "es"        "Confirmar que quiere jugar {1}:"
     }
-    "MapVetoBanMenuText"
+    "MapSelectionBanMenuText"
     {
         "es"        "Seleccionar un mapa a banear:"
     }
-    "MapVetoBanConfirmMenuText"
+    "MapSelectionBanConfirmMenuText"
     {
         "es"        "Confirmar que quiere banear {1}:"
     }
-    "MapVetoSidePickMenuText"
+    "MapSelectionSidePickMenuText"
     {
         "es"        "Seleccionar un lado para {1}"
     }
-    "MapVetoSidePickConfirmMenuText"
+    "MapSelectionSidePickConfirmMenuText"
     {
         "es"        "Confirmar que quiere empezar {1}:"
     }
@@ -304,7 +304,7 @@
     {
         "es"        "No"
     }
-    "VetoCountdown"
+    "MapSelectionCountdown"
     {
         "es"        "El veto comenzará en {1} segundos."
     }

--- a/translations/fr/get5.phrases.txt
+++ b/translations/fr/get5.phrases.txt
@@ -1,6 +1,6 @@
 "Phrases"
 {
-    "ReadyToVetoInfoMessage"
+    "ReadyForMapSelectionInfoMessage"
     {
         "fr"            "Taper {1} quand votre équipe est prête pour le tour de veto."
     }
@@ -40,11 +40,11 @@
     {
         "fr"            "{1} a gagné le round au couteau. En attente de leur choix entre {2} et {3}."
     }
-    "WaitingForGOTVBrodcastEndingInfoMessage"
+    "WaitingForGOTVBroadcastEnding"
     {
         "fr"            "La map changera dès que la diffusion GOTV sera terminée."
     }
-    "WaitingForGOTVVetoInfoMessage"
+    "WaitingForGOTVMapSelection"
     {
         "fr"            "La map changera dès que la diffusion GOTV aura diffusé le tour de veto."
     }
@@ -180,23 +180,23 @@
     {
         "fr"            "Vous devez disposer d'au moins {1} joueur(s) sur le serveur pour vous déclarer prêt(e)."
     }
-    "TeamReadyToVetoInfoMessage"
+    "TeamIsReadyForMapSelection"
     {
         "fr"            "{1} est prêt pour le tour de veto."
     }
-    "TeamReadyToRestoreBackupInfoMessage"
+    "TeamIsReadyToRestoreBackup"
     {
         "fr"            "{1} est prêt à restaurer la sauvegarde du match."
     }
-    "TeamReadyToKnifeInfoMessage"
+    "TeamIsReadyToKnife"
     {
         "fr"            "{1} est prêt pour le knife round."
     }
-    "TeamReadyToBeginInfoMessage"
+    "TeamIsReadyToBegin"
     {
         "fr"            "{1} est prêt à commencer le match."
     }
-    "TeamNotReadyInfoMessage"
+    "TeamIsNoLongerReady"
     {
         "fr"            "{1} n'est plus prêt."
     }
@@ -324,23 +324,23 @@
     {
         "fr"            "Map {1}: {2}"
     }
-    "TeamPickedMapInfoMessage"
+    "TeamPickedMap"
     {
         "fr"            "{1} a choisi {2} comme map {3}."
     }
-    "TeamSelectSideInfoMessage"
+    "TeamSelectedSide"
     {
         "fr"            "{1} a choisi de commencer en {2} sur {3}."
     }
-    "TeamVetoedMapInfoMessage"
+    "TeamBannedMap"
     {
         "fr"            "{1} a rejeté {2}."
     }
-    "CaptainLeftOnVetoInfoMessage"
+    "CaptainLeftDuringMapSelection"
     {
         "fr"            "Un chef d'équipe a quitté pendant le tour de veto, match en pause."
     }
-    "ReadyToResumeVetoInfoMessage"
+    "ReadyToResumeMapSelection"
     {
         "fr"            "Taper {1} quand vous êtes prêt(e) à reprendre le tour de veto."
     }
@@ -388,27 +388,27 @@
     {
         "fr"            "[PAS PRÊT]"
     }
-    "MapVetoPickMenuText"
+    "MapSelectionPickMenuText"
     {
         "fr"        "Selectionnez une map à JOUER :"
     }
-    "MapVetoPickConfirmMenuText"
+    "MapSelectionPickConfirmMenuText"
     {
         "fr"        "Confirmez que vous souhaitez jouer {1} :"
     }
-    "MapVetoBanMenuText"
+    "MapSelectionBanMenuText"
     {
         "fr"        "Selectionnez une map à BANNIR :"
     }
-    "MapVetoBanConfirmMenuText"
+    "MapSelectionBanConfirmMenuText"
     {
         "fr"        "Confirmez que vous souhaitez la bannir {1} :"
     }
-    "MapVetoSidePickMenuText"
+    "MapSelectionSidePickMenuText"
     {
         "fr"        "Selectionner un côté pour {1}"
     }
-    "MapVetoSidePickConfirmMenuText"
+    "MapSelectionSidePickConfirmMenuText"
     {
         "fr"        "Confirmez que vous voulez commencer {1} :"
     }
@@ -420,7 +420,7 @@
     {
         "fr"        "Non"
     }
-    "VetoCountdown"
+    "MapSelectionCountdown"
     {
         "fr"        "Le veto commencera dans {1} seconde(s)."
     }

--- a/translations/get5.phrases.txt
+++ b/translations/get5.phrases.txt
@@ -1,9 +1,9 @@
 "Phrases"
 {
-    "ReadyToVetoInfoMessage"
+    "ReadyForMapSelectionInfoMessage"
     {
         "#format"       "{1:s}"
-        "en"            "Type {1} when your team is ready to veto."
+        "en"            "Type {1} when your team is ready for map selection."
     }
     "WaitingForCastersReadyInfoMessage"
     {
@@ -47,13 +47,13 @@
         "#format"       "{1:s},{2:s},{3:s}"
         "en"            "{1} won the knife round. Waiting for them to type {2} or {3}."
     }
-    "WaitingForGOTVBrodcastEndingInfoMessage"
+    "WaitingForGOTVBroadcastEnding"
     {
-        "en"            "The map will change once the GOTV broadcast has ended."
+        "en"            "The map will change once GOTV has finished broadcasting."
     }
-    "WaitingForGOTVVetoInfoMessage"
+    "WaitingForGOTVMapSelection"
     {
-        "en"            "The map will change once the GOTV broadcast has displayed the map vetos."
+        "en"            "The map will change once GOTV has broadcast the map selection."
     }
     "NoMatchSetupInfoMessage"
     {
@@ -206,27 +206,27 @@
         "#format"       "{1:d}"
         "en"            "You must have at least {1} player(s) on the server to ready up."
     }
-    "TeamReadyToVetoInfoMessage"
+    "TeamIsReadyForMapSelection"
     {
         "#format"       "{1:s}"
-        "en"            "{1} is ready to veto."
+        "en"            "{1} is ready for map selection."
     }
-    "TeamReadyToRestoreBackupInfoMessage"
+    "TeamIsReadyToRestoreBackup"
     {
         "#format"       "{1:s}"
         "en"            "{1} is ready to restore the match backup."
     }
-    "TeamReadyToKnifeInfoMessage"
+    "TeamIsReadyToKnife"
     {
         "#format"       "{1:s}"
         "en"            "{1} is ready to knife for sides."
     }
-    "TeamReadyToBeginInfoMessage"
+    "TeamIsReadyToBegin"
     {
         "#format"       "{1:s}"
         "en"            "{1} is ready to begin the match."
     }
-    "TeamNotReadyInfoMessage"
+    "TeamIsNoLongerReady"
     {
         "#format"       "{1:s}"
         "en"            "{1} is no longer ready."
@@ -375,29 +375,29 @@
         "#format"       "{1:d},{2:s}"
         "en"            "Map {1}: {2}"
     }
-    "TeamPickedMapInfoMessage"
+    "TeamPickedMap"
     {
         "#format"       "{1:s},{2:s},{3:d}"
         "en"            "{1} picked {2} as map {3}."
     }
-    "TeamSelectSideInfoMessage"
+    "TeamSelectedSide"
     {
         "#format"       "{1:s},{2:s},{3:s}"
-        "en"            "{1} has selected to start on {2} on {3}."
+        "en"            "{1} has elected to start as {2} on {3}."
     }
-    "TeamVetoedMapInfoMessage"
+    "TeamBannedMap"
     {
         "#format"       "{1:s},{2:s}"
-        "en"            "{1} vetoed {2}."
+        "en"            "{1} banned {2}."
     }
-    "CaptainLeftOnVetoInfoMessage"
+    "CaptainLeftDuringMapSelection"
     {
-        "en"            "A captain left during the veto, pausing the veto."
+        "en"            "A team captain left during map selection. Map selection is paused."
     }
-    "ReadyToResumeVetoInfoMessage"
+    "ReadyToResumeMapSelection"
     {
         "#format"       "{1:s}"
-        "en"            "Type {1} when you are ready to resume the veto."
+        "en"            "Type {1} when you are ready to resume map selection."
     }
     "MatchConfigLoadedInfoMessage"
     {
@@ -448,30 +448,30 @@
     {
         "en"            "[NOT READY]"
     }
-    "MapVetoPickMenuText"
+    "MapSelectionPickMenuText"
     {
         "en"        "Select a map to PLAY:"
     }
-    "MapVetoPickConfirmMenuText"
+    "MapSelectionPickConfirmMenuText"
     {
         "#format"       "{1:s}"
         "en"        "Confirm you want to PLAY {1}:"
     }
-    "MapVetoBanMenuText"
+    "MapSelectionBanMenuText"
     {
-        "en"        "Select a map to VETO:"
+        "en"        "Select a map to BAN:"
     }
-    "MapVetoBanConfirmMenuText"
+    "MapSelectionBanConfirmMenuText"
     {
         "#format"       "{1:s}"
-        "en"        "Confirm you want to VETO {1}:"
+        "en"        "Confirm you want to BAN {1}:"
     }
-    "MapVetoSidePickMenuText"
+    "MapSelectionSidePickMenuText"
     {
         "#format"       "{1:s}"
         "en"        "Select a side for {1}:"
     }
-    "MapVetoSidePickConfirmMenuText"
+    "MapSelectionSidePickConfirmMenuText"
     {
         "#format"       "{1:s}"
         "en"        "Confirm you want to start {1}:"
@@ -484,10 +484,10 @@
     {
         "en"        "No"
     }
-    "VetoCountdown"
+    "MapSelectionCountdown"
     {
         "#format"   "{1:s}"
-        "en"        "Veto commencing in {1} seconds."
+        "en"        "Map selection commencing in {1}..."
     }
     "SurrenderCommandNotEnabled"
     {

--- a/translations/hu/get5.phrases.txt
+++ b/translations/hu/get5.phrases.txt
@@ -1,6 +1,6 @@
 "Phrases"
 {
-    "ReadyToVetoInfoMessage"
+    "ReadyForMapSelectionInfoMessage"
     {
         "hu"            "Írd be a {1} parancsot, ha a csapatod készen áll a vétóra."
     }
@@ -40,11 +40,11 @@
     {
         "hu"            "{1} nyerte meg a kés kört. Várakozunk, hogy kiválasszák a megfelelő oldalt. {2} vagy {3}."
     }
-    "WaitingForGOTVBrodcastEndingInfoMessage"
+    "WaitingForGOTVBroadcastEnding"
     {
         "hu"            "A pálya akkor fog váltani, ha a GOTV adás befejeződött."
     }
-    "WaitingForGOTVVetoInfoMessage"
+    "WaitingForGOTVMapSelection"
     {
         "hu"            "A pálya akkor fog váltani, ha a GOTV adás megjelenítette a pálya vétókat."
     }
@@ -176,23 +176,23 @@
     {
         "hu"            "A szerveren legalább {1} játékosnak készen kell állnia a kezdéshez."
     }
-    "TeamReadyToVetoInfoMessage"
+    "TeamIsReadyForMapSelection"
     {
         "hu"            "{1} készenáll a vétó megkezdésére."
     }
-    "TeamReadyToRestoreBackupInfoMessage"
+    "TeamIsReadyToRestoreBackup"
     {
         "hu"            "{1} készen áll a mérkőzés visszaállítására."
     }
-    "TeamReadyToKnifeInfoMessage"
+    "TeamIsReadyToKnife"
     {
         "hu"            "{1} készenáll, hogy késeljen az oldalért."
     }
-    "TeamReadyToBeginInfoMessage"
+    "TeamIsReadyToBegin"
     {
         "hu"            "{1} készen áll a mérkőzés megkezdésére."
     }
-    "TeamNotReadyInfoMessage"
+    "TeamIsNoLongerReady"
     {
         "hu"            "{1} már nem áll készen."
     }
@@ -304,23 +304,23 @@
     {
         "hu"            "{1}. Pálya: {2}"
     }
-    "TeamPickedMapInfoMessage"
+    "TeamPickedMap"
     {
         "hu"            "{1} választotta a {2} {3}. pályának."
     }
-    "TeamSelectSideInfoMessage"
+    "TeamSelectedSide"
     {
         "hu"            "{1} választott, hogy kezd {2} oldalon a(z) {3}. pályán."
     }
-    "TeamVetoedMapInfoMessage"
+    "TeamBannedMap"
     {
         "hu"            "{1} szavazott {2}."
     }
-    "CaptainLeftOnVetoInfoMessage"
+    "CaptainLeftDuringMapSelection"
     {
         "hu"            "A csapatkapitány kilépett a vétó során, a vétó szünetel."
     }
-    "ReadyToResumeVetoInfoMessage"
+    "ReadyToResumeMapSelection"
     {
         "hu"            "Írd be a {1} parancsot ha készenállsz a vétó folytatására."
     }
@@ -348,27 +348,27 @@
     {
         "hu"            "[NEM ÁLL KÉSZEN]"
     }
-    "MapVetoPickMenuText"
+    "MapSelectionPickMenuText"
     {
         "hu"            "Válassz pályát, amin játszanál:"
     }
-    "MapVetoPickConfirmMenuText"
+    "MapSelectionPickConfirmMenuText"
     {
         "hu"            "Erősítse meg, hogy játszana {1}:"
     }
-    "MapVetoBanMenuText"
+    "MapSelectionBanMenuText"
     {
         "hu"            "Válaszon egy pályát amit vétózna:"
     }
-    "MapVetoBanConfirmMenuText"
+    "MapSelectionBanConfirmMenuText"
     {
         "hu"            "Erősítse meg, hogy vétózza a {1} pályát:"
     }
-    "MapVetoSidePickMenuText"
+    "MapSelectionSidePickMenuText"
     {
         "hu"            "Válasszon oldalt {1}:"
     }
-    "MapVetoSidePickConfirmMenuText"
+    "MapSelectionSidePickConfirmMenuText"
     {
         "hu"            "Erősítse meg, hogy {1}-ben kezd:"
     }
@@ -380,7 +380,7 @@
     {
         "hu"            "Nem"
     }
-    "VetoCountdown"
+    "MapSelectionCountdown"
     {
         "hu"            "Kezdődik a vétózás {1} másodperc múlva."
     }

--- a/translations/pl/get5.phrases.txt
+++ b/translations/pl/get5.phrases.txt
@@ -1,6 +1,6 @@
 "Phrases"
 {
-    "ReadyToVetoInfoMessage"
+    "ReadyForMapSelectionInfoMessage"
     {
         "pl"            "Napisz {1} kiedy Twoja drużyna będzie gotowa do głosowania."
     }
@@ -24,7 +24,7 @@
     {
         "pl"            "{1} wygralo runde nożową. Oczekiwanie na {2} lub {3}."
     }
-    "WaitingForGOTVBrodcastEndingInfoMessage"
+    "WaitingForGOTVBroadcastEnding"
     {
         "pl"            "Mapa zostanie zmieniona gdy transmisja GOTV zostanie zakończona."
     }
@@ -84,23 +84,23 @@
     {
         "pl"            "Musi być conajmniej {1} graczy na serwerze aby móc być gotowym."
     }
-    "TeamReadyToVetoInfoMessage"
+    "TeamIsReadyForMapSelection"
     {
         "pl"            "{1} jest gotowe do głosowania."
     }
-    "TeamReadyToRestoreBackupInfoMessage"
+    "TeamIsReadyToRestoreBackup"
     {
         "pl"            "{1} jest gotowe do przywrócenia meczu."
     }
-    "TeamReadyToKnifeInfoMessage"
+    "TeamIsReadyToKnife"
     {
         "pl"            "{1} jest gotowe do nożówki za strony."
     }
-    "TeamReadyToBeginInfoMessage"
+    "TeamIsReadyToBegin"
     {
         "pl"            "{1} jest gotowe do rozpoczęcia meczu."
     }
-    "TeamNotReadyInfoMessage"
+    "TeamIsNoLongerReady"
     {
         "pl"            "{1} anulowali swoją gotowość."
     }
@@ -200,23 +200,23 @@
     {
         "pl"            "Mapa {1}: {2}"
     }
-    "TeamPickedMapInfoMessage"
+    "TeamPickedMap"
     {
         "pl"            "{1} wybrało {2} jako mapę {3}."
     }
-    "TeamSelectSideInfoMessage"
+    "TeamSelectedSide"
     {
         "pl"            "{1} wybrało stronę {2} na {3}."
     }
-    "TeamVetoedMapInfoMessage"
+    "TeamBannedMap"
     {
         "pl"            "{1} odrzuciło {2}."
     }
-    "CaptainLeftOnVetoInfoMessage"
+    "CaptainLeftDuringMapSelection"
     {
         "pl"            "Kapitan opuścił serwer, głosowanie zostało wstrzymane."
     }
-    "ReadyToResumeVetoInfoMessage"
+    "ReadyToResumeMapSelection"
     {
         "pl"            "Napisz {1} kiedy Twoja drużyna będzie gotowa do wznowienia głosowania."
     }

--- a/translations/pt/get5.phrases.txt
+++ b/translations/pt/get5.phrases.txt
@@ -2,7 +2,7 @@
 {
     "ReadyForMapSelectionInfoMessage"
     {
-        "pt"            "Digite {1} quando seu time estiver pronto para o veto."
+        "pt"            "Digite {1} quando seu time estiver pronto para a seleção de mapas."
     }
     "WaitingForCastersReadyInfoMessage"
     {
@@ -46,7 +46,7 @@
     }
     "WaitingForGOTVMapSelection"
     {
-        "pt"            "O mapa mudará assim que a transmissão da GOTV exibir os vetos do mapa."
+        "pt"            "O mapa mudará assim que a GOTV transmitir a seleção do mapa."
     }
     "NoMatchSetupInfoMessage"
     {
@@ -186,7 +186,7 @@
     }
     "TeamIsReadyForMapSelection"
     {
-        "pt"            "{1} está pronto para o veto."
+        "pt"            "{1} está pronto para a seleção de mapa."
     }
     "TeamIsReadyToRestoreBackup"
     {
@@ -322,15 +322,15 @@
     }
     "TeamBannedMap"
     {
-        "pt"            "{1} vetou {2}."
+        "pt"            "{1} baniu {2}."
     }
     "CaptainLeftDuringMapSelection"
     {
-        "pt"            "Um capitão deixou a partida durante o veto, pausando o veto."
+        "pt"            "A seleção de mapas foi pausada porque um capitão de time saiu."
     }
     "ReadyToResumeMapSelection"
     {
-        "pt"            "Digite {1} quando você estiver pronto para resumir o veto."
+        "pt"            "Digite {1} quando você estiver pronto para retomar a seleção de mapas."
     }
     "MatchConfigLoadedInfoMessage"
     {
@@ -386,11 +386,11 @@
     }
     "MapSelectionBanMenuText"
     {
-        "pt"        "Selecione um mapa para VETAR:"
+        "pt"        "Selecione um mapa para BANIR:"
     }
     "MapSelectionBanConfirmMenuText"
     {
-        "pt"        "Confirme que você quer VETAR {1}:"
+        "pt"        "Confirme que você quer BANIR {1}:"
     }
     "MapSelectionSidePickMenuText"
     {
@@ -410,7 +410,7 @@
     }
     "MapSelectionCountdown"
     {
-        "pt"        "Veto começando em {1} segundos."
+        "pt"        "Seleção de mapas começando em {1}..."
     }
     "SurrenderCommandNotEnabled"
     {

--- a/translations/pt/get5.phrases.txt
+++ b/translations/pt/get5.phrases.txt
@@ -1,6 +1,6 @@
 "Phrases"
 {
-    "ReadyToVetoInfoMessage"
+    "ReadyForMapSelectionInfoMessage"
     {
         "pt"            "Digite {1} quando seu time estiver pronto para o veto."
     }
@@ -40,11 +40,11 @@
     {
         "pt"            "{1} venceu o Round Faca. Esperando pelo time vencedor digitar {2} ou {3}."
     }
-    "WaitingForGOTVBrodcastEndingInfoMessage"
+    "WaitingForGOTVBroadcastEnding"
     {
         "pt"            "O mapa vai mudar assim que o transmissão do GOTV acabar."
     }
-    "WaitingForGOTVVetoInfoMessage"
+    "WaitingForGOTVMapSelection"
     {
         "pt"            "O mapa mudará assim que a transmissão da GOTV exibir os vetos do mapa."
     }
@@ -184,23 +184,23 @@
     {
         "pt"            "Você precisa ter pelo menos {1} jogadores conectados no servidor para ficar pronto."
     }
-    "TeamReadyToVetoInfoMessage"
+    "TeamIsReadyForMapSelection"
     {
         "pt"            "{1} está pronto para o veto."
     }
-    "TeamReadyToRestoreBackupInfoMessage"
+    "TeamIsReadyToRestoreBackup"
     {
         "pt"            "{1} está pronto para restaurar o backup da partida."
     }
-    "TeamReadyToKnifeInfoMessage"
+    "TeamIsReadyToKnife"
     {
         "pt"            "{1} está pronto para jogar o Round Faca."
     }
-    "TeamReadyToBeginInfoMessage"
+    "TeamIsReadyToBegin"
     {
         "pt"            "{1} está pronto para começar a partida."
     }
-    "TeamNotReadyInfoMessage"
+    "TeamIsNoLongerReady"
     {
         "pt"            "{1} deixou de estar pronto."
     }
@@ -312,23 +312,23 @@
     {
         "pt"            "Mapa {1}: {2}"
     }
-    "TeamPickedMapInfoMessage"
+    "TeamPickedMap"
     {
         "pt"            "{1} escolheu {2} como mapa {3}."
     }
-    "TeamSelectSideInfoMessage"
+    "TeamSelectedSide"
     {
         "pt"            "{1} escolheu começar no lado {2} em {3}."
     }
-    "TeamVetoedMapInfoMessage"
+    "TeamBannedMap"
     {
         "pt"            "{1} vetou {2}."
     }
-    "CaptainLeftOnVetoInfoMessage"
+    "CaptainLeftDuringMapSelection"
     {
         "pt"            "Um capitão deixou a partida durante o veto, pausando o veto."
     }
-    "ReadyToResumeVetoInfoMessage"
+    "ReadyToResumeMapSelection"
     {
         "pt"            "Digite {1} quando você estiver pronto para resumir o veto."
     }
@@ -376,27 +376,27 @@
     {
         "pt"            "[NOT READY]"
     }
-    "MapVetoPickMenuText"
+    "MapSelectionPickMenuText"
     {
         "pt"        "Selecione um mapa para JOGAR:"
     }
-    "MapVetoPickConfirmMenuText"
+    "MapSelectionPickConfirmMenuText"
     {
         "pt"        "Confirme que você quer JOGAR {1}:"
     }
-    "MapVetoBanMenuText"
+    "MapSelectionBanMenuText"
     {
         "pt"        "Selecione um mapa para VETAR:"
     }
-    "MapVetoBanConfirmMenuText"
+    "MapSelectionBanConfirmMenuText"
     {
         "pt"        "Confirme que você quer VETAR {1}:"
     }
-    "MapVetoSidePickMenuText"
+    "MapSelectionSidePickMenuText"
     {
         "pt"        "Selecione um lado para {1}:"
     }
-    "MapVetoSidePickConfirmMenuText"
+    "MapSelectionSidePickConfirmMenuText"
     {
         "pt"        "Confirme que você quer começar de {1}:"
     }
@@ -408,7 +408,7 @@
     {
         "pt"        "Não"
     }
-    "VetoCountdown"
+    "MapSelectionCountdown"
     {
         "pt"        "Veto começando em {1} segundos."
     }

--- a/translations/ru/get5.phrases.txt
+++ b/translations/ru/get5.phrases.txt
@@ -1,6 +1,6 @@
 "Phrases"
 {
-    "ReadyToVetoInfoMessage"
+    "ReadyForMapSelectionInfoMessage"
     {
         "ru"            "Напишите {1} когда ваша команда будет готова к голосованию."
     }
@@ -40,11 +40,11 @@
     {
         "ru"            "{1} выиграли раунд. Ожидаем, пока они напишут {2} или {3}."
     }
-    "WaitingForGOTVBrodcastEndingInfoMessage"
+    "WaitingForGOTVBroadcastEnding"
     {
         "ru"            "Карта будет изменена, когда закончится трансляция на GOTV."
     }
-    "WaitingForGOTVVetoInfoMessage"
+    "WaitingForGOTVMapSelection"
     {
         "ru"            "Карта изменится, как только на GOTV будут показаны вето на карты."
     }
@@ -180,23 +180,23 @@
     {
         "ru"            "У вас должно быть по крайней мере {1} игрок(ов) на сервере, чтобы подготовиться."
     }
-    "TeamReadyToVetoInfoMessage"
+    "TeamIsReadyForMapSelection"
     {
         "ru"            "{1} готовы для голосования."
     }
-    "TeamReadyToRestoreBackupInfoMessage"
+    "TeamIsReadyToRestoreBackup"
     {
         "ru"            "{1} готовы загрузить сохраненную игру."
     }
-    "TeamReadyToKnifeInfoMessage"
+    "TeamIsReadyToKnife"
     {
         "ru"            "{1} готовы к ножевому раунду."
     }
-    "TeamReadyToBeginInfoMessage"
+    "TeamIsReadyToBegin"
     {
         "ru"            "{1} готовы начать матч."
     }
-    "TeamNotReadyInfoMessage"
+    "TeamIsNoLongerReady"
     {
         "ru"            "{1} пока не готовы."
     }
@@ -324,23 +324,23 @@
     {
         "ru"            "Карта {1}: {2}"
     }
-    "TeamPickedMapInfoMessage"
+    "TeamPickedMap"
     {
         "ru"            "{1} выбрал {2} как карту {3}."
     }
-    "TeamSelectSideInfoMessage"
+    "TeamSelectedSide"
     {
         "ru"            "{1} выбрали начать за {2} на {3}."
     }
-    "TeamVetoedMapInfoMessage"
+    "TeamBannedMap"
     {
         "ru"            "{1} вычеркнули {2}."
     }
-    "CaptainLeftOnVetoInfoMessage"
+    "CaptainLeftDuringMapSelection"
     {
         "ru"            "Капитан пропал по время голосования, голосование приостановлено."
     }
-    "ReadyToResumeVetoInfoMessage"
+    "ReadyToResumeMapSelection"
     {
         "ru"            "Напишите {1}, когда будете готовы продолжить голосование."
     }
@@ -388,27 +388,27 @@
     {
         "ru"            "[NOT READY]"
     }
-    "MapVetoPickMenuText"
+    "MapSelectionPickMenuText"
     {
         "ru"        "Выберите карту для ИГРЫ:"
     }
-    "MapVetoPickConfirmMenuText"
+    "MapSelectionPickConfirmMenuText"
     {
         "ru"        "Подтвердите, что вы хотите ИГРАТЬ {1}:"
     }
-    "MapVetoBanMenuText"
+    "MapSelectionBanMenuText"
     {
         "ru"        "Выберите карту, на которую нужно наложить ВЕТО:"
     }
-    "MapVetoBanConfirmMenuText"
+    "MapSelectionBanConfirmMenuText"
     {
         "ru"        "Подтвердите, что вы хотите наложить ВЕТО на {1}:"
     }
-    "MapVetoSidePickMenuText"
+    "MapSelectionSidePickMenuText"
     {
         "ru"        "Выберите сторону для {1}:"
     }
-    "MapVetoSidePickConfirmMenuText"
+    "MapSelectionSidePickConfirmMenuText"
     {
         "ru"        "Подтвердите, что вы хотите начать за {1}:"
     }
@@ -420,7 +420,7 @@
     {
         "ru"        "Нет"
     }
-    "VetoCountdown"
+    "MapSelectionCountdown"
     {
         "ru"        "Наложение вето начинается через {1} сек."
     }

--- a/translations/ru/get5.phrases.txt
+++ b/translations/ru/get5.phrases.txt
@@ -2,7 +2,7 @@
 {
     "ReadyForMapSelectionInfoMessage"
     {
-        "ru"            "Напишите {1} когда ваша команда будет готова к голосованию."
+        "ru"            "Напишите {1} когда ваша команда будет готова к выбору карты."
     }
     "WaitingForCastersReadyInfoMessage"
     {
@@ -46,7 +46,7 @@
     }
     "WaitingForGOTVMapSelection"
     {
-        "ru"            "Карта изменится, как только на GOTV будут показаны вето на карты."
+        "ru"            "Карта изменится, как только на GOTV будет показан выбор карты."
     }
     "NoMatchSetupInfoMessage"
     {
@@ -182,7 +182,7 @@
     }
     "TeamIsReadyForMapSelection"
     {
-        "ru"            "{1} готовы для голосования."
+        "ru"            "{1} готовы для выбора карты."
     }
     "TeamIsReadyToRestoreBackup"
     {
@@ -334,15 +334,15 @@
     }
     "TeamBannedMap"
     {
-        "ru"            "{1} вычеркнули {2}."
+        "ru"            "{1} запретили {2}."
     }
     "CaptainLeftDuringMapSelection"
     {
-        "ru"            "Капитан пропал по время голосования, голосование приостановлено."
+        "ru"            "Капитан команды вышел во время выбора карты. Выбор карты приостановлен."
     }
     "ReadyToResumeMapSelection"
     {
-        "ru"            "Напишите {1}, когда будете готовы продолжить голосование."
+        "ru"            "Напишите {1}, когда будете готовы продолжить выбор карты."
     }
     "MatchConfigLoadedInfoMessage"
     {
@@ -398,11 +398,11 @@
     }
     "MapSelectionBanMenuText"
     {
-        "ru"        "Выберите карту, на которую нужно наложить ВЕТО:"
+        "ru"        "Выберите карту для запрета:"
     }
     "MapSelectionBanConfirmMenuText"
     {
-        "ru"        "Подтвердите, что вы хотите наложить ВЕТО на {1}:"
+        "ru"        "Подтвердите, что вы хотите запретить {1}:"
     }
     "MapSelectionSidePickMenuText"
     {
@@ -422,7 +422,7 @@
     }
     "MapSelectionCountdown"
     {
-        "ru"        "Наложение вето начинается через {1} сек."
+        "ru"        "Выбор карты начинается через {1}..."
     }
     "SurrenderCommandNotEnabled"
     {


### PR DESCRIPTION
This allows the match configuration to come with a `veto_mode` key that takes an array of strings in order to allow a custom veto mode.

Closes https://github.com/splewis/get5/issues/643.

In this example, we do a default "each team bans one, then picks one, last one played" with a pool of 5 maps. Providing a logically impossible setup will result in an error, but aside from that, you can do whatever you want.

We also now allow providing `map_sides` even when vetoing, so in this case, team2 will start CT on the first map and team1 will start CT on the second map, because the other team picked. Of course, you can omit this and let the team pick a side as well, like before.

```json
{
  "num_maps": 3,
  "maplist": [
    "de_dust2",
    "de_mirage",
    "de_inferno",
    "de_ancient",
    "de_vertigo"
  ],
  "veto_mode": [
    "team1_ban",
    "team2_ban",
    "team1_pick",
    "team2_pick"
  ],
  "map_sides": [
    "team2_ct",
    "team1_ct",
    "knife"
  ],
  "team1": {
    "name": "Team A Default",
    "players": {
      "76561197996413459": "PlayerAName1"
    },
    "coaches": {
      "76561197996426735": "CoachAName1"
    }
  },
  "team2": {
    "name": "Team B Default",
    "players": {
      "76561197996413459": "PlayerBName1"
    },
    "coaches": {
      "76561197996426735": "CoachBName1"
    }
  }
}
```

I still need to test it and update the docs.