### PR TITLE
Automatically adjust minimum surrender votes

### DIFF
--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -273,7 +273,8 @@ to [surrender](../surrender-forfeit#surrender). This cannot be set lower than `1
 
 ####`get5_surrender_required_votes`
 :   The number of votes required to [surrender](../surrender-forfeit#surrender) as a team. If set to `1` or below, any
-attempt to surrender will immediately succeed.<br>**`Default: 3`**
+attempt to surrender will immediately succeed. This value is practically limited to the value
+of [`players_per_team`](../match_schema#schema).<br>**`Default: 3`**
 
 ####`get5_surrender_time_limit`
 :   The number of seconds a team has to vote to [surrender](../surrender-forfeit#surrender) after the first vote is

--- a/scripting/get5/util.sp
+++ b/scripting/get5/util.sp
@@ -483,7 +483,7 @@ stock bool WritePlaceholderInsteadOfEmptyString(const KeyValues kv, char[] buffe
 // If one attempts this, it simply creates a new key for each slash, so we have to escape this in order
 // for workshop maps to work with backups.
 stock void EscapeKeyValueKeyRead(char[] buffer, const int bufferSize) {
- ReplaceString(buffer, bufferSize, "__slash__", "/");
+  ReplaceString(buffer, bufferSize, "__slash__", "/");
 }
 
 stock void EscapeKeyValueKeyWrite(char[] buffer, const int bufferSize) {


### PR DESCRIPTION
If `players_per_team` is 2 (say if playing wingman) and `get5_surrender_required_votes` is 3 (the default), this would automatically bring the required votes down to 2.

Also run formatter.