### PR TITLE
Fix workshop map names in backups

### DIFF
--- a/configs/get5/tests/default_valid.cfg
+++ b/configs/get5/tests/default_valid.cfg
@@ -15,7 +15,7 @@
     {
         "de_dust2"   ""
         "de_mirage"  ""
-        "de_inferno" ""
+        "workshop/1193875520/de_aztec" ""
         "de_ancient" ""
     }
     "map_sides"

--- a/configs/get5/tests/default_valid.json
+++ b/configs/get5/tests/default_valid.json
@@ -13,7 +13,7 @@
   "maplist": [
     "de_dust2",
     "de_mirage",
-    "de_inferno",
+    "workshop/1193875520/de_aztec",
     "de_ancient"
   ],
   "map_sides": [

--- a/scripting/get5/backups.sp
+++ b/scripting/get5/backups.sp
@@ -270,6 +270,7 @@ static bool WriteBackupStructure(const char[] path) {
   kv.JumpToKey("maps", true);
   for (int i = 0; i < g_MapsToPlay.Length; i++) {
     g_MapsToPlay.GetString(i, mapName, sizeof(mapName));
+    EscapeKeyValueKeyWrite(mapName, sizeof(mapName));
     kv.SetNum(mapName, view_as<int>(g_MapSides.Get(i)));
   }
   kv.GoBack();
@@ -449,6 +450,7 @@ bool RestoreFromBackup(const char[] path, char[] error) {
       do {
         if (index == loadedMapNumber) {
           kv.GetSectionName(loadedMapName, sizeof(loadedMapName));
+          EscapeKeyValueKeyRead(loadedMapName, sizeof(loadedMapName));
           break;
         }
         index++;
@@ -529,6 +531,7 @@ bool RestoreFromBackup(const char[] path, char[] error) {
     if (kv.GotoFirstSubKey(false)) {
       do {
         kv.GetSectionName(mapName, sizeof(mapName));
+        EscapeKeyValueKeyRead(mapName, sizeof(mapName));
         SideChoice sides = view_as<SideChoice>(kv.GetNum(NULL_STRING));
         g_MapsToPlay.PushString(mapName);
         g_MapSides.Push(sides);

--- a/scripting/get5/matchconfig.sp
+++ b/scripting/get5/matchconfig.sp
@@ -354,6 +354,7 @@ void WriteMatchToKv(KeyValues kv) {
   for (int i = 0; i < g_MapPoolList.Length; i++) {
     char map[PLATFORM_MAX_PATH];
     g_MapPoolList.GetString(i, map, sizeof(map));
+    EscapeKeyValueKeyWrite(map, sizeof(map));
     kv.SetString(map, KEYVALUE_STRING_PLACEHOLDER);
   }
   kv.GoBack();
@@ -680,6 +681,7 @@ static bool ReadKeyValueMaplistSection(const KeyValues kv, char[] buffer, char[]
     FormatEx(error, PLATFORM_MAX_PATH, "\"maplist\" property contains invalid map name in match config KeyValues.");
     return false;
   }
+  EscapeKeyValueKeyRead(buffer, PLATFORM_MAX_PATH);
   return true;
 }
 
@@ -1360,6 +1362,7 @@ Action Command_CreateMatch(int client, int args) {
   kv.SetNum("clinch_series", 1);
 
   kv.JumpToKey("maplist", true);
+  EscapeKeyValueKeyWrite(matchMap, sizeof(matchMap));
   kv.SetString(matchMap, KEYVALUE_STRING_PLACEHOLDER);
   kv.GoBack();
 
@@ -1429,6 +1432,7 @@ Action Command_CreateScrim(int client, int args) {
   kv.SetString("matchid", matchid);
   kv.SetNum("scrim", 1);
   kv.JumpToKey("maplist", true);
+  EscapeKeyValueKeyWrite(matchMap, sizeof(matchMap));
   kv.SetString(matchMap, KEYVALUE_STRING_PLACEHOLDER);
   kv.GoBack();
 

--- a/scripting/get5/tests.sp
+++ b/scripting/get5/tests.sp
@@ -669,13 +669,13 @@ static void ValidMatchConfigTest(const char[] matchConfig) {
   AssertStrEq("Spectator Team Name", g_TeamNames[Get5Team_Spec], "Spectator Team Name");
 
   AssertEq("Map List Length", g_MapsToPlay.Length, 3);
-  char mapName[32];
+  char mapName[PLATFORM_MAX_PATH];
   g_MapsToPlay.GetString(0, mapName, sizeof(mapName));
   AssertStrEq("Map 1 Name", mapName, "de_dust2");
   g_MapsToPlay.GetString(1, mapName, sizeof(mapName));
   AssertStrEq("Map 2 Name", mapName, "de_mirage");
   g_MapsToPlay.GetString(2, mapName, sizeof(mapName));
-  AssertStrEq("Map 3 Name", mapName, "de_inferno");
+  AssertStrEq("Map 3 Name", mapName, "workshop/1193875520/de_aztec");
 
   AssertEq("Map sides length", g_MapSides.Length, 3);
   AssertEq("Sides 0", view_as<int>(g_MapSides.Get(0)), view_as<int>(SideChoice_KnifeRound));
@@ -752,6 +752,7 @@ static void ValidMatchConfigTest(const char[] matchConfig) {
     do {
       index++;
       AssertTrue("Read map name from backup", backup.GetSectionName(mapName, sizeof(mapName)));
+      EscapeKeyValueKeyRead(mapName, sizeof(mapName));
       if (index == 0) {
         AssertStrEq("Check map name 1 in backup", mapName, "de_dust2");
         AssertEq("Check map side 1 in backup", backup.GetNum(NULL_STRING), view_as<int>(SideChoice_KnifeRound));
@@ -759,7 +760,7 @@ static void ValidMatchConfigTest(const char[] matchConfig) {
         AssertStrEq("Check map name 2 in backup", mapName, "de_mirage");
         AssertEq("Check map side 2 in backup", backup.GetNum(NULL_STRING), view_as<int>(SideChoice_Team1T));
       } else if (index == 2) {
-        AssertStrEq("Check map name 3 in backup", mapName, "de_inferno");
+        AssertStrEq("Check map name 3 in backup", mapName, "workshop/1193875520/de_aztec");
         AssertEq("Check map side 3 in backup", backup.GetNum(NULL_STRING), view_as<int>(SideChoice_Team1CT));
       }
     } while (backup.GotoNextKey(false));

--- a/scripting/get5/util.sp
+++ b/scripting/get5/util.sp
@@ -479,6 +479,17 @@ stock bool WritePlaceholderInsteadOfEmptyString(const KeyValues kv, char[] buffe
   return false;
 }
 
+// For some odd reason, KeyValues cannot write key names with forward slashes in them.
+// If one attempts this, it simply creates a new key for each slash, so we have to escape this in order
+// for workshop maps to work with backups.
+stock void EscapeKeyValueKeyRead(char[] buffer, const int bufferSize) {
+ ReplaceString(buffer, bufferSize, "__slash__", "/");
+}
+
+stock void EscapeKeyValueKeyWrite(char[] buffer, const int bufferSize) {
+  ReplaceString(buffer, bufferSize, "/", "__slash__");
+}
+
 stock Get5Team OtherMatchTeam(Get5Team team) {
   if (team == Get5Team_1) {
     return Get5Team_2;


### PR DESCRIPTION
For some reason, `KeyValues` cannot store a key with a forward slash in its name, so we have to escape these when writing backups that contain workshop maps (`workshop/mapid/mapname`).

Tested and working.