### PR TITLE
Allow workshop maps in maplist

### DIFF
--- a/documentation/docs/match_schema.md
+++ b/documentation/docs/match_schema.md
@@ -95,8 +95,16 @@ interface Get5Match {
     This parameter is ignored if `map_sides` is set for all maps. `standard` and `always_knife` behave similarly (knife)
     when `skip_veto` is `true`.<br><br>**`Default: "standard"`**
 13. _Required_<br>The map pool to pick from, as an array of strings (`["de_dust2", "de_nuke"]` etc.), or if `skip_veto`
-    is `true`, the order of maps played (limited by `num_maps`). Similarly to teams, you can set this to an object
-    with a `fromfile` property to load a map list from a separate file.
+    is `true`, the order of maps played (limited by `num_maps`).<br><br>You can load maps from workshop collections by
+    using the syntax `"workshop/map_id/map_name"`, i.e. `"workshop/1193875520/Old Aztec"`. The name parameter is used to
+    present the map in the [map selection](../veto) phase. If you provide maps from the community workshop, you must
+    have a [Steam Web API key](https://steamcommunity.com/dev) configured for your server, or the match config will fail
+    to load.<br><br>Similarly to teams, you can set this to an object with a `fromfile` property to load a map list from
+    a separate file.<br><br>If you use workshop maps, it is recommended that you
+    set [`mp_match_end_restart 1`](https://totalcsgo.com/command/mpmatchendrestart) on your server, so a new map does
+    not load in case it takes a long time to download a workshop map. You can also set `sv_broadcast_ugc_downloads 1`
+    and `sv_broadcast_ugc_download_progress_interval 1` if you want to inform players that a workshop map is being
+    downloaded. In the vast majority of cases, this process should only take a few seconds.
 14. _Optional_<br>Wrapper for the server's `mp_teamprediction_pct`. This determines the chances of `team1`
     winning.<br><br>**`Default: 0`**
 15. _Optional_<br>Wrapper for the server's `mp_teamprediction_txt`.<br><br>**`Default: ""`**
@@ -201,6 +209,7 @@ These examples are identical in the way they would work if loaded.
       "maplist": [
         "de_dust2",
         "de_nuke",
+        "workshop/1193875520/Old Aztec",
         "de_inferno",
         "de_mirage",
         "de_vertigo",
@@ -280,7 +289,16 @@ These examples are identical in the way they would work if loaded.
                 "76561197987511774": "Anders Blume"
             }
         },
-        "maplist": ["de_dust2", "de_nuke", "de_inferno", "de_mirage", "de_vertigo", "de_ancient", "de_overpass"],
+        "maplist": [
+            "de_dust2",
+            "de_nuke",
+            "workshop/1193875520/Old Aztec",
+            "de_inferno",
+            "de_mirage",
+            "de_vertigo",
+            "de_ancient",
+            "de_overpass"
+        ],
         "map_sides": ["team1_ct", "team2_ct", "knife"], // Example; would only work with "skip_veto": true
         "team1": {
             "fromfile": "addons/sourcemod/get5/team_navi.json"
@@ -324,92 +342,93 @@ These examples are identical in the way they would work if loaded.
     ```cfg title="addons/sourcemod/get5/astralis_vs_navi_3123.cfg"
     "Match"
     {
-    	"match_title"               "Astralis vs. NaVi"
-    	"matchid"		            "3123"
-        "clinch_series"             "1"
-    	"num_maps"		            "3"
-    	"players_per_team"          "5"
-    	"coaches_per_team"          "2"
-        "coaches_must_ready"        "1"
-    	"min_players_to_ready"      "2"
-    	"min_spectators_to_ready"   "0"
-    	"skip_veto"		            "0"
-    	"veto_first"	            "team1"
-        "side_type"		            "standard"
-    	"spectators"    
-    	{
-    	    "name" "Blast PRO 2021"
-    		"players"
-    		{
-    			"76561197987511774"	"Anders Blume"
-    		}
-    	}
-    	"maplist"
-    	{
-    		"de_dust2"		""
-    		"de_nuke"		""
-    		"de_inferno"	""
-    		"de_mirage"		""
-    		"de_vertigo"	""
-    		"de_ancient"	""
-    		"de_overpass"	""
-    	}
-    	"map_sides"  // Example; would only work with "skip_veto" "1"
-    	{
-    	    "team1_ct" ""
-    	    "team2_ct" ""
-    	    "knife"    ""
-    	}
-    	"team1"
-    	{
-            "fromfile"  "addons/sourcemod/get5/team_navi.cfg"
-    	}
-    	"team2"
-    	{
-    		"name"		"Astralis"
-    		"tag"		"Astralis"
-    		"flag"		"DK"
-    		"logo"		"astr"
-    		"players"
-    		{
+        "match_title"             "Astralis vs. NaVi"
+        "matchid"                 "3123"
+        "clinch_series"           "1"
+        "num_maps"                "3"
+        "players_per_team"        "5"
+        "coaches_per_team"        "2"
+        "coaches_must_ready"      "1"
+        "min_players_to_ready"    "2"
+        "min_spectators_to_ready" "0"
+        "skip_veto"               "0"
+        "veto_first"              "team1"
+        "side_type"               "standard"
+        "spectators"    
+        {
+            "name" "Blast PRO 2021"
+            "players"
+            {
+                "76561197987511774" "Anders Blume"
+            }
+        }
+        "maplist"
+        {
+            "de_dust2"                      ""
+            "de_nuke"                       ""
+            "workshop/1193875520/Old Aztec" ""
+            "de_inferno"                    ""
+            "de_mirage"                     ""
+            "de_vertigo"                    ""
+            "de_ancient"                    ""
+            "de_overpass"                   ""
+        }
+        "map_sides"  // Example; would only work with "skip_veto" "1"
+        {
+            "team1_ct" ""
+            "team2_ct" ""
+            "knife"    ""
+        }
+        "team1"
+        {
+            "fromfile" "addons/sourcemod/get5/team_navi.cfg"
+        }
+        "team2"
+        {
+            "name" "Astralis"
+            "tag"  "Astralis"
+            "flag" "DK"
+            "logo" "astr"
+            "players"
+            {
                 "76561197990682262" "Xyp9x"
                 "76561198010511021" "gla1ve"
                 "76561197979669175" "K0nfig"
                 "76561198028458803" "BlameF"
                 "76561198024248129" "farlig"
-    		}
-    		"coaches"
-    		{
+            }
+            "coaches"
+            {
                 "76561197987144812" "Trace"
             }
-    	}
-    	"cvars"
-    	{
+        }
+        "cvars"
+        {
             "hostname"                       "Get5 Match #3123"
             "mp_friendly_fire"               "0"
             "get5_stop_command_enabled"      "0"
             "sm_practicemode_can_be_started" "0"
-    	}
+        }
     }
     ```
     `fromfile` example:
     ```cfg title="addons/sourcemod/get5/team_navi.cfg"
     "Team"
     { 
-        "name"		"Natus Vincere"
-    	"tag"		"NaVi"
-    	"flag"		"UA"
-    	"logo"		"navi"
-    	"players"
-    	{
+        "name" "Natus Vincere"
+        "tag"  "NaVi"
+        "flag" "UA"
+        "logo" "navi"
+        "players"
+        {
             "76561198034202275" "s1mple"
             "76561198044045107" "electronic"
             "76561198246607476" "b1t"
             "76561198121220486" "Perfecto"
             "76561198040577200" "sdy"
-    	}
-    	"coaches"
-    	{
+        }
+        "coaches"
+        {
             "76561198013523865" "B1ad3"
         }
     }

--- a/documentation/docs/stats_system.md
+++ b/documentation/docs/stats_system.md
@@ -33,27 +33,27 @@ Partial Example:
 ```
 "Stats"
 {
-	"series_type"       "bo1"
-	"team1_name"        "EnvyUs"
-	"team2_name"        "Fnatic"
-	"map0"
-	{
-		"mapname"		"de_mirage"
-		"demo_filename" "304_map1_de_mirage.dem"
-		"winner"		"team1"
-		"team1"
-		{
-			"score"		"5"
-			"73613643164646"
-			{
-				"name"		"xyz"
-				"kills"		"0"
-				"deaths"    "1"
-				"assists"	"5"
-				"damage"	"352"
-			}
-		}
-	}
+    "series_type"       "bo1"
+    "team1_name"        "EnvyUs"
+    "team2_name"        "Fnatic"
+    "map0"
+    {
+        "mapname"       "de_mirage"
+        "demo_filename" "304_map1_de_mirage.dem"
+        "winner"        "team1"
+        "team1"
+        {
+            "score"          "5"
+            "73613643164646"
+            {
+                "name"    "xyz"
+                "kills"   "0"
+                "deaths"  "1"
+                "assists" "5"
+                "damage"  "352"
+            }
+        }
+    }
 }
 ```
 
@@ -115,11 +115,11 @@ Raw text link can be found [here](https://raw.githubusercontent.com/splewis/get5
     ```
     "get5"
     {
-        "driver"			"mysql"
-        "host"				"127.0.0.1"
-        "database"			"get5"
-        "user"				"get5_db_user"
-        "pass"				"super_secret_password"
-        "port"			    "3306"
+        "driver"   "mysql"
+        "host"     "127.0.0.1"
+        "database" "get5"
+        "user"     "get5_db_user"
+        "pass"     "super_secret_password"
+        "port"     "3306"
     }
     ```

--- a/scripting/get5/maps.sp
+++ b/scripting/get5/maps.sp
@@ -12,11 +12,24 @@ void ChangeMap(const char[] map, float delay = 3.0) {
 }
 
 static Action Timer_DelayedChangeMap(Handle timer, Handle pack) {
+  if (!g_MapChangePending) {
+    delete pack;
+    return Plugin_Handled;
+  }
   char map[PLATFORM_MAX_PATH];
   ResetPack(pack);
   ReadPackString(pack, map, sizeof(map));
   CloseHandle(pack);
-  ServerCommand("changelevel %s", map);
-
+  if (StrContains(map, "workshop") == 0) {
+    ServerCommand("host_workshop_map %d", GetMapIdFromString(map));
+  } else {
+    ServerCommand("changelevel %s", map);
+  }
   return Plugin_Handled;
+}
+
+int GetMapIdFromString(const char[] map) {
+  char buffers[4][PLATFORM_MAX_PATH];
+  ExplodeString(map, "/", buffers, sizeof(buffers), PLATFORM_MAX_PATH);
+  return StringToInt(buffers[1]);
 }

--- a/scripting/get5/mapveto.sp
+++ b/scripting/get5/mapveto.sp
@@ -405,16 +405,29 @@ static void PickSide(const Get5Side side, const Get5Team team) {
   EventLogger_LogAndDeleteEvent(event);
 }
 
-static bool RemoveMapFromMapPool(const ArrayList mapPool, const char[] str, char[] buffer, const int bufferSize) {
+bool RemoveMapFromMapPool(const ArrayList mapPool, const char[] str, char[] buffer, const int bufferSize) {
   int eraseIndex = -1;
+  bool duplicateMatches = false;
   for (int i = 0; i < mapPool.Length; i++) {
     mapPool.GetString(i, buffer, bufferSize);
-    // Minimum 3 chars unless it's a complete match. Should handle all edge cases.
+    // Minimum 3 chars unless it's a complete match
     if ((strlen(str) >= 3 && StrContains(buffer, str, false) > -1) || StrEqual(buffer, str, false)) {
       if (eraseIndex >= 0) {
-        return false;  // Only 1 match allowed.
+        duplicateMatches = true;
+        break;
       }
       eraseIndex = i;
+    }
+  }
+  // Restart, this time only matching the full string.
+  if (duplicateMatches) {
+    eraseIndex = -1;
+    for (int i = 0; i < mapPool.Length; i++) {
+      mapPool.GetString(i, buffer, bufferSize);
+      if (StrEqual(buffer, str, false)) {
+        eraseIndex = i;
+        break;
+      }
     }
   }
   if (eraseIndex >= 0) {

--- a/scripting/get5/tests.sp
+++ b/scripting/get5/tests.sp
@@ -395,6 +395,25 @@ static void MapVetoLogicTest() {
   delete mapPool;
 
   delete pickOrder;
+
+  mapPool = GetMapPool(3);
+  mapPool.PushString("de_dust");  // Subset of "de_dust2"
+
+  AssertFalse("Check map pool match no match", RemoveMapFromMapPool(mapPool, "not_a_map", error, sizeof(error)));
+  AssertEq("Check map pool match no match, size 4", 4, mapPool.Length);
+  AssertFalse("Check map pool match double match, ambiguous",
+              RemoveMapFromMapPool(mapPool, "dust", error, sizeof(error)));
+  AssertEq("Check map pool match double match, size 4", 4, mapPool.Length);
+  AssertTrue("Check map pool match double match, precise",
+             RemoveMapFromMapPool(mapPool, "de_dust", error, sizeof(error)));
+  AssertEq("Check map pool match precise match, size 3", 3, mapPool.Length);
+  AssertTrue("Check map pool match single, subset", RemoveMapFromMapPool(mapPool, "mirage", error, sizeof(error)));
+  AssertEq("Check map pool match precise match, size 2", 2, mapPool.Length);
+  AssertTrue("Check map pool match single, subset after double match removed",
+             RemoveMapFromMapPool(mapPool, "dust", error, sizeof(error)));
+  AssertEq("Check map pool match precise match, size 1", 1, mapPool.Length);
+
+  delete mapPool;
 }
 
 static void MissingPropertiesTest() {
@@ -817,6 +836,23 @@ static void Utils_Test() {
   expected = "76561198064755913";
   AssertTrue("ConvertAuthToSteam64_4_return", ConvertAuthToSteam64(input, output));
   AssertStrEq("ConvertAuthToSteam64_4_value", output, expected);
+
+  char mapName[64] = "workshop/3374744/Old Aztec";
+  char formattedMapName[64];
+  FormatMapName(mapName, formattedMapName, sizeof(formattedMapName));
+  AssertStrEq("Check workshop map name correctly formatted", "Old Aztec", formattedMapName);
+  AssertEq("Check workshop map ID extraction", GetMapIdFromString(mapName), 3374744);
+
+  mapName = "workshop/837575";  // name missing
+  FormatMapName(mapName, formattedMapName, sizeof(formattedMapName));
+  AssertStrEq("Check workshop map name incorrectly formatted", "837575", formattedMapName);
+  AssertEq("Check workshop map ID extraction", GetMapIdFromString(mapName), 837575);
+
+  mapName = "de_dust2";
+  FormatMapName(mapName, formattedMapName, sizeof(formattedMapName), true);
+  AssertStrEq("Check regular map name correctly formatted", "Dust II", formattedMapName);
+  FormatMapName(mapName, formattedMapName, sizeof(formattedMapName), true, true);
+  AssertStrEq("Check regular map name correctly formatted and colored", "{GREEN}Dust II{NORMAL}", formattedMapName);
 }
 
 static void AssertConVarEquals(const char[] conVarName, const char[] expectedValue) {

--- a/scripting/get5/util.sp
+++ b/scripting/get5/util.sp
@@ -318,7 +318,7 @@ stock void FormatMapName(const char[] mapName, char[] buffer, int len, bool clea
   mapStringIndex = (numSplits > 0) ? (numSplits - 1) : (0);
   strcopy(buffer, len, buffers[mapStringIndex]);
 
-  if (cleanName) {
+  if (cleanName && StrContains("workshop", mapName, false) != 0) {
     if (StrEqual(buffer, "de_cache")) {
       strcopy(buffer, len, "Cache");
     } else if (StrEqual(buffer, "de_inferno")) {


### PR DESCRIPTION
Closes https://github.com/splewis/get5/issues/755.

Maps can be added to the `maplist` using the syntax `"workshop/map_id/map_name"`, i.e. `"workshop/1193875520/Old Aztec"`.

The name is used in the map selection phase to identify the map.

~One thing left to do here is to put the game into warmup mode when the map ends, if the next map is a workshop map, as it may take 5-10 seconds to download the map.~ Edit: Instead we add 20 seconds to the restart delay, which should be plenty to download a map.