### PR TITLE
Add stats to round end event + fix stats per side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,105 @@ Whenever you update your Get5 plugin, remember to **always** update the `transla
 Please see the [installation instructions](https://splewis.github.io/get5/latest/installation/#installation) for
 details.
 
+# 0.14.0
+
+⚠️ PRERELEASE
+
+#### 2022-03-09
+
+### Breaking Changes 🛠
+
+1. The `Get5_OnPlayerSay` event now includes messages sent from Console (or potentially GOTV). You should filter out
+   these messages on your end if you don't want to react to them. Note that console is always `user_id` 0 and GOTV's
+   name is always `GOTV`. Alternatively, you can ignore all messages with an empty `steamid`.
+2. The [stats system](https://splewis.github.io/get5/latest/stats_system/#keyvalue) has been updated. This means that
+   the structure has been modified to allow for more information, specifically the starting side and score for each side
+   for each team.
+
+   **If you use any of the stats extensions, you must also update those plugins (`get5_mysqlstats.smx`
+   and `get5_apistats.smx`)!**
+
+   Keys changed for each team (i.e. `map0 -> team1`):
+    1. Players' SteamIDs and stats have moved from the root of the team object into a key called `players`.
+    2. Added `score_ct`
+    3. Added `score_t`
+    4. Added `starting_side` (`2` for T, `3` for CT as this is an integer enum)
+3. The structure of the `Get5_OnRoundEnd` JSON event has changed (not to be confused with the KeyValues file in #2
+   above):
+
+   `teamX_score` (int) has been replaced by an object called `teamX`, which looks like this.
+
+   Old:
+   ```json
+   {
+     "event": "round_end",
+     "matchid": "29844",
+     "map_number": 0,
+     "map_name": "de_dust2",
+     "round_number": 21,
+     "round_time": 34944,
+     "reason": 8,
+     "winner": {
+       "team": "team1",
+       "side": "ct"
+     },
+     "team1_score": 10,
+     "team2_score": 12
+   }
+   ```
+   New:
+   ```json
+   {
+     "event": "round_end",
+     "matchid": "29844",
+     "map_number": 0,
+     "map_name": "de_dust2",
+     "round_number": 21,
+     "round_time": 34944,
+     "reason": 8,
+     "winner": {
+       "team": "team1",
+       "side": "ct"
+     },
+     "team1": {
+       "name": "TeamName",
+       "score": 10,
+       "score_ct": 4,
+       "score_t": 6,
+       "side": "t",
+       "starting_side": "ct",
+       "players": [
+         {
+           "name": "Nyxi",
+           "steamid": "76561197996426755",
+           "stats": {
+             // Full player stats.
+           }
+         }
+       ]
+     },
+     // same for "team2"
+   }
+   ```
+
+   This affects the `Get5_OnRoundEnd` forward as well, so if you have a plugin that reads this data, you must update it.
+   For full details and the SourceMod properties, see
+   the [event documentation](https://splewis.github.io/get5/dev/events_and_forwards/#events).
+
+### New Features / Changes 🎉
+
+1. Get5 is now built with SourceMod 1.11.
+2. The JSON "pretty print" spacing string has changed from 4 spaces to 1 tab. This is strictly because there is a 16KB
+   max buffer size in SourceMod, which we come dangerously close to when posting the full player stats via JSON. If you
+   play 6v6 or 7v7, you may need to
+   set [`get5_pretty_print_json 0`](https://splewis.github.io/get5/latest/configuration/#get5_pretty_print_json) to
+   avoid hitting the limit. You **will** see an error in console if this happens.
+3. The `get5_mysqlstats` extension now uses a transaction to update stat rows for each player. This improves performance
+   via reduced I/O between the game server and the database server.
+4. The [documentation of events](https://splewis.github.io/get5/dev/events_and_forwards/#events) is now rendered
+   on `https://redocly.github.io` instead of being embedded in the Get5 documentation website. This allows for more
+   space and makes it easier to browse/read.
+
 # 0.13.0
 
 #### 2022-02-18
@@ -59,7 +158,7 @@ details.
    round ends. This behavior can be controlled
    via [`get5_allow_pause_cancellation`](https://splewis.github.io/get5/latest/configuration/#get5_allow_pause_cancellation).
 
-## New Features / Changes 🎉
+### New Features / Changes 🎉
 
 1. Admins can now use the
    command [`get5_add_ready_time`](https://splewis.github.io/get5/latest/commands/#get5_add_ready_time) to add more time

--- a/documentation/docs/event_schema.yml
+++ b/documentation/docs/event_schema.yml
@@ -8,6 +8,7 @@ paths:
     post:
       tags:
         - All Events
+      summary: Get_OnEvent
       description: |
         Called when **any event** is fired. This forward takes two parameters (while all others take only one); the
         event object itself *and* a string representing the encoded JSON object. If you use this forward, you should
@@ -23,6 +24,7 @@ paths:
     post:
       tags:
         - Series Flow
+      summary: Get5_OnGameStateChanged
       description: |
         Fired when the game state changes.
       requestBody:
@@ -32,25 +34,27 @@ paths:
               title: Get5GameStateChangedEvent
               allOf:
                 - $ref: "#/components/schemas/Get5Event"
-              properties:
-                event:
-                  enum:
-                    - game_state_changed
-                new_state:
-                  description: The state the game has transitioned to. `NewState`
-                    in SourceMod.
-                  allOf:
-                    - "$ref": "#/components/schemas/Get5State"
-                old_state:
-                  description: The state the game has transitioned from. `OldState`
-                    in SourceMod.
-                  allOf:
-                    - "$ref": "#/components/schemas/Get5State"
+                - type: object
+                  properties:
+                    event:
+                      enum:
+                        - game_state_changed
+                    new_state:
+                      description: The state the game has transitioned to. `NewState`
+                        in SourceMod.
+                      allOf:
+                        - "$ref": "#/components/schemas/Get5State"
+                    old_state:
+                      description: The state the game has transitioned from. `OldState`
+                        in SourceMod.
+                      allOf:
+                        - "$ref": "#/components/schemas/Get5State"
       responses: { }
   "/Get5_OnPlayerConnected":
     post:
       tags:
         - Client Actions
+      summary: Get5_OnPlayerConnected
       description: |
         Fired when a player connects to the server.
       requestBody:
@@ -60,19 +64,21 @@ paths:
               title: Get5PlayerConnectedEvent
               allOf:
                 - $ref: "#/components/schemas/Get5PlayerDisconnectedEvent"
-              properties:
-                event:
-                  enum:
-                    - player_connect
-                ip_address:
-                  type: string
-                  example: '34.132.182.66'
-                  description: The IP address of the connecting client. `GetIPAddress()` and `SetIPAddress()` in SourceMod.
+                - type: object
+                  properties:
+                    event:
+                      enum:
+                        - player_connect
+                    ip_address:
+                      type: string
+                      example: '34.132.182.66'
+                      description: The IP address of the connecting client. `GetIPAddress()` and `SetIPAddress()` in SourceMod.
       responses: { }
   "/Get5_OnPlayerDisconnected":
     post:
       tags:
         - Client Actions
+      summary: Get5_OnPlayerDisconnected
       description: |
         Fired when a player disconnects from the server.
       requestBody:
@@ -82,15 +88,17 @@ paths:
               title: Get5PlayerDisconnectedEvent
               allOf:
                 - $ref: "#/components/schemas/Get5PlayerDisconnectedEvent"
-              properties:
-                event:
-                  enum:
-                    - player_disconnect
+                - type: object
+                  properties:
+                    event:
+                      enum:
+                        - player_disconnect
       responses: { }
   "/Get5_OnPreLoadMatchConfig":
     post:
       tags:
         - Series Flow
+      summary: Get5_OnPreLoadMatchConfig
       description: |
         Fired when the server attempts to load a match config.
       requestBody:
@@ -100,19 +108,21 @@ paths:
               title: Get5PreloadMatchConfigEvent
               allOf:
                 - $ref: "#/components/schemas/Get5Event"
-              properties:
-                event:
-                  enum:
-                    - preload_match_config
-                filename:
-                  type: string
-                  description: The file the server attempted to load. `GetFileName()`
-                    and `SetFileName()` in SourceMod.
+                - type: object
+                  properties:
+                    event:
+                      enum:
+                        - preload_match_config
+                    filename:
+                      type: string
+                      description: The file the server attempted to load. `GetFileName()`
+                        and `SetFileName()` in SourceMod.
       responses: { }
   "/Get5_OnLoadMatchConfigFailed":
     post:
       tags:
         - Series Flow
+      summary: Get5_OnLoadMatchConfigFailed
       description: |
         Fired when a match config fails to load.
       requestBody:
@@ -122,20 +132,22 @@ paths:
               title: Get5LoadMatchConfigFailedEvent
               allOf:
                 - $ref: "#/components/schemas/Get5Event"
-              properties:
-                event:
-                  enum:
-                    - match_config_load_fail
-                reason:
-                  type: string
-                  description: The error description for why the config load failed.
-                    `GetReason()` and `SetReason()` in SourceMod.
-                  example: You done goofed.
+                - type: object
+                  properties:
+                    event:
+                      enum:
+                        - match_config_load_fail
+                    reason:
+                      type: string
+                      description: The error description for why the config load failed.
+                        `GetReason()` and `SetReason()` in SourceMod.
+                      example: You done goofed.
       responses: { }
   "/Get5_OnSeriesInit":
     post:
       tags:
         - Series Flow
+      summary: Get5_OnSeriesInit
       description: |
         Fired when a series is started after loading a match config.
       requestBody:
@@ -145,25 +157,27 @@ paths:
               title: Get5SeriesStartedEvent
               allOf:
                 - "$ref": "#/components/schemas/Get5MatchEvent"
-              properties:
-                event:
-                  enum:
-                    - series_start
-                team1_name:
-                  type: string
-                  example: NaVi
-                  description: The name of team 1. `GetTeam1Name()` and `SetTeam1Name()`
-                    in SourceMod.
-                team2_name:
-                  type: string
-                  example: Astralis
-                  description: The name of team 2. `GetTeam2Name()` and `SetTeam2Name()`
-                    in SourceMod.
+                - type: object
+                  properties:
+                    event:
+                      enum:
+                        - series_start
+                    team1_name:
+                      type: string
+                      example: NaVi
+                      description: The name of team 1. `GetTeam1Name()` and `SetTeam1Name()`
+                        in SourceMod.
+                    team2_name:
+                      type: string
+                      example: Astralis
+                      description: The name of team 2. `GetTeam2Name()` and `SetTeam2Name()`
+                        in SourceMod.
       responses: { }
   "/Get5_OnMatchPaused":
     post:
       tags:
         - Map Flow
+      summary: Get5_OnMatchPaused
       description: |
         Fired when a request for a match pause is granted. If you need to know when a pause begins, see
         `Get5_OnPauseBegan`.
@@ -174,15 +188,17 @@ paths:
               title: Get5MatchPausedEvent
               allOf:
                 - "$ref": "#/components/schemas/Get5MatchPauseEvent"
-              properties:
-                event:
-                  enum:
-                    - game_paused
+                - type: object
+                  properties:
+                    event:
+                      enum:
+                        - game_paused
       responses: { }
   "/Get5_OnMatchUnpaused":
     post:
       tags:
         - Map Flow
+      summary: Get5_OnMatchUnpaused
       description: |
         Fired when the match is unpaused.
       requestBody:
@@ -192,15 +208,17 @@ paths:
               title: Get5MatchUnpausedEvent
               allOf:
                 - "$ref": "#/components/schemas/Get5MatchPauseEvent"
-              properties:
-                event:
-                  enum:
-                    - game_unpaused
+                - type: object
+                  properties:
+                    event:
+                      enum:
+                        - game_unpaused
       responses: { }
   "/Get5_OnPauseBegan":
     post:
       tags:
         - Map Flow
+      summary: Get5_OnPauseBegan
       description: |
         Fired when a pause begins. This forward is only fired during freeze-time. If a pause is called during
         freezetime, this and `Get5_OnMatchPaused` are called at the same time.
@@ -211,15 +229,17 @@ paths:
               title: Get5MatchPauseBeganEvent
               allOf:
                 - "$ref": "#/components/schemas/Get5MatchPauseEvent"
-              properties:
-                event:
-                  enum:
-                    - pause_began
+                - type: object
+                  properties:
+                    event:
+                      enum:
+                        - pause_began
       responses: { }
   "/Get5_OnMapResult":
     post:
       tags:
         - Series Flow
+      summary: Get5_OnMapResult
       description: |
         Fired when the map ends.
       requestBody:
@@ -229,27 +249,29 @@ paths:
               title: Get5MapResultEvent
               allOf:
                 - "$ref": "#/components/schemas/Get5MapEvent"
-              properties:
-                event:
-                  enum:
-                    - map_result
-                team1_score:
-                  type: integer
-                  minimum: 0
-                  description: The score of team1. `Team1Score` in SourceMod.
-                  example: 16
-                team2_score:
-                  type: integer
-                  minimum: 0
-                  description: The score of team2. `Team2Score` in SourceMod.
-                  example: 13
-                winner:
-                  $ref: "#/components/schemas/Get5Winner"
+                - type: object
+                  properties:
+                    event:
+                      enum:
+                        - map_result
+                    team1_score:
+                      type: integer
+                      minimum: 0
+                      description: The score of team1. `Team1Score` in SourceMod.
+                      example: 16
+                    team2_score:
+                      type: integer
+                      minimum: 0
+                      description: The score of team2. `Team2Score` in SourceMod.
+                      example: 13
+                    winner:
+                      $ref: "#/components/schemas/Get5Winner"
       responses: { }
   "/Get5_OnSeriesResult":
     post:
       tags:
         - Series Flow
+      summary: Get5_OnSeriesResult
       description: |
         Fired when a series is over. `winner` indicates team and side 0 if there was no winner in cases of a draw or
         if the series was forcefully canceled.
@@ -260,36 +282,38 @@ paths:
               title: Get5SeriesResultEvent
               allOf:
                 - "$ref": "#/components/schemas/Get5MatchEvent"
-              properties:
-                event:
-                  enum:
-                    - series_end
-                team1_series_score:
-                  type: integer
-                  minimum: 0
-                  example: 2
-                  description: The map/series score of team1. `Team1SeriesScore` in
-                    SourceMod.
-                team2_series_score:
-                  type: integer
-                  minimum: 0
-                  description: The map/series score of team2. `Team2SeriesScore` in
-                    SourceMod.
-                winner:
-                  $ref: "#/components/schemas/Get5Winner"
-                time_until_restore:
-                  type: integer
-                  minimum: 0
-                  example: 45
-                  description: |
-                    The number of seconds until Get5 restores any changed ConVars after the series has ended. This is
-                    the GOTV broadcast delay plus a few seconds. If you use this event to relinquish a server instance,
-                    you should wait until this time has passed before starting a new match or shutting down the server.
+                - type: object
+                  properties:
+                    event:
+                      enum:
+                        - series_end
+                    team1_series_score:
+                      type: integer
+                      minimum: 0
+                      example: 2
+                      description: The map/series score of team1. `Team1SeriesScore` in
+                        SourceMod.
+                    team2_series_score:
+                      type: integer
+                      minimum: 0
+                      description: The map/series score of team2. `Team2SeriesScore` in
+                        SourceMod.
+                    winner:
+                      $ref: "#/components/schemas/Get5Winner"
+                    time_until_restore:
+                      type: integer
+                      minimum: 0
+                      example: 45
+                      description: |
+                        The number of seconds until Get5 restores any changed ConVars after the series has ended. This is
+                        the GOTV broadcast delay plus a few seconds. If you use this event to relinquish a server instance,
+                        you should wait until this time has passed before starting a new match or shutting down the server.
       responses: { }
   "/Get5_OnKnifeRoundStarted":
     post:
       tags:
         - Map Flow
+      summary: Get5_OnKnifeRoundStarted
       description: |
         Fired when the knife round starts.
       requestBody:
@@ -299,15 +323,17 @@ paths:
               title: Get5KnifeRoundStartedEvent
               allOf:
                 - "$ref": "#/components/schemas/Get5MapEvent"
-              properties:
-                event:
-                  enum:
-                    - knife_start
+                - type: object
+                  properties:
+                    event:
+                      enum:
+                        - knife_start
       responses: { }
   "/Get5_OnKnifeRoundWon":
     post:
       tags:
         - Map Flow
+      summary: Get5_OnKnifeRoundWon
       description: |
         Fired when the knife round is over and the teams have elected to swap or stay. `side` represents the chosen side
         of the winning team, not the side that won the knife round.
@@ -318,21 +344,23 @@ paths:
               title: Get5KnifeRoundWonEvent
               allOf:
                 - "$ref": "#/components/schemas/Get5MapTeamEvent"
-              properties:
-                event:
-                  enum:
-                    - knife_won
-                side:
-                  $ref: "#/components/schemas/Get5Side"
-                swapped:
-                  type: boolean
-                  description: Indicates if the winning team elected to swap sides
-                    or not. `Swapped` on SourceMod.
+                - type: object
+                  properties:
+                    event:
+                      enum:
+                        - knife_won
+                    side:
+                      $ref: "#/components/schemas/Get5Side"
+                    swapped:
+                      type: boolean
+                      description: Indicates if the winning team elected to swap sides
+                        or not. `Swapped` on SourceMod.
       responses: { }
   "/Get5_OnSidePicked":
     post:
       tags:
         - Series Flow
+      summary: Get5_OnSidePicked
       description: |
         Fired when a side is picked by a team.
       requestBody:
@@ -342,22 +370,24 @@ paths:
               title: Get5SidePickedEvent
               allOf:
                 - "$ref": "#/components/schemas/Get5MapSelectionEvent"
-              properties:
-                event:
-                  enum:
-                    - side_picked
-                side:
-                  $ref: "#/components/schemas/Get5Side"
-                map_number:
-                  type: integer
-                  minimum: 0
-                  description: The map number the team chose a side for. `MapNumber`
-                    in SourceMod.
+                - type: object
+                  properties:
+                    event:
+                      enum:
+                        - side_picked
+                    side:
+                      $ref: "#/components/schemas/Get5Side"
+                    map_number:
+                      type: integer
+                      minimum: 0
+                      description: The map number the team chose a side for. `MapNumber`
+                        in SourceMod.
       responses: { }
   "/Get5_OnMapPicked":
     post:
       tags:
         - Series Flow
+      summary: Get5_OnMapPicked
       description: |
         Fired when a team picks a map.
       requestBody:
@@ -367,19 +397,21 @@ paths:
               title: Get5MapPickedEvent
               allOf:
                 - "$ref": "#/components/schemas/Get5MapSelectionEvent"
-              properties:
-                event:
-                  enum:
-                    - map_picked
-                map_number:
-                  type: integer
-                  minimum: 0
-                  description: The map number of the chosen map.
+                - type: object
+                  properties:
+                    event:
+                      enum:
+                        - map_picked
+                    map_number:
+                      type: integer
+                      minimum: 0
+                      description: The map number of the chosen map.
       responses: { }
   "/Get5_OnMapVetoed":
     post:
       tags:
         - Series Flow
+      summary: Get5_OnMapVetoed
       description: |
         Fired when a team vetos a map.
       requestBody:
@@ -389,15 +421,17 @@ paths:
               title: Get5MapPickedEvent
               allOf:
                 - "$ref": "#/components/schemas/Get5MapSelectionEvent"
-              properties:
-                event:
-                  enum:
-                    - map_vetoed
+                - type: object
+                  properties:
+                    event:
+                      enum:
+                        - map_vetoed
       responses: { }
   "/Get5_OnTeamReadyStatusChanged":
     post:
       tags:
         - Map Flow
+      summary: Get5_OnTeamReadyStatusChanged
       description: |
         Fired when a team's ready status changes.
       requestBody:
@@ -407,24 +441,26 @@ paths:
               title: Get5TeamReadyStatusChangedEvent
               allOf:
                 - "$ref": "#/components/schemas/Get5MatchTeamEvent"
-              properties:
-                event:
-                  enum:
-                    - team_ready_status_changed
-                ready:
-                  type: boolean
-                  description: Indicates if the team was marked as ready or not (unready).
-                game_state:
-                  description: |
-                    The game state the ready change was announced during. `GameState` in SourceMod and represented as
-                    an integer enum.
-                  allOf:
-                    - "$ref": "#/components/schemas/Get5State"
+                - type: object
+                  properties:
+                    event:
+                      enum:
+                        - team_ready_status_changed
+                    ready:
+                      type: boolean
+                      description: Indicates if the team was marked as ready or not (unready).
+                    game_state:
+                      description: |
+                        The game state the ready change was announced during. `GameState` in SourceMod and represented as
+                        an integer enum.
+                      allOf:
+                        - "$ref": "#/components/schemas/Get5State"
       responses: { }
   "/Get5_OnGoingLive":
     post:
       tags:
         - Map Flow
+      summary: Get5_OnGoingLive
       description: |
         Fired when a map is going live.
       requestBody:
@@ -434,15 +470,17 @@ paths:
               title: Get5GoingLiveEvent
               allOf:
                 - "$ref": "#/components/schemas/Get5MapEvent"
-              properties:
-                event:
-                  enum:
-                    - going_live
+                - type: object
+                  properties:
+                    event:
+                      enum:
+                        - going_live
       responses: { }
   "/Get5_OnRoundStart":
     post:
       tags:
         - Live
+      summary: Get5_OnRoundStart
       description: |
         Fired when a round starts (when freezetime begins).
       requestBody:
@@ -452,15 +490,17 @@ paths:
               title: Get5RoundStartedEvent
               allOf:
                 - "$ref": "#/components/schemas/Get5RoundEvent"
-              properties:
-                event:
-                  enum:
-                    - round_start
+                - type: object
+                  properties:
+                    event:
+                      enum:
+                        - round_start
       responses: { }
   "/Get5_OnRoundEnd":
     post:
       tags:
         - Live
+      summary: Get5_OnRoundEnd
       description: |
         Fired when a round ends - when the result is in; not when the round stops. Game activity can occur after this.
       requestBody:
@@ -470,30 +510,34 @@ paths:
               title: Get5RoundEndedEvent
               allOf:
                 - "$ref": "#/components/schemas/Get5TimedRoundEvent"
-              properties:
-                event:
-                  enum:
-                    - round_end
-                reason:
-                  type: integer
-                  minimum: 0
-                  description: The reason for the round ending. `Reason` in SourceMod.
-                    See https://sourcemod.dev/#/cstrike/enumeration.CSRoundEndReason.
-                winner:
-                  $ref: "#/components/schemas/Get5Winner"
-                team1_score:
-                  type: integer
-                  minimum: 0
-                  description: The round score of team 1. `Team1Score` in SourceMod.
-                team2_score:
-                  type: integer
-                  minimum: 0
-                  description: The round score of team 2. `Team2Score` in SourceMod.
+                - type: object
+                  properties:
+                    event:
+                      enum:
+                        - round_end
+                    reason:
+                      type: integer
+                      minimum: 0
+                      description: The reason for the round ending. `Reason` in SourceMod.
+                        See https://sourcemod.dev/#/cstrike/enumeration.CSRoundEndReason.
+                    winner:
+                      $ref: "#/components/schemas/Get5Winner"
+                    team1:
+                      title: Get5StatsTeam
+                      description: The stats for team 1.
+                      allOf:
+                        - $ref: "#/components/schemas/Get5StatsTeam"
+                    team2:
+                      title: Get5StatsTeam
+                      description: The stats for team 2.
+                      allOf:
+                        - $ref: "#/components/schemas/Get5StatsTeam"
       responses: { }
   "/Get5_OnRoundStatsUpdated":
     post:
       tags:
         - Live
+      summary: Get5_OnRoundStatsUpdated
       description: |
         Fired after the stats update on round end.
       requestBody:
@@ -503,15 +547,17 @@ paths:
               title: Get5RoundStatsUpdatedEvent
               allOf:
                 - "$ref": "#/components/schemas/Get5RoundEvent"
-              properties:
-                event:
-                  enum:
-                    - stats_updated
+                - type: object
+                  properties:
+                    event:
+                      enum:
+                        - stats_updated
       responses: { }
   "/Get5_OnBackupRestore":
     post:
       tags:
         - Series Flow
+      summary: Get5_OnBackupRestore
       description: |
         Fired when a round is restored from a backup. Note that the map and round numbers indicate the round being
         restored **to**, not the round the backup was requested during.
@@ -522,19 +568,21 @@ paths:
               title: Get5BackupRestoredEvent
               allOf:
                 - "$ref": "#/components/schemas/Get5RoundEvent"
-              properties:
-                event:
-                  enum:
-                    - backup_loaded
-                filename:
-                  type: string
-                  description: The name of the file that was used to restore the game
-                    state from. `GetFileName()` and `SetFileName()` in SourceMod.
+                - type: object
+                  properties:
+                    event:
+                      enum:
+                        - backup_loaded
+                    filename:
+                      type: string
+                      description: The name of the file that was used to restore the game
+                        state from. `GetFileName()` and `SetFileName()` in SourceMod.
       responses: { }
   "/Get5_OnDemoFinished":
     post:
       tags:
         - Series Flow
+      summary: Get5_OnDemoFinished
       description: |
         Fired when the GOTV recording has ended. This event does not fire if no demo was recorded.
       requestBody:
@@ -544,15 +592,17 @@ paths:
               title: Get5DemoFinishedEvent
               allOf:
                 - "$ref": "#/components/schemas/Get5DemoFileEvent"
-              properties:
-                event:
-                  enum:
-                    - demo_finished
+                - type: object
+                  properties:
+                    event:
+                      enum:
+                        - demo_finished
       responses: { }
   "/Get5_OnDemoUploadEnded":
     post:
       tags:
         - Series Flow
+      summary: Get5_OnDemoUploadEnded
       description: |
         Fired when the request to upload a demo ends, regardless if it succeeds or fails. If you upload demos, you
         should not shut down a server until this event has fired.
@@ -563,18 +613,20 @@ paths:
               title: Get5DemoUploadEndedEvent
               allOf:
                 - "$ref": "#/components/schemas/Get5DemoFileEvent"
-              properties:
-                event:
-                  enum:
-                    - demo_upload_ended
-                success:
-                  type: boolean
-                  description: Whether the upload was successful. `Success` in SourceMod.
+                - type: object
+                  properties:
+                    event:
+                      enum:
+                        - demo_upload_ended
+                    success:
+                      type: boolean
+                      description: Whether the upload was successful. `Success` in SourceMod.
       responses: { }
   "/Get5_OnPlayerBecameMVP":
     post:
       tags:
         - Live
+      summary: Get5_OnPlayerBecameMVP
       description: |
         Fired when a player is elected the MVP of the round.
       requestBody:
@@ -584,19 +636,21 @@ paths:
               title: Get5RoundMVPEvent
               allOf:
                 - "$ref": "#/components/schemas/Get5PlayerRoundEvent"
-              properties:
-                event:
-                  enum:
-                    - round_mvp
-                reason:
-                  type: integer
-                  minimum: 0
-                  description: The reason for the MVP assignment. `Reason` in SourceMod.
+                - type: object
+                  properties:
+                    event:
+                      enum:
+                        - round_mvp
+                    reason:
+                      type: integer
+                      minimum: 0
+                      description: The reason for the MVP assignment. `Reason` in SourceMod.
       responses: { }
   "/Get5_OnGrenadeThrown":
     post:
       tags:
         - Live
+      summary: Get5_OnGrenadeThrown
       description: |
         Fired whenever a grenade is thrown by a player. The `weapon` property reflects the grenade used.
       requestBody:
@@ -606,15 +660,17 @@ paths:
               title: Get5GrenadeThrownEvent
               allOf:
                 - "$ref": "#/components/schemas/Get5PlayerWeaponEvent"
-              properties:
-                event:
-                  enum:
-                    - grenade_thrown
+                - type: object
+                  properties:
+                    event:
+                      enum:
+                        - grenade_thrown
       responses: { }
   "/Get5_OnPlayerDeath":
     post:
       tags:
         - Live
+      summary: Get5_OnPlayerDeath
       description: |
         Fired when a player dies.
       requestBody:
@@ -624,55 +680,57 @@ paths:
               title: Get5PlayerDeathEvent
               allOf:
                 - "$ref": "#/components/schemas/Get5PlayerWeaponEvent"
-              properties:
-                event:
-                  enum:
-                    - player_death
-                bomb:
-                  type: boolean
-                  description: Indicates if the player died from the bomb explosion. `Bomb` in SourceMod.
-                headshot:
-                  type: boolean
-                  description: Indicates if the player died from a headshot. `Headshot`
-                    in SourceMod.
-                thru_smoke:
-                  type: boolean
-                  description: Indicates if the player was killed through smoke. `ThruSmoke`
-                    in SourceMod.
-                penetrated:
-                  type: boolean
-                  description: Indicates if the player was killed through an object
-                    (another player or walls). `Penetrated` in SourceMod.
-                attacker_blind:
-                  type: boolean
-                  description: Indicates if the attacker was blind while the player
-                    died. `AttackerBlind` in SourceMod.
-                no_scope:
-                  type: boolean
-                  description: Indicates if the attacker killed the player with a
-                    rifle without scoping. `NoScope` in SourceMod.
-                suicide:
-                  type: boolean
-                  description: Indicates if the player died from suicide, such as
-                    falling or dying from their own grenade. C4 bomb kills do not
-                    count as suicide. `Suicide` in SourceMod.
-                friendly_fire:
-                  type: boolean
-                  description: Indicates if the player died from friendly fire. `FriendlyFire`
-                    in SourceMod.
-                attacker:
-                  allOf:
-                    - type: object
-                      nullable: true
-                      title: Get5Player
-                    - "$ref": "#/components/schemas/Get5Player"
-                assist:
-                  "$ref": "#/components/schemas/Get5AssisterObject"
+                - type: object
+                  properties:
+                    event:
+                      enum:
+                        - player_death
+                    bomb:
+                      type: boolean
+                      description: Indicates if the player died from the bomb explosion. `Bomb` in SourceMod.
+                    headshot:
+                      type: boolean
+                      description: Indicates if the player died from a headshot. `Headshot`
+                        in SourceMod.
+                    thru_smoke:
+                      type: boolean
+                      description: Indicates if the player was killed through smoke. `ThruSmoke`
+                        in SourceMod.
+                    penetrated:
+                      type: boolean
+                      description: Indicates if the player was killed through an object
+                        (another player or walls). `Penetrated` in SourceMod.
+                    attacker_blind:
+                      type: boolean
+                      description: Indicates if the attacker was blind while the player
+                        died. `AttackerBlind` in SourceMod.
+                    no_scope:
+                      type: boolean
+                      description: Indicates if the attacker killed the player with a
+                        rifle without scoping. `NoScope` in SourceMod.
+                    suicide:
+                      type: boolean
+                      description: Indicates if the player died from suicide, such as
+                        falling or dying from their own grenade. C4 bomb kills do not
+                        count as suicide. `Suicide` in SourceMod.
+                    friendly_fire:
+                      type: boolean
+                      description: Indicates if the player died from friendly fire. `FriendlyFire`
+                        in SourceMod.
+                    attacker:
+                      allOf:
+                        - type: object
+                          nullable: true
+                          title: Get5Player
+                        - "$ref": "#/components/schemas/Get5Player"
+                    assist:
+                      "$ref": "#/components/schemas/Get5AssisterObject"
       responses: { }
   "/Get5_OnPlayerSay":
     post:
       tags:
         - Client Actions
+      summary: Get5_OnPlayerSay
       description: |
         Fired when a player types in chat.
       requestBody:
@@ -682,29 +740,31 @@ paths:
               title: Get5PlayerSayEvent
               allOf:
                 - "$ref": "#/components/schemas/Get5PlayerTimedRoundEvent"
-              properties:
-                event:
-                  enum:
-                    - player_say
-                command:
-                  type: string
-                  enum:
-                    - say
-                    - say_team
-                  example: say
-                  description: The command the player sent. `GetCommand()` and `SetCommand()` in SourceMod.
-                message:
-                  type: string
-                  minLength: 1
-                  example: gg have fun
-                  description: |
-                    The arguments passed to the command; the message written. `GetMessage()` and `SetMessage()` in
-                    SourceMod.
+                - type: object
+                  properties:
+                    event:
+                      enum:
+                        - player_say
+                    command:
+                      type: string
+                      enum:
+                        - say
+                        - say_team
+                      example: say
+                      description: The command the player sent. `GetCommand()` and `SetCommand()` in SourceMod.
+                    message:
+                      type: string
+                      minLength: 1
+                      example: gg have fun
+                      description: |
+                        The arguments passed to the command; the message written. `GetMessage()` and `SetMessage()` in
+                        SourceMod.
       responses: { }
   "/Get5_OnHEGrenadeDetonated":
     post:
       tags:
         - Live
+      summary: Get5_OnHEGrenadeDetonated
       description: |
         Fired when an HE grenade detonates. `player` describes who threw the HE and `victims` who were affected.
         `weapon` is always an HE grenade.
@@ -715,15 +775,17 @@ paths:
               title: Get5HEDetonatedEvent
               allOf:
                 - "$ref": "#/components/schemas/Get5VictimWithDamageGrenadeEvent"
-              properties:
-                event:
-                  enum:
-                    - hegrenade_detonated
+                - type: object
+                  properties:
+                    event:
+                      enum:
+                        - hegrenade_detonated
       responses: { }
   "/Get5_OnMolotovDetonated":
     post:
       tags:
         - Live
+      summary: Get5_OnMolotovDetonated
       description: |
         Fired when a molotov grenade expires. `player` describes
         who threw the molotov and `victims` who were affected. `weapon` is
@@ -736,15 +798,17 @@ paths:
               title: Get5MolotovDetonatedEvent
               allOf:
                 - "$ref": "#/components/schemas/Get5VictimWithDamageGrenadeEvent"
-              properties:
-                event:
-                  enum:
-                    - molotov_detonated
+                - type: object
+                  properties:
+                    event:
+                      enum:
+                        - molotov_detonated
       responses: { }
   "/Get5_OnFlashbangDetonated":
     post:
       tags:
         - Live
+      summary: Get5_OnFlashbangDetonated
       description: |
         Fired when a flash bang grenade detonates. `player` describes
         who threw the flash bang and `victims` who were affected. `weapon`
@@ -756,15 +820,17 @@ paths:
               title: Get5FlashbangDetonatedEvent
               allOf:
                 - "$ref": "#/components/schemas/Get5VictimGrenadeEvent"
-              properties:
-                event:
-                  enum:
-                    - flashbang_detonated
+                - type: object
+                  properties:
+                    event:
+                      enum:
+                        - flashbang_detonated
       responses: { }
   "/Get5_OnSmokeGrenadeDetonated":
     post:
       tags:
         - Live
+      summary: Get5_OnSmokeGrenadeDetonated
       description: |
         Fired when an smoke grenade expires. `player` describes
         who threw the grenade. `weapon` is always a smoke grenade.
@@ -775,19 +841,21 @@ paths:
               title: Get5SmokeDetonatedEvent
               allOf:
                 - "$ref": "#/components/schemas/Get5PlayerWeaponEvent"
-              properties:
-                event:
-                  enum:
-                    - smokegrenade_detonated
-                extinguished_molotov:
-                  type: boolean
-                  description: Indicates if the smoke distinguished an active molotov/firebomb.
-                    `ExtinguishedMolotov` in SourceMod.
+                - type: object
+                  properties:
+                    event:
+                      enum:
+                        - smokegrenade_detonated
+                    extinguished_molotov:
+                      type: boolean
+                      description: Indicates if the smoke distinguished an active molotov/firebomb.
+                        `ExtinguishedMolotov` in SourceMod.
       responses: { }
   "/Get5_OnDecoyStarted":
     post:
       tags:
         - Live
+      summary: Get5_OnDecoyStarted
       description: |
         Fired when a decoy starts making noise. `player` describes
         who threw the grenade. `weapon` is always a decoy grenade.
@@ -798,15 +866,17 @@ paths:
               title: Get5DecoyStartedEvent
               allOf:
                 - "$ref": "#/components/schemas/Get5PlayerWeaponEvent"
-              properties:
-                event:
-                  enum:
-                    - decoygrenade_started
+                - type: object
+                  properties:
+                    event:
+                      enum:
+                        - decoygrenade_started
       responses: { }
   "/Get5_OnBombPlanted":
     post:
       tags:
         - Live
+      summary: Get5_OnBombPlanted
       description: |
         Fired when the bomb is planted. `player` describes who planted the bomb.
       requestBody:
@@ -816,15 +886,17 @@ paths:
               title: Get5BombPlantedEvent
               allOf:
                 - "$ref": "#/components/schemas/Get5PlayerBombEvent"
-              properties:
-                event:
-                  enum:
-                    - bomb_planted
+                - type: object
+                  properties:
+                    event:
+                      enum:
+                        - bomb_planted
       responses: { }
   "/Get5_OnBombDefused":
     post:
       tags:
         - Live
+      summary: Get5_OnBombDefused
       description: |
         Fired when the bomb is defused. `player` describes who defused the bomb.
       requestBody:
@@ -834,21 +906,23 @@ paths:
               title: Get5BombDefusedEvent
               allOf:
                 - "$ref": "#/components/schemas/Get5PlayerBombEvent"
-              properties:
-                event:
-                  enum:
-                    - bomb_defused
-                bomb_time_remaining:
-                  type: number
-                  minimum: 0
-                  example: 12438
-                  description: Indicates how many milliseconds remained on the bomb
-                    timer when it was defused.
+                - type: object
+                  properties:
+                    event:
+                      enum:
+                        - bomb_defused
+                    bomb_time_remaining:
+                      type: number
+                      minimum: 0
+                      example: 12438
+                      description: Indicates how many milliseconds remained on the bomb
+                        timer when it was defused.
       responses: { }
   "/Get5_OnBombExploded":
     post:
       tags:
         - Live
+      summary: Get5_OnBombExploded
       description: |
         Fired when the bomb explodes.
       requestBody:
@@ -858,10 +932,11 @@ paths:
               title: Get5BombExplodedEvent
               allOf:
                 - "$ref": "#/components/schemas/Get5BombEvent"
-              properties:
-                event:
-                  enum:
-                    - bomb_exploded
+                - type: object
+                  properties:
+                    event:
+                      enum:
+                        - bomb_exploded
       responses: { }
 components:
   schemas:
@@ -888,102 +963,115 @@ components:
     Get5MatchEvent:
       allOf:
         - "$ref": "#/components/schemas/Get5Event"
-      properties:
-        matchid:
-          type: string
-          description: The ID of the match. `GetMatchId()` and `SetMatchId()` in SourceMod.
-          example: '14272'
+        - type: object
+          properties:
+            matchid:
+              type: string
+              description: The ID of the match. `GetMatchId()` and `SetMatchId()` in SourceMod.
+              example: '14272'
     Get5MatchTeamEvent:
       allOf:
         - "$ref": "#/components/schemas/Get5MatchEvent"
-      properties:
-        team:
-          $ref: "#/components/schemas/Get5Team"
+        - type: object
+          properties:
+            team:
+              $ref: "#/components/schemas/Get5Team"
     Get5MapEvent:
       allOf:
         - "$ref": "#/components/schemas/Get5MatchEvent"
-      properties:
-        map_number:
-          type: integer
-          minimum: 0
-          example: 0
-          description: The map number in the series, starting at 0. `MapNumber` in
-            SourceMod.
+        - type: object
+          properties:
+            map_number:
+              type: integer
+              minimum: 0
+              example: 0
+              description: The map number in the series, starting at 0. `MapNumber` in
+                SourceMod.
     Get5DemoFileEvent:
       allOf:
         - "$ref": "#/components/schemas/Get5MapEvent"
-      properties:
-        filename:
-          type: string
-          example: "1324_map_0_de_nuke.dem"
-          description: |
-            The name of the file containing the GOTV recording of the map. The format is determined by the
-            `get5_demo_name_format` parameter.
+        - type: object
+          properties:
+            filename:
+              type: string
+              example: "1324_map_0_de_nuke.dem"
+              description: |
+                The name of the file containing the GOTV recording of the map. The format is determined by the
+                `get5_demo_name_format` parameter.
     Get5MapSelectionEvent:
       allOf:
         - "$ref": "#/components/schemas/Get5MatchTeamEvent"
-      properties:
-        map_name:
-          type: string
-          example: de_nuke
-          description: The name of the map related to the event (map picked/banned
-            etc.). `GetMapName()` and `SetMapName()` in SourceMod.
+        - type: object
+          properties:
+            map_name:
+              type: string
+              example: de_nuke
+              description: The name of the map related to the event (map picked/banned
+                etc.). `GetMapName()` and `SetMapName()` in SourceMod.
     Get5MapTeamEvent:
       allOf:
         - "$ref": "#/components/schemas/Get5MapEvent"
-      properties:
-        team:
-          $ref: "#/components/schemas/Get5Team"
+        - type: object
+          properties:
+            team:
+              $ref: "#/components/schemas/Get5Team"
     Get5RoundEvent:
       allOf:
         - "$ref": "#/components/schemas/Get5MapEvent"
-      properties:
-        round_number:
-          type: integer
-          minimum: 0
-          example: 13
-          description: The round number of the map, starting at 0. `RoundNumber` in
-            SourceMod.
+        - type: object
+          properties:
+            round_number:
+              type: integer
+              minimum: 0
+              example: 13
+              description: The round number of the map, starting at 0. `RoundNumber` in
+                SourceMod.
     Get5PlayerRoundEvent:
       allOf:
         - "$ref": "#/components/schemas/Get5RoundEvent"
-      properties:
-        player:
-          "$ref": "#/components/schemas/Get5Player"
+        - type: object
+          properties:
+            player:
+              "$ref": "#/components/schemas/Get5Player"
     Get5TimedRoundEvent:
       allOf:
         - "$ref": "#/components/schemas/Get5RoundEvent"
-      properties:
-        round_time:
-          type: integer
-          description: The number of milliseconds into the round the event occurred.
-            `RoundTime` in SourceMod.
-          minimum: 0
-          example: 51434
+        - type: object
+          properties:
+            round_time:
+              type: integer
+              description: The number of milliseconds into the round the event occurred.
+                `RoundTime` in SourceMod.
+              minimum: 0
+              example: 51434
     Get5BombEvent:
       allOf:
         - "$ref": "#/components/schemas/Get5TimedRoundEvent"
-      properties:
-        site:
-          $ref: "#/components/schemas/Get5Site"
+        - type: object
+          properties:
+            site:
+              $ref: "#/components/schemas/Get5Site"
     Get5PlayerBombEvent:
       allOf:
         - "$ref": "#/components/schemas/Get5PlayerTimedRoundEvent"
-      properties:
-        site:
-          $ref: "#/components/schemas/Get5Site"
+        - type: object
+          properties:
+            site:
+              $ref: "#/components/schemas/Get5Site"
     Get5PlayerTimedRoundEvent:
       allOf:
         - "$ref": "#/components/schemas/Get5TimedRoundEvent"
-      properties:
-        player:
-          "$ref": "#/components/schemas/Get5Player"
+        - type: object
+          properties:
+            player:
+              "$ref": "#/components/schemas/Get5Player"
     Get5PlayerWeaponEvent:
       allOf:
         - "$ref": "#/components/schemas/Get5PlayerTimedRoundEvent"
-      properties:
-        weapon:
-          "$ref": "#/components/schemas/Get5Weapon"
+        - type: object
+          properties:
+            weapon:
+              "$ref": "#/components/schemas/Get5Weapon"
     Get5Winner:
       type: object
       description: Describes a winning team (their side and team number). `Winner` in SourceMod.
@@ -1025,17 +1113,46 @@ components:
           properties:
             pause_type:
               $ref: "#/components/schemas/Get5PauseType"
-    Get5Player:
+    Get5StatsTeam:
       type: object
       properties:
-        user_id:
+        name:
+          type: string
+          description: The name of the team.
+          example: Natus Vincere
+        score:
           type: integer
           minimum: 0
-          description: |
-            The in-game user ID of the player. This uniquely identifies the player within a server and is
-            auto-incremented for each connecting player. 0 for Console but >0 for all players, bots or GOTV. If the same
-            player reconnects, they will be given a new ID. `steamid` uniquely identifies the player outside the server.
-          example: 4
+          description: The team's total score on the current map.
+          example: 14
+        score_ct:
+          type: integer
+          minimum: 0
+          description: The team's score on the CT side on the current map.
+          example: 10
+        score_t:
+          type: integer
+          minimum: 0
+          description: The team's score on the T side on the current map.
+          example: 14
+        players:
+          type: array
+          description: The players on the team.
+          items:
+            $ref: "#/components/schemas/Get5StatsPlayer"
+        side:
+          title: Get5Side
+          description: The current side of the team.
+          allOf:
+            - $ref: "#/components/schemas/Get5Side"
+        starting_side:
+          title: Get5Side
+          description: The starting side of the team.
+          allOf:
+            - $ref: "#/components/schemas/Get5Side"
+    Get5PlayerBase:
+      type: object
+      properties:
         steamid:
           type: string
           example: '76561198279375306'
@@ -1043,19 +1160,39 @@ components:
             The SteamID64 of the player. `GetSteamId()` and `SetSteamId()`
             in SourceMod. This will be `BOT-%d` if the player is a bot, where `%d` is the user ID (`user_id`).
             The string will be empty for Console and GOTV.
-        side:
-          $ref: "#/components/schemas/Get5Side"
         name:
           type: string
           description: |
             The in-game name of the player. If the player is a bot, this will be "BOT Gary" etc. If console, this value
             is `Console` and if GOTV, this value is `GOTV`. `GetName()` and `SetName()` in SourceMod.
           example: s1mple
-        is_bot:
-          type: boolean
-          description: Indicates if the player is a bot. `IsBot` in SourceMod.
-          example: false
-      description: Describes a player. `Player` in SourceMod (or `Attacker` on `Get5PlayerDeathEvent`).
+    Get5StatsPlayer:
+      allOf:
+        - "$ref": "#/components/schemas/Get5PlayerBase"
+        - type: object
+          properties:
+            stats:
+              $ref: "#/components/schemas/Get5PlayerStats"
+    Get5Player:
+      allOf:
+        - "$ref": "#/components/schemas/Get5PlayerBase"
+        - type: object
+          properties:
+            user_id:
+              type: integer
+              minimum: 0
+              description: |
+                The in-game user ID of the player. This uniquely identifies the player within a server and is
+                auto-incremented for each connecting player. 0 for Console but >0 for all players, bots or GOTV. If the same
+                player reconnects, they will be given a new ID. `steamid` uniquely identifies the player outside the server.
+              example: 4
+            side:
+              $ref: "#/components/schemas/Get5Side"
+            is_bot:
+              type: boolean
+              description: Indicates if the player is a bot. `IsBot` in SourceMod.
+              example: false
+          description: Describes a player. `Player` in SourceMod (or `Attacker` on `Get5PlayerDeathEvent`).
     Get5Weapon:
       type: object
       properties:
@@ -1101,57 +1238,61 @@ components:
     Get5VictimGrenadeEvent:
       allOf:
         - "$ref": "#/components/schemas/Get5PlayerWeaponEvent"
-      properties:
-        victims:
-          type: array
-          items:
-            oneOf:
-              - "$ref": "#/components/schemas/Get5BlindedGrenadeVictim"
-              - "$ref": "#/components/schemas/Get5DamageGrenadeVictim"
-          description: Describes the victims of the grenade. For flash bangs, these
-            are `Get5BlindedGrenadeVictim` and for molotovs/firebombs and HE, these
-            are `Get5DamageGrenadeVictim`. The array is empty if the grenade did not
-            affect anyone. `Victims` in SourceMod.
+        - type: object
+          properties:
+            victims:
+              type: array
+              items:
+                oneOf:
+                  - "$ref": "#/components/schemas/Get5BlindedGrenadeVictim"
+                  - "$ref": "#/components/schemas/Get5DamageGrenadeVictim"
+              description: Describes the victims of the grenade. For flash bangs, these
+                are `Get5BlindedGrenadeVictim` and for molotovs/firebombs and HE, these
+                are `Get5DamageGrenadeVictim`. The array is empty if the grenade did not
+                affect anyone. `Victims` in SourceMod.
     Get5VictimWithDamageGrenadeEvent:
       allOf:
         - "$ref": "#/components/schemas/Get5VictimGrenadeEvent"
-      properties:
-        damage_enemies:
-          type: integer
-          minimum: 0
-          description: The total damage the grenade did to enemies. `DamageEnemies`
-            in SourceMod.
-        damage_friendlies:
-          type: integer
-          minimum: 0
-          description: The total damage the grenade did to friendlies. `DamageFriendlies`
-            in SourceMod.
+        - type: object
+          properties:
+            damage_enemies:
+              type: integer
+              minimum: 0
+              description: The total damage the grenade did to enemies. `DamageEnemies`
+                in SourceMod.
+            damage_friendlies:
+              type: integer
+              minimum: 0
+              description: The total damage the grenade did to friendlies. `DamageFriendlies`
+                in SourceMod.
     Get5DamageGrenadeVictim:
       allOf:
         - "$ref": "#/components/schemas/Get5GrenadeVictim"
-      properties:
-        damage:
-          type: integer
-          maximum: 100
-          minimum: 1
-          description: The damage afflicted to the player by the grenade. `Damage`
-            in SourceMod.
-        killed:
-          type: boolean
-          description: Indicates if the grenade victim (`player`) was killed by the
-            grenade. `Killed` in SourceMod.
-      description: Describes a victim of a HE or molotov/firebomb.
+        - type: object
+          properties:
+            damage:
+              type: integer
+              maximum: 100
+              minimum: 1
+              description: The damage afflicted to the player by the grenade. `Damage`
+                in SourceMod.
+            killed:
+              type: boolean
+              description: Indicates if the grenade victim (`player`) was killed by the
+                grenade. `Killed` in SourceMod.
+          description: Describes a victim of a HE or molotov/firebomb.
     Get5BlindedGrenadeVictim:
       allOf:
         - "$ref": "#/components/schemas/Get5GrenadeVictim"
-      properties:
-        blind_duration:
-          type: number
-          maximum: 5
-          minimum: 0.5
-          description: The duration in seconds the victim (`player`) was blinded by
-            the grenade. `BlindDuration` in SourceMod.
-      description: Describes a victim of a flash bang.
+        - type: object
+          properties:
+            blind_duration:
+              type: number
+              maximum: 5
+              minimum: 0.5
+              description: The duration in seconds the victim (`player`) was blinded by
+                the grenade. `BlindDuration` in SourceMod.
+          description: Describes a victim of a flash bang.
     Get5Site:
       type: string
       enum:
@@ -1161,10 +1302,179 @@ components:
     Get5PlayerDisconnectedEvent:
       allOf:
         - "$ref": "#/components/schemas/Get5MatchEvent"
+        - type: object
+          properties:
+            player:
+              $ref: "#/components/schemas/Get5Player"
+    Get5PlayerStats:
+      type: object
+      description: The stats of the player.
       properties:
-        player:
-          $ref: "#/components/schemas/Get5Player"
-
+        kills:
+          type: integer
+          minimum: 0
+          description: 'The number of kills the player had. `Kills` in SourceMod.'
+          example: 34
+        deaths:
+          type: integer
+          minimum: 0
+          description: 'The number of deaths the player had. `Deaths` in SourceMod.'
+          example: 8
+        assists:
+          type: integer
+          minimum: 0
+          description: 'The number of assists the player had. `Assists` in SourceMod.'
+          example: 5
+        flashbang_assists:
+          type: integer
+          minimum: 0
+          description: 'The number of flashbang assists the player had. `FlashbangAssists` in SourceMod.'
+          example: 3
+        team_kills:
+          type: integer
+          minimum: 0
+          description: 'The number of team-kills the player had. `TeamKills` in SourceMod.'
+          example: 0
+        suicides:
+          type: integer
+          minimum: 0
+          description: 'The number of suicides the player had. `Suicides` in SourceMod.'
+          example: 0
+        damage:
+          type: integer
+          minimum: 0
+          description: 'The total amount of damage the player dealt. `Damage` in SourceMod.'
+          example: 2948
+        utility_damage:
+          type: integer
+          minimum: 0
+          description: 'The total amount of damage the player dealt via utility. `UtilityDamage` in SourceMod.'
+          example: 173
+        enemies_flashed:
+          type: integer
+          minimum: 0
+          description: 'The number of enemies flashed by the player. `EnemiesFlashed` in SourceMod.'
+          example: 6
+        friendlies_flashed:
+          type: integer
+          minimum: 0
+          description: 'The number of teammates flashed by the player. `FriendliesFlashed` in SourceMod.'
+          example: 2
+        knife_kills:
+          type: integer
+          minimum: 0
+          description: 'The number kills the player had with a knife. `KnifeKills` in SourceMod.'
+          example: 1
+        headshot_kills:
+          type: integer
+          minimum: 0
+          description: 'The number kills the player had that were headshots. `HeadshotKills` in SourceMod.'
+          example: 19
+        rounds_played:
+          type: integer
+          minimum: 0
+          description: 'The number of rounds the player started. `RoundsPlayed` in SourceMod.'
+          example: 27
+        bomb_defuses:
+          type: integer
+          minimum: 0
+          description: 'The number of times the player defused the bomb. `BombDefuses` in SourceMod.'
+          example: 4
+        bomb_plants:
+          type: integer
+          minimum: 0
+          description: 'The number of times the player planted the bomb. `BombPlants` in SourceMod.'
+          example: 3
+        1k:
+          type: integer
+          minimum: 0
+          description: 'The number of rounds where the player killed 1 opponent. `Kills1` in SourceMod.'
+          example: 3
+        2k:
+          type: integer
+          minimum: 0
+          description: 'The number of rounds where the player killed 2 opponents. `Kills2` in SourceMod.'
+          example: 2
+        3k:
+          type: integer
+          minimum: 0
+          description: 'The number of rounds where the player killed 3 opponents. `Kills3` in SourceMod.'
+          example: 3
+        4k:
+          type: integer
+          minimum: 0
+          description: 'The number of rounds where the player killed 4 opponents. `Kills4` in SourceMod.'
+          example: 0
+        5k:
+          type: integer
+          minimum: 0
+          description: 'The number of rounds where the player killed 5 opponents. `Kills5` in SourceMod.'
+          example: 1
+        1v1:
+          type: integer
+          minimum: 0
+          description: 'The number of 1v1s the player won. `OneV1s` in SourceMod.'
+          example: 1
+        1v2:
+          type: integer
+          minimum: 0
+          description: 'The number of 1v2s the player won. `OneV2s` in SourceMod.'
+          example: 3
+        1v3:
+          type: integer
+          minimum: 0
+          description: 'The number of 1v3s the player won. `OneV3s` in SourceMod.'
+          example: 2
+        1v4:
+          type: integer
+          minimum: 0
+          description: 'The number of 1v4s the player won. `OneV4s` in SourceMod.'
+          example: 0
+        1v5:
+          type: integer
+          minimum: 0
+          description: 'The number of 1v5s the player won. `OneV5s` in SourceMod.'
+          example: 1
+        first_kills_t:
+          type: integer
+          minimum: 0
+          description: 'The number of rounds where the player had the first kill in the round while playing the T side. `FirstKillsT` in SourceMod.'
+          example: 6
+        first_kills_ct:
+          type: integer
+          minimum: 0
+          description: 'The number of rounds where the player had the first kill in the round while playing the CT side. `FirstKillsCT` in SourceMod.'
+          example: 5
+        first_deaths_t:
+          type: integer
+          minimum: 0
+          description: 'The number of rounds where the player was the first to die in the round while playing the T side. `FirstDeathsT` in SourceMod.'
+          example: 1
+        first_deaths_ct:
+          type: integer
+          minimum: 0
+          description: 'The number of rounds where the player was the first to die in the round while playing the CT side. `FirstDeathsCT` in SourceMod.'
+          example: 1
+        trade_kills:
+          type: integer
+          minimum: 0
+          description: 'The number of times the player got a kill in a trade. `TradeKills` in SourceMod.'
+          example: 3
+        kast:
+          type: integer
+          minimum: 0
+          description: 'The number of rounds where the player (k)illed a player, had an (a)ssist, (s)urvived or was (t)raded. `KAST` in SourceMod.'
+          example: 23
+        score:
+          type: integer
+          minimum: 0
+          description: 'The in-game "score" of the player. `Score` in SourceMod.'
+          example: 45
+        mvp:
+          type: integer
+          minimum: 0
+          description: 'The number of times the player was elected the round MVP. `MVPs` in SourceMod.'
+          example: 4
 tags:
   - name: All Events
     description: Forward fired for all events.

--- a/documentation/docs/events_and_forwards.md
+++ b/documentation/docs/events_and_forwards.md
@@ -28,4 +28,9 @@ table below indicate the name of the forward in SourceMod.
 
 ## Events
 
-<swagger-ui src="event_schema.yml"/>
+Documentation of the events is available
+on [https://redocly.github.io/redoc/?url=https://splewis.github.io/get5/latest/event_schema.yml](https://redocly.github.io/redoc/?url=https://splewis.github.io/get5/latest/event_schema.yml){:target="_blank"}.
+
+!!! warning "Stable docs"
+
+    If you want to browse the development version of the events, replace `latest` with `dev` in the URL.

--- a/documentation/requirements.txt
+++ b/documentation/requirements.txt
@@ -1,4 +1,3 @@
-mkdocs-swagger-ui-tag==0.3.0
 mkdocs
 mkdocs-material
 mike

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -357,6 +357,10 @@ public void OnPluginStart() {
   InitDebugLog(DEBUG_CVAR, "get5");
   LogDebug("OnPluginStart version=%s", PLUGIN_VERSION);
 
+  // Because we JSON encode the entire match stats on round end, we change from 4 spaces to a tab when pretty-printing.
+  // It saves a significant number of bytes, and we're limited to 16K. See SendEventJSONToURL().
+  JSON_PP_INDENT = "\t";
+
   // Because we use SDKHooks for damage, we need to re-hook clients that are already on the server
   // in case the plugin is reloaded. This includes bots.
   LOOP_CLIENTS(i) {
@@ -772,8 +776,8 @@ public void OnClientPostAdminCheck(int client) {
 public Action OnClientSayCommand(int client, const char[] command, const char[] sArgs) {
   if (client > 0 && g_GameState == Get5State_Veto && g_MuteAllChatDuringMapSelectionCvar.BoolValue &&
       StrEqual(command, "say") && client != g_VetoCaptains[Get5Team_1] && client != g_VetoCaptains[Get5Team_2]) {
-      Get5_Message(client, "%t", "MapSelectionTeamChatOnly");
-      return Plugin_Stop;
+    Get5_Message(client, "%t", "MapSelectionTeamChatOnly");
+    return Plugin_Stop;
   }
   return Plugin_Continue;
 }
@@ -1911,10 +1915,12 @@ static Action Event_RoundEnd(Event event, const char[] name, bool dontBroadcast)
   }
 
   if (g_GameState == Get5State_Live) {
-    int csTeamWinner = event.GetInt("winner");
+    Get5Side winnerSide = view_as<Get5Side>(event.GetInt("winner"));
+    Get5Side team1Side = view_as<Get5Side>(Get5TeamToCSTeam(Get5Team_1));
+    Get5Side team2Side = view_as<Get5Side>(Get5TeamToCSTeam(Get5Team_2));
 
-    int team1Score = CS_GetTeamScore(Get5TeamToCSTeam(Get5Team_1));
-    int team2Score = CS_GetTeamScore(Get5TeamToCSTeam(Get5Team_2));
+    int team1Score = CS_GetTeamScore(view_as<int>(team1Side));
+    int team2Score = CS_GetTeamScore(view_as<int>(team2Side));
 
     if (team1Score == team2Score) {
       // If a vote is started and the game proceeds to a tie; stop the timers as surrender can now not be performed.
@@ -1924,7 +1930,7 @@ static Action Event_RoundEnd(Event event, const char[] name, bool dontBroadcast)
     Get5_MessageToAll("%s {GREEN}%d {NORMAL}- {GREEN}%d %s", g_FormattedTeamNames[Get5Team_1], team1Score, team2Score,
                       g_FormattedTeamNames[Get5Team_2]);
 
-    Stats_RoundEnd(csTeamWinner);
+    Stats_RoundEnd(winnerSide, team1Side, team2Side);
 
     if (g_DamagePrintCvar.BoolValue) {
       LOOP_CLIENTS(i) {
@@ -1970,12 +1976,17 @@ static Action Event_RoundEnd(Event event, const char[] name, bool dontBroadcast)
       }
     }
 
+    Get5StatsTeam team1 = new Get5StatsTeam(g_TeamNames[Get5Team_1], team1Score, team1Side);
+    Get5StatsTeam team2 = new Get5StatsTeam(g_TeamNames[Get5Team_2], team2Score, team2Side);
+
+    FillPlayerStats(team1, team2);
+
     // CSRoundEndReason is incorrect in CSGO compared to the enumerations defined here:
     // https://github.com/alliedmodders/sourcemod/blob/master/plugins/include/cstrike.inc#L53-L77
     // - which is why we subtract one.
     Get5RoundEndedEvent roundEndEvent = new Get5RoundEndedEvent(
       g_MatchID, g_MapNumber, g_RoundNumber, GetRoundTime(), view_as<CSRoundEndReason>(event.GetInt("reason") - 1),
-      new Get5Winner(CSTeamToGet5Team(csTeamWinner), view_as<Get5Side>(csTeamWinner)), team1Score, team2Score);
+      new Get5Winner(CSTeamToGet5Team(view_as<int>(winnerSide)), winnerSide), team1, team2);
 
     LogDebug("Calling Get5_OnRoundEnd()");
     Call_StartForward(g_OnRoundEnd);

--- a/scripting/get5/events.sp
+++ b/scripting/get5/events.sp
@@ -14,6 +14,13 @@ void SendEventJSONToURL(const char[] event) {
     return;
   }
 
+  int contentLength = strlen(event);
+  if (contentLength >= 16383) {
+    LogError(
+      "JSON event size exceeds the maximum supported value of 16382 bytes and cannot be sent to your log URL. You should consider setting get5_pretty_print_json 0 to reduce the JSON size.");
+    return;
+  }
+
   static char error[PLATFORM_MAX_PATH];
   Handle eventRequest = CreateGet5HTTPRequest(k_EHTTPMethodPOST, eventUrl, error);
   if (eventRequest == INVALID_HANDLE) {
@@ -33,7 +40,8 @@ void SendEventJSONToURL(const char[] event) {
     delete eventRequest;
     return;
   }
-  SteamWorks_SetHTTPRequestRawPostBody(eventRequest, "application/json", event, strlen(event));
+
+  SteamWorks_SetHTTPRequestRawPostBody(eventRequest, "application/json", event, contentLength);
   SteamWorks_SetHTTPRequestNetworkActivityTimeout(eventRequest, 15);  // Default 60 is a bit much.
   SteamWorks_SetHTTPCallbacks(eventRequest, EventRequestCallback);
   SteamWorks_SendHTTPRequest(eventRequest);

--- a/scripting/get5_apistats.sp
+++ b/scripting/get5_apistats.sp
@@ -248,11 +248,17 @@ static void UpdateRoundStats(const char[] matchId, const int mapNumber) {
   FormatEx(mapKey, sizeof(mapKey), "map%d", mapNumber);
   if (kv.JumpToKey(mapKey)) {
     if (kv.JumpToKey("team1")) {
-      UpdatePlayerStats(matchId, mapNumber, kv, Get5Team_1);
+      if (kv.JumpToKey("players")) {
+        UpdatePlayerStats(matchId, mapNumber, kv, Get5Team_1);
+        kv.GoBack();
+      }
       kv.GoBack();
     }
     if (kv.JumpToKey("team2")) {
-      UpdatePlayerStats(matchId, mapNumber, kv, Get5Team_2);
+      if (kv.JumpToKey("players")) {
+        UpdatePlayerStats(matchId, mapNumber, kv, Get5Team_2);
+        kv.GoBack();
+      }
       kv.GoBack();
     }
     kv.GoBack();

--- a/scripting/include/get5.inc
+++ b/scripting/include/get5.inc
@@ -6,6 +6,63 @@
 #include <json>  // github.com/clugg/sm-json
 #include <cstrike>
 
+// Series stats (root section)
+#define STAT_SERIESWINNER "winner"
+#define STAT_SERIESTYPE "series_type"
+#define STAT_SERIES_TEAM1NAME "team1_name"
+#define STAT_SERIES_TEAM2NAME "team2_name"
+#define STAT_SERIES_FORFEIT "forfeit"
+
+// Map stats (under "map0", "map1", etc.)
+#define STAT_MAPNAME "mapname"
+#define STAT_MAPWINNER "winner"
+#define STAT_DEMOFILENAME "demo_filename"
+
+// Team stats (under map section, then "team1" or "team2")
+#define STAT_TEAMSCORE "score"
+#define STAT_TEAMSCORE_CT "score_ct"
+#define STAT_TEAMSCORE_T "score_t"
+#define STAT_STARTING_SIDE "starting_side"
+
+// Player stats (under map section, then team section, then player's steam64)
+// If adding stuff here, also add to the InitPlayerStats function!
+#define STAT_INIT "init" // used to zero-fill stats only. Not a real stat.
+#define STAT_COACHING "coaching" // indicates if the player is a coach.
+#define STAT_NAME "name"
+#define STAT_KILLS "kills"
+#define STAT_DEATHS "deaths"
+#define STAT_ASSISTS "assists"
+#define STAT_FLASHBANG_ASSISTS "flashbang_assists"
+#define STAT_TEAMKILLS "teamkills"
+#define STAT_SUICIDES "suicides"
+#define STAT_DAMAGE "damage"
+#define STAT_UTILITY_DAMAGE "util_damage"
+#define STAT_ENEMIES_FLASHED "enemies_flashed"
+#define STAT_FRIENDLIES_FLASHED "friendlies_flashed"
+#define STAT_KNIFE_KILLS "knife_kills"
+#define STAT_HEADSHOT_KILLS "headshot_kills"
+#define STAT_ROUNDSPLAYED "roundsplayed"
+#define STAT_BOMBDEFUSES "bomb_defuses"
+#define STAT_BOMBPLANTS "bomb_plants"
+#define STAT_1K "1kill_rounds"
+#define STAT_2K "2kill_rounds"
+#define STAT_3K "3kill_rounds"
+#define STAT_4K "4kill_rounds"
+#define STAT_5K "5kill_rounds"
+#define STAT_V1 "v1"
+#define STAT_V2 "v2"
+#define STAT_V3 "v3"
+#define STAT_V4 "v4"
+#define STAT_V5 "v5"
+#define STAT_FIRSTKILL_T "firstkill_t"
+#define STAT_FIRSTKILL_CT "firstkill_ct"
+#define STAT_FIRSTDEATH_T "firstdeath_t"
+#define STAT_FIRSTDEATH_CT "firstdeath_ct"
+#define STAT_TRADEKILL "tradekill"
+#define STAT_KAST "kast"
+#define STAT_CONTRIBUTION_SCORE "contribution_score"
+#define STAT_MVP "mvp"
+
 enum Get5Side {
   Get5Side_None = CS_TEAM_NONE,
   Get5Side_Spec = CS_TEAM_SPECTATOR,
@@ -165,6 +222,468 @@ native bool Get5_GetMatchStats(KeyValues kv);
 // Increases an (integer-typed) player statistic in the plugin's stats keyvalue structure.
 native int Get5_IncreasePlayerStat(int client, const char[] statName, int amount = 1);
 
+
+methodmap Get5PlayerStats < JSON_Object {
+
+  property int Kills {
+    public set(int val) {
+      this.SetInt("kills", val);
+    }
+    public get() {
+      return this.GetInt("kills");
+    }
+  }
+
+  property int Deaths {
+    public set(int val) {
+      this.SetInt("deaths", val);
+    }
+    public get() {
+      return this.GetInt("deaths");
+    }
+  }
+
+  property int Assists {
+    public set(int val) {
+      this.SetInt("assists", val);
+    }
+    public get() {
+      return this.GetInt("assists");
+    }
+  }
+
+  property int FlashbangAssists {
+    public set(int val) {
+      this.SetInt("flashbang_assists", val);
+    }
+    public get() {
+      return this.GetInt("flashbang_assists");
+    }
+  }
+
+  property int TeamKills {
+    public set(int val) {
+      this.SetInt("team_kills", val);
+    }
+    public get() {
+      return this.GetInt("team_kills");
+    }
+  }
+
+  property int Suicides {
+    public set(int val) {
+      this.SetInt("suicides", val);
+    }
+    public get() {
+      return this.GetInt("suicides");
+    }
+  }
+
+  property int Damage {
+    public set(int val) {
+      this.SetInt("damage", val);
+    }
+    public get() {
+      return this.GetInt("damage");
+    }
+  }
+
+  property int UtilityDamage {
+    public set(int val) {
+      this.SetInt("utility_damage", val);
+    }
+    public get() {
+      return this.GetInt("utility_damage");
+    }
+  }
+
+  property int EnemiesFlashed {
+    public set(int val) {
+      this.SetInt("enemies_flashed", val);
+    }
+    public get() {
+      return this.GetInt("enemies_flashed");
+    }
+  }
+
+  property int FriendliesFlashed {
+    public set(int val) {
+      this.SetInt("friendlies_flashed", val);
+    }
+    public get() {
+      return this.GetInt("friendlies_flashed");
+    }
+  }
+
+  property int KnifeKills {
+    public set(int val) {
+      this.SetInt("knife_kills", val);
+    }
+    public get() {
+      return this.GetInt("knife_kills");
+    }
+  }
+
+  property int HeadshotKills {
+    public set(int val) {
+      this.SetInt("headshot_kills", val);
+    }
+    public get() {
+      return this.GetInt("headshot_kills");
+    }
+  }
+
+  property int RoundsPlayed {
+    public set(int val) {
+      this.SetInt("rounds_played", val);
+    }
+    public get() {
+      return this.GetInt("rounds_played");
+    }
+  }
+
+  property int BombDefuses {
+    public set(int val) {
+      this.SetInt("bomb_defuses", val);
+    }
+    public get() {
+      return this.GetInt("bomb_defuses");
+    }
+  }
+
+  property int BombPlants {
+    public set(int val) {
+      this.SetInt("bomb_plants", val);
+    }
+    public get() {
+      return this.GetInt("bomb_plants");
+    }
+  }
+
+  property int Kills1 {
+    public set(int val) {
+      this.SetInt("1k", val);
+    }
+    public get() {
+      return this.GetInt("1k");
+    }
+  }
+
+  property int Kills2 {
+    public set(int val) {
+      this.SetInt("2k", val);
+    }
+    public get() {
+      return this.GetInt("2k");
+    }
+  }
+
+  property int Kills3 {
+    public set(int val) {
+      this.SetInt("3k", val);
+    }
+    public get() {
+      return this.GetInt("3k");
+    }
+  }
+
+  property int Kills4 {
+    public set(int val) {
+      this.SetInt("4k", val);
+    }
+    public get() {
+      return this.GetInt("4k");
+    }
+  }
+
+  property int Kills5 {
+    public set(int val) {
+      this.SetInt("5k", val);
+    }
+    public get() {
+      return this.GetInt("5k");
+    }
+  }
+
+  property int OneV1s {
+    public set(int val) {
+      this.SetInt("1v1", val);
+    }
+    public get() {
+      return this.GetInt("1v1");
+    }
+  }
+
+  property int OneV2s {
+    public set(int val) {
+      this.SetInt("1v2", val);
+    }
+    public get() {
+      return this.GetInt("1v2");
+    }
+  }
+
+  property int OneV3s {
+    public set(int val) {
+      this.SetInt("1v3", val);
+    }
+    public get() {
+      return this.GetInt("1v3");
+    }
+  }
+
+  property int OneV4s {
+    public set(int val) {
+      this.SetInt("1v4", val);
+    }
+    public get() {
+      return this.GetInt("1v4");
+    }
+  }
+
+  property int OneV5s {
+    public set(int val) {
+      this.SetInt("1v5", val);
+    }
+    public get() {
+      return this.GetInt("1v5");
+    }
+  }
+
+  property int FirstKillsT {
+    public set(int val) {
+      this.SetInt("first_kills_t", val);
+    }
+    public get() {
+      return this.GetInt("first_kills_t");
+    }
+  }
+
+  property int FirstKillsCT {
+    public set(int val) {
+      this.SetInt("first_kills_ct", val);
+    }
+    public get() {
+      return this.GetInt("first_kills_ct");
+    }
+  }
+
+  property int FirstDeathsT {
+    public set(int val) {
+      this.SetInt("first_deaths_t", val);
+    }
+    public get() {
+      return this.GetInt("first_deaths_t");
+    }
+  }
+
+  property int FirstDeathsCT {
+    public set(int val) {
+      this.SetInt("first_deaths_ct", val);
+    }
+    public get() {
+      return this.GetInt("first_deaths_ct");
+    }
+  }
+
+  property int TradeKills {
+    public set(int val) {
+      this.SetInt("trade_kills", val);
+    }
+    public get() {
+      return this.GetInt("trade_kills");
+    }
+  }
+
+  property int KAST {
+    public set(int val) {
+      this.SetInt("kast", val);
+    }
+    public get() {
+      return this.GetInt("kast");
+    }
+  }
+
+  property int Score {
+    public set(int val) {
+      this.SetInt("score", val);
+    }
+    public get() {
+      return this.GetInt("score");
+    }
+  }
+
+  property int MVPs {
+    public set(int val) {
+      this.SetInt("mvp", val);
+    }
+    public get() {
+      return this.GetInt("mvp");
+    }
+  }
+
+  public Get5PlayerStats(const int kills, const int deaths, const int assists, const int flashbangAssists,
+        const int teamKills, const int suicides, const int damage, const int utilityDamage, const int enemiesFlashed,
+        const int friendliesFlashed, const int knifeKills, const int headshotKills, const int roundsPlayed,
+        const int bombDefuses, const int bombPlants, const int kills1, const int kills2, const int kills3,
+        const int kills4, const int kills5, const int oneV1s, const int oneV2s, const int oneV3s,
+        const int oneV4s, const int oneV5s, const int firstKillsT, const int firstKillsCT, const int firstDeathsT,
+        const int firstDeathsCT, const int tradeKills, const int kast, const int score, const int mvp) {
+    Get5PlayerStats self = view_as<Get5PlayerStats>(new JSON_Object());
+    self.Kills = kills;
+    self.Deaths = deaths;
+    self.Assists = assists;
+    self.FlashbangAssists = flashbangAssists;
+    self.TeamKills = teamKills;
+    self.Suicides = suicides;
+    self.Damage = damage;
+    self.UtilityDamage = utilityDamage;
+    self.EnemiesFlashed = enemiesFlashed;
+    self.FriendliesFlashed = friendliesFlashed;
+    self.KnifeKills = knifeKills;
+    self.HeadshotKills = headshotKills;
+    self.RoundsPlayed = roundsPlayed;
+    self.BombDefuses = bombDefuses;
+    self.BombPlants = bombPlants;
+    self.OneV1s = oneV1s;
+    self.OneV2s = oneV2s;
+    self.OneV3s = oneV3s;
+    self.OneV4s = oneV4s;
+    self.OneV5s = oneV5s;
+    self.Kills1 = kills1;
+    self.Kills2 = kills2;
+    self.Kills3 = kills3;
+    self.Kills4 = kills4;
+    self.Kills5 = kills5;
+    self.FirstKillsT = firstKillsT;
+    self.FirstKillsCT = firstKillsCT;
+    self.FirstDeathsT = firstDeathsT;
+    self.FirstDeathsCT = firstDeathsCT;
+    self.TradeKills = tradeKills;
+    self.KAST = kast;
+    self.Score = score
+    self.MVPs = mvp;
+    return self;
+  }
+}
+
+methodmap Get5PlayerBase < JSON_Object {
+  public bool SetSteamId(const char[] value) {
+    return this.SetString("steamid", value);
+  }
+  public bool GetSteamId(char[] buffer, const int maxSize) {
+    return this.GetString("steamid", buffer, maxSize);
+  }
+
+  public bool SetName(const char[] value) {
+    return this.SetString("name", value);
+  }
+  public bool GetName(char[] buffer, const int maxSize) {
+    return this.GetString("name", buffer, maxSize);
+  }
+}
+
+methodmap Get5StatsPlayer < Get5PlayerBase {
+
+  property Get5PlayerStats Stats {
+    public get() {
+      return view_as<Get5PlayerStats>(this.GetObject("stats"));
+    }
+    public set(Get5PlayerStats val) {
+      this.SetObject("stats", val);
+    }
+  }
+
+  public Get5StatsPlayer(const char[] steamId, const char[] name, const Get5PlayerStats stats) {
+    Get5StatsPlayer self = view_as<Get5StatsPlayer>(new JSON_Object());
+    self.SetSteamId(steamId);
+    self.SetName(name);
+    self.Stats = stats;
+    return self;
+  }
+}
+
+methodmap Get5StatsTeam < JSON_Object {
+
+  public bool GetName(char[] buffer, const int maxSize) {
+    return this.GetString("name", buffer, maxSize);
+  }
+
+  public bool SetName(const char[] value) {
+    return this.SetString("name", value);
+  }
+
+  property int Score {
+    public get() {
+      return this.GetInt("score");
+    }
+    public set(int val) {
+      this.SetInt("score", val);
+    }
+  }
+
+  property int ScoreCT {
+    public get() {
+      return this.GetInt("score_ct");
+    }
+    public set(int val) {
+      this.SetInt("score_ct", val);
+    }
+  }
+
+  property int ScoreT {
+    public get() {
+      return this.GetInt("score_t");
+    }
+    public set(int val) {
+      this.SetInt("score_t", val);
+    }
+  }
+
+  // Array of type Get5StatsPlayer
+  property JSON_Array Players {
+    public get() {
+      return view_as<JSON_Array>(this.GetObject("players"));
+    }
+    public set(JSON_Array players) {
+      this.SetObject("players", players);
+    }
+  }
+
+  property Get5Side Side {
+    public get() {
+      return view_as<Get5Side>(this.GetInt("side_int"));
+    }
+    public set(Get5Side side) {
+      this.SetInt("side_int", view_as<int>(side));
+      this.SetHidden("side_int", true);
+      ConvertGet5SideToStringInJson(this, "side", side);
+    }
+  }
+
+  property Get5Side StartingSide {
+    public get() {
+      return view_as<Get5Side>(this.GetInt("starting_side_int"));
+    }
+    public set(Get5Side side) {
+      this.SetInt("starting_side_int", view_as<int>(side));
+      this.SetHidden("starting_side_int", true);
+      ConvertGet5SideToStringInJson(this, "starting_side", side);
+    }
+  }
+
+  public Get5StatsTeam(const char[] teamName, const int score, const Get5Side side) {
+    Get5StatsTeam self = view_as<Get5StatsTeam>(new JSON_Object());
+    self.SetName(teamName);
+    self.Score = score;
+    self.Players = new JSON_Array();
+    self.Side = side;
+    self.ScoreCT = 0;
+    self.ScoreT = 0;
+    self.StartingSide = Get5Side_None;
+    return self;
+  }
+}
 
 methodmap Get5StatusTeam < JSON_Object {
 
@@ -349,7 +868,7 @@ methodmap Get5Winner < JSON_Object {
   }
 }
 
-methodmap Get5Player < JSON_Object {
+methodmap Get5Player < Get5PlayerBase {
 
   property Get5Side Side {
     public get() {
@@ -360,20 +879,6 @@ methodmap Get5Player < JSON_Object {
       this.SetHidden("side_int", true);
       ConvertGet5SideToStringInJson(this, "side", side);
     }
-  }
-
-  public bool SetSteamId(const char[] value) {
-    return this.SetString("steamid", value);
-  }
-  public bool GetSteamId(char[] buffer, const int maxSize) {
-    return this.GetString("steamid", buffer, maxSize);
-  }
-
-  public bool SetName(const char[] value) {
-    return this.SetString("name", value);
-  }
-  public bool GetName(char[] buffer, const int maxSize) {
-    return this.GetString("name", buffer, maxSize);
   }
 
   property bool IsBot {
@@ -1078,25 +1583,26 @@ methodmap Get5RoundEndedEvent < Get5TimedRoundEvent {
     }
   }
 
-  property int Team1Score {
+  property Get5StatsTeam Team1 {
     public get() {
-      return this.GetInt("team1_score");
+      return view_as<Get5StatsTeam>(this.GetObject("team1"));
     }
-    public set(int score) {
-      this.SetInt("team1_score", score);
+    public set(Get5StatsTeam team) {
+      this.SetObject("team1", team);
     }
   }
 
-  property int Team2Score {
+  property Get5StatsTeam Team2 {
     public get() {
-      return this.GetInt("team2_score");
+      return view_as<Get5StatsTeam>(this.GetObject("team2"));
     }
-    public set(int score) {
-      this.SetInt("team2_score", score);
+    public set(Get5StatsTeam team) {
+      this.SetObject("team2", team);
     }
   }
 
-  public Get5RoundEndedEvent(const char[] matchId, const int mapNumber, const int roundNumber, const int roundTime, const CSRoundEndReason reason, const Get5Winner winner, const int team1Score, const int team2Score) {
+  public Get5RoundEndedEvent(const char[] matchId, const int mapNumber, const int roundNumber, const int roundTime,
+      const CSRoundEndReason reason, const Get5Winner winner, const Get5StatsTeam team1, const Get5StatsTeam team2) {
     Get5RoundEndedEvent self = view_as<Get5RoundEndedEvent>(new JSON_Object());
     self.SetEvent("round_end");
     self.SetMatchId(matchId);
@@ -1105,8 +1611,8 @@ methodmap Get5RoundEndedEvent < Get5TimedRoundEvent {
     self.RoundTime = roundTime;
     self.Reason = reason;
     self.Winner = winner;
-    self.Team1Score = team1Score;
-    self.Team2Score = team2Score;
+    self.Team1 = team1;
+    self.Team2 = team2;
     return self;
   }
 }
@@ -1866,60 +2372,6 @@ forward void Get5_OnPauseBegan(const Get5MatchPauseBeganEvent event);
 // Note that the match ID, map number and round number is the one being restored *to*, not the current game state at the
 // time the backup is loaded.
 forward void Get5_OnBackupRestore(const Get5BackupRestoredEvent event);
-
-// Series stats (root section)
-#define STAT_SERIESWINNER "winner"
-#define STAT_SERIESTYPE "series_type"
-#define STAT_SERIES_TEAM1NAME "team1_name"
-#define STAT_SERIES_TEAM2NAME "team2_name"
-#define STAT_SERIES_FORFEIT "forfeit"
-
-// Map stats (under "map0", "map1", etc.)
-#define STAT_MAPNAME "mapname"
-#define STAT_MAPWINNER "winner"
-#define STAT_DEMOFILENAME "demo_filename"
-
-// Team stats (under map section, then "team1" or "team2")
-#define STAT_TEAMSCORE "score"
-
-// Player stats (under map section, then team section, then player's steam64)
-// If adding stuff here, also add to the InitPlayerStats function!
-#define STAT_INIT "init" // used to zero-fill stats only. Not a real stat.
-#define STAT_COACHING "coaching" // indicates if the player is a coach.
-#define STAT_NAME "name"
-#define STAT_KILLS "kills"
-#define STAT_DEATHS "deaths"
-#define STAT_ASSISTS "assists"
-#define STAT_FLASHBANG_ASSISTS "flashbang_assists"
-#define STAT_TEAMKILLS "teamkills"
-#define STAT_SUICIDES "suicides"
-#define STAT_DAMAGE "damage"
-#define STAT_UTILITY_DAMAGE "util_damage"
-#define STAT_ENEMIES_FLASHED "enemies_flashed"
-#define STAT_FRIENDLIES_FLASHED "friendlies_flashed"
-#define STAT_KNIFE_KILLS "knife_kills"
-#define STAT_HEADSHOT_KILLS "headshot_kills"
-#define STAT_ROUNDSPLAYED "roundsplayed"
-#define STAT_BOMBDEFUSES "bomb_defuses"
-#define STAT_BOMBPLANTS "bomb_plants"
-#define STAT_1K "1kill_rounds"
-#define STAT_2K "2kill_rounds"
-#define STAT_3K "3kill_rounds"
-#define STAT_4K "4kill_rounds"
-#define STAT_5K "5kill_rounds"
-#define STAT_V1 "v1"
-#define STAT_V2 "v2"
-#define STAT_V3 "v3"
-#define STAT_V4 "v4"
-#define STAT_V5 "v5"
-#define STAT_FIRSTKILL_T "firstkill_t"
-#define STAT_FIRSTKILL_CT "firstkill_ct"
-#define STAT_FIRSTDEATH_T "firstdeath_t"
-#define STAT_FIRSTDEATH_CT "firstdeath_ct"
-#define STAT_TRADEKILL "tradekill"
-#define STAT_KAST "kast"
-#define STAT_CONTRIBUTION_SCORE "contribution_score"
-#define STAT_MVP "mvp"
 
 public SharedPlugin __pl_get5 = {
     name = "get5",


### PR DESCRIPTION
This adds stats to the `Get5_OnRoundEnd` event and also adds side-specific scores to the stats system.

This is going to be breaking as I plan on cleaning up the keys in the stats object for consistency.

Also fixes some inheritance syntax issues in the event documentation.

Closes https://github.com/splewis/get5/issues/990
Closes https://github.com/splewis/get5/issues/518

WIP.