### PR TITLE
Include console messages in `Get5_OnPlayerSay`

### DIFF
--- a/documentation/docs/event_schema.yml
+++ b/documentation/docs/event_schema.yml
@@ -1033,7 +1033,7 @@ components:
           minimum: 0
           description: |
             The in-game user ID of the player. This uniquely identifies the player within a server and is
-            auto-incremented for each connecting player. 0 for GOTV/Console but >0 for all players or bots. If the same
+            auto-incremented for each connecting player. 0 for Console but >0 for all players, bots or GOTV. If the same
             player reconnects, they will be given a new ID. `steamid` uniquely identifies the player outside the server.
           example: 4
         steamid:
@@ -1042,14 +1042,14 @@ components:
           description: |
             The SteamID64 of the player. `GetSteamId()` and `SetSteamId()`
             in SourceMod. This will be `BOT-%d` if the player is a bot, where `%d` is the user ID (`user_id`).
-            The string will be empty for Console and GOTV (although we *should* never see this in practice).
+            The string will be empty for Console and GOTV.
         side:
           $ref: "#/components/schemas/Get5Side"
         name:
           type: string
           description: |
-            The in-game name of the player. If the player is a bot, this will be "BOT Gary" etc. `GetName()` and
-            `SetName()` in SourceMod.
+            The in-game name of the player. If the player is a bot, this will be "BOT Gary" etc. If console, this value
+            is `Console` and if GOTV, this value is `GOTV`. `GetName()` and `SetName()` in SourceMod.
           example: s1mple
         is_bot:
           type: boolean

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -770,29 +770,23 @@ public void OnClientPostAdminCheck(int client) {
 }
 
 public Action OnClientSayCommand(int client, const char[] command, const char[] sArgs) {
-  if (g_GameState == Get5State_Veto && g_MuteAllChatDuringMapSelectionCvar.BoolValue && StrEqual(command, "say")) {
-    if (client != g_VetoCaptains[Get5Team_1] && client != g_VetoCaptains[Get5Team_2]) {
+  if (client > 0 && g_GameState == Get5State_Veto && g_MuteAllChatDuringMapSelectionCvar.BoolValue &&
+      StrEqual(command, "say") && client != g_VetoCaptains[Get5Team_1] && client != g_VetoCaptains[Get5Team_2]) {
       Get5_Message(client, "%t", "MapSelectionTeamChatOnly");
       return Plugin_Stop;
-    }
   }
   return Plugin_Continue;
 }
 
 public void OnClientSayCommand_Post(int client, const char[] command, const char[] sArgs) {
   if (g_GameState != Get5State_None && (StrEqual(command, "say") || StrEqual(command, "say_team"))) {
-    if (IsValidClient(client)) {
-      Get5PlayerSayEvent event = new Get5PlayerSayEvent(g_MatchID, g_MapNumber, g_RoundNumber, GetRoundTime(),
-                                                        GetPlayerObject(client), command, sArgs);
-
-      LogDebug("Calling Get5_OnPlayerSay()");
-
-      Call_StartForward(g_OnPlayerSay);
-      Call_PushCell(event);
-      Call_Finish();
-
-      EventLogger_LogAndDeleteEvent(event);
-    }
+    Get5PlayerSayEvent event = new Get5PlayerSayEvent(g_MatchID, g_MapNumber, g_RoundNumber, GetRoundTime(),
+                                                      GetPlayerObject(client), command, sArgs);
+    LogDebug("Calling Get5_OnPlayerSay()");
+    Call_StartForward(g_OnPlayerSay);
+    Call_PushCell(event);
+    Call_Finish();
+    EventLogger_LogAndDeleteEvent(event);
   }
   CheckForChatAlias(client, sArgs);
 }

--- a/scripting/get5/stats.sp
+++ b/scripting/get5/stats.sp
@@ -124,8 +124,10 @@ Get5Player GetPlayerObject(int client) {
     return new Get5Player(0, "", view_as<Get5Side>(CS_TEAM_NONE), "Console", false);
   }
 
+  int userId = GetClientUserId(client);
+
   if (IsClientSourceTV(client)) {
-    return new Get5Player(0, "", view_as<Get5Side>(CS_TEAM_NONE), "GOTV", false);
+    return new Get5Player(userId, "", view_as<Get5Side>(CS_TEAM_NONE), "GOTV", false);
   }
 
   // In cases where users disconnect (Get5PlayerDisconnectedEvent) without being on a team, they
@@ -135,8 +137,6 @@ Get5Player GetPlayerObject(int client) {
 
   char name[MAX_NAME_LENGTH];
   GetClientName(client, name, sizeof(name));
-
-  int userId = GetClientUserId(client);
 
   if (IsAuthedPlayer(client)) {
     char auth[AUTH_LENGTH];


### PR DESCRIPTION
This includes any messages console may type in chat in the `Get5_OnPlayerSay` forward. Useful if admins message players. Breaking change as integrations now must filter out this event if `user_id` is zero.