### PR TITLE
Lots of improvements to stats + add support for team ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,20 +21,96 @@ details.
    name is always `GOTV`. Alternatively, you can ignore all messages with an empty `steamid`.
 2. The [stats system](https://splewis.github.io/get5/dev/stats_system/#keyvalue) has been updated. This means that
    the structure has been modified to allow for more information, specifically the starting side and score for each side
-   for each team.
+   for each team, full stats for players as well as a new option to add team IDs.
 
    **If you use any of the stats extensions, you must also update those plugins (`get5_mysqlstats.smx`
    and `get5_apistats.smx`)!**
 
+   Keys changed in the map root (i.e. `map0`):
+    1. `team1_name` and `team2_name` removed.
+    2. `team1` and `team2` added (objects), each with an `id` and a `name` key.
+
    Keys changed for each team (i.e. `map0 -> team1`):
-    1. Players' SteamIDs and stats have moved from the root of the team object into a key called `players`.
+    1. Players' SteamIDs and stats have moved from the root of the team object into an object called `players`.
     2. Added `score_ct`
     3. Added `score_t`
     4. Added `starting_side` (`2` for T, `3` for CT as this is an integer enum)
-3. The structure of the `Get5_OnRoundEnd` JSON event has changed (not to be confused with the KeyValues file in #2
-   above):
 
-   `teamX_score` (int) has been replaced by an object called `teamX`, which looks like this.
+3. The structure of the `Get5_OnSeriesInit` JSON event has changed:
+
+   Old:
+   ```json5
+   {
+     "event": "series_start",
+     "matchid": "29844",
+     "team1_name": "TeamName",
+     "team2_name": "AnotherTeamName"
+   }
+   ```
+   New:
+   ```json5
+   {
+     "event": "series_start",
+     "series_length": 3, // Bo3
+     "matchid": "29844",
+     "team1": {
+       "id": "482", // nullable in JSON, empty string in SourceMod.
+       "name": "TeamName"
+     }
+     // same for team2
+   }
+   ```
+4. The structure of the `Get5_OnMapResult` JSON event has changed:
+
+   Old:
+   ```json5
+   {
+     "event": "map_result",
+     "matchid": "29844",
+     "map_number": 0,
+     "winner": {
+       "team": "team1",
+       "side": "t"
+     },
+     "team1_score": 10,
+     "team2_score": 12
+   }
+   ```
+
+   New:
+   ```json5
+   {
+     "event": "map_result",
+     "matchid": "29844",
+     "map_number": 0,
+     "winner": {
+       "team": "team1",
+       "side": "t"
+     },
+     "team1": {
+       "id": "482", // nullable in JSON, empty string in SourceMod.
+       "name": "TeamName",
+       "series_score": 1,
+       "score": 10,
+       "score_ct": 4,
+       "score_t": 6,
+       "side": "t",
+       "starting_side": "ct",
+       "players": [
+         {
+           "name": "Nyxi",
+           "steamid": "76561197996426755",
+           "stats": {
+             // Full player stats.
+           }
+         }
+       ]
+     },
+     // same for team2
+   }
+   ```
+
+5. Similarly to 4., the structure of the `Get5_OnRoundEnd` JSON event has changed:
 
    Old:
    ```json5
@@ -69,7 +145,9 @@ details.
        "side": "t"
      },
      "team1": {
+       "id": "482", // nullable in JSON, empty string in SourceMod.
        "name": "TeamName",
+       "series_score": 1,
        "score": 10,
        "score_ct": 4,
        "score_t": 6,
@@ -89,8 +167,8 @@ details.
    }
    ```
 
-   This affects the `Get5_OnRoundEnd` forward as well, so if you have a plugin that reads this data, you must update it.
-   For full details and the SourceMod properties, see
+   These changes affect the corresponding forwards as well, so if you have a plugin that reads this data, you must
+   update it. For full details and the SourceMod properties, see
    the [event documentation](https://splewis.github.io/get5/dev/events_and_forwards/#events).
 4. Get5 no longer sets its [game state](https://splewis.github.io/get5/dev/commands/#get5_status) to `none`
    immediately following the end of the series, but now waits until the restore timer fires. Get5 will be in `post_game`
@@ -106,7 +184,8 @@ details.
    set [`get5_pretty_print_json 0`](https://splewis.github.io/get5/dev/configuration/#get5_pretty_print_json) to
    avoid hitting the limit. You **will** see an error in console if this happens.
 3. The `get5_mysqlstats` extension now uses a transaction to update stat rows for each player. This improves performance
-   via reduced I/O between the game server and the database server.
+   via reduced I/O between the game server and the database server. It now also runs on the JSON methodmaps provided to
+   forwards instead of copying the KeyValue stat object.
 4. The [documentation of events](https://splewis.github.io/get5/dev/events_and_forwards/#events) is now rendered
    on `https://redocly.github.io` instead of being embedded in the Get5 documentation website. This allows for more
    space and makes it easier to browse/read.
@@ -116,6 +195,8 @@ details.
    [`mp_teamlogo_1`](https://totalcsgo.com/command/mpteamlogo1) etc.) are now reset to blank when Get5 ends a series.
    Previously, these parameters would linger and would have to be manually reset or replaced by loading a new match
    configuration.
+6. You can now provide an `id` parameter to your team objects in match configurations, which is echoed back in the
+   forwards and JSON events.
 
 # 0.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ details.
 
 ⚠️ PRERELEASE
 
-#### 2022-03-09
+#### 2022-03-11
 
 ### Breaking Changes 🛠
 
@@ -170,7 +170,7 @@ details.
    These changes affect the corresponding forwards as well, so if you have a plugin that reads this data, you must
    update it. For full details and the SourceMod properties, see
    the [event documentation](https://splewis.github.io/get5/dev/events_and_forwards/#events).
-4. Get5 no longer sets its [game state](https://splewis.github.io/get5/dev/commands/#get5_status) to `none`
+6. Get5 no longer sets its [game state](https://splewis.github.io/get5/dev/commands/#get5_status) to `none`
    immediately following the end of the series, but now waits until the restore timer fires. Get5 will be in `post_game`
    until the timer runs out, similarly to when waiting for the next map. This means that GOTV broadcasts will have a
    chance to finish before Get5 releases the server.
@@ -332,10 +332,10 @@ to [the documentation](https://splewis.github.io/get5/latest/translations/) for 
    separately from [`get5_time_to_start`](https://splewis.github.io/get5/latest/configuration/#get5_time_to_start). If
    you don't set this variable, players will have infinite time to ready for veto.
 4. `maplist` is now required in match configurations. There is now no "default map list" in Get5.
-6. The `filename` property of the `demo_finished` and `demo_upload_ended` events now includes the folder, i.e. the full
+5. The `filename` property of the `demo_finished` and `demo_upload_ended` events now includes the folder, i.e. the full
    path to the file, if [`get5_demo_path`](https://splewis.github.io/get5/latest/configuration/#get5_demo_path) is set.
-7. `Get5_OnPreLoadMatchConfig()` no longer fires when loading a backup file.
-8. If you use `fromfile`, make sure to always have JSON files end with `.json`, or Get5 will assume they are KeyValues,
+6. `Get5_OnPreLoadMatchConfig()` no longer fires when loading a backup file.
+7. If you use `fromfile`, make sure to always have JSON files end with `.json`, or Get5 will assume they are KeyValues,
    regardless of the format of the match config.
 
 ### New Features 🎉

--- a/configs/get5/tests/default_valid.cfg
+++ b/configs/get5/tests/default_valid.cfg
@@ -27,6 +27,7 @@
     "favored_percentage_text"  "team percentage text"
     "team1"
     {
+        "id"         "TeamAID"
         "name"       "Team A Default"
         "tag"        "TAG-A"
         "flag"       "US"

--- a/configs/get5/tests/default_valid.json
+++ b/configs/get5/tests/default_valid.json
@@ -23,6 +23,7 @@
   "favored_percentage_team1": 75,
   "favored_percentage_text": "team percentage text",
   "team1": {
+    "id": "TeamAID",
     "name": "Team A Default",
     "tag": "TAG-A",
     "flag": "US",

--- a/configs/get5/tests/team2.cfg
+++ b/configs/get5/tests/team2.cfg
@@ -1,5 +1,6 @@
 "Team"
 {
+    "id"        "TeamBID"
     "name"      "Team B Default"
     "tag"       "TAG-FF"
     "flag"      "DE"

--- a/configs/get5/tests/team2.json
+++ b/configs/get5/tests/team2.json
@@ -1,4 +1,5 @@
 {
+  "id": "TeamBID",
   "name": "Team B Default",
   "tag": "TAG-FF",
   "flag": "DE",

--- a/documentation/docs/event_schema.yml
+++ b/documentation/docs/event_schema.yml
@@ -163,16 +163,14 @@ paths:
                     event:
                       enum:
                         - series_start
-                    team1_name:
-                      type: string
-                      example: NaVi
-                      description: The name of team 1. `GetTeam1Name()` and `SetTeam1Name()`
-                        in SourceMod.
-                    team2_name:
-                      type: string
-                      example: Astralis
-                      description: The name of team 2. `GetTeam2Name()` and `SetTeam2Name()`
-                        in SourceMod.
+                    series_length:
+                      type: integer
+                      minimum: 1
+                      description: The number of maps in the series, i.e. 3 for a Bo3. `SeriesLength` in SourceMod.
+                    team1:
+                      "$ref": "#/components/schemas/Get5TeamWrapper"
+                    team2:
+                      "$ref": "#/components/schemas/Get5TeamWrapper"
       responses: { }
   "/Get5_OnMatchPaused":
     post:
@@ -255,16 +253,10 @@ paths:
                     event:
                       enum:
                         - map_result
-                    team1_score:
-                      type: integer
-                      minimum: 0
-                      description: The score of team1. `Team1Score` in SourceMod.
-                      example: 16
-                    team2_score:
-                      type: integer
-                      minimum: 0
-                      description: The score of team2. `Team2Score` in SourceMod.
-                      example: 13
+                    team1:
+                      $ref: "#/components/schemas/Get5StatsTeam"
+                    team2:
+                      $ref: "#/components/schemas/Get5StatsTeam"
                     winner:
                       $ref: "#/components/schemas/Get5Winner"
       responses: { }
@@ -1112,43 +1104,59 @@ components:
           properties:
             pause_type:
               $ref: "#/components/schemas/Get5PauseType"
-    Get5StatsTeam:
+    Get5TeamWrapper:
       type: object
+      description: Describes a team. `Team1` or `Team2` in SourceMod.
       properties:
+        id:
+          type: string
+          description: User-supplied ID of the team, if one was provided. `GetId()` and `SetId()` in SourceMod. `null` in JSON and an empty string in SourceMod.
+          example: "2843"
+          nullable: true
         name:
           type: string
-          description: The name of the team.
+          description: The name of the team. `GetName()` and `SetName()` in SourceMod.
           example: Natus Vincere
-        score:
-          type: integer
-          minimum: 0
-          description: The team's total score on the current map.
-          example: 14
-        score_ct:
-          type: integer
-          minimum: 0
-          description: The team's score on the CT side on the current map.
-          example: 10
-        score_t:
-          type: integer
-          minimum: 0
-          description: The team's score on the T side on the current map.
-          example: 14
-        players:
-          type: array
-          description: The players on the team.
-          items:
-            $ref: "#/components/schemas/Get5StatsPlayer"
-        side:
-          title: Get5Side
-          description: The current side of the team.
-          allOf:
-            - $ref: "#/components/schemas/Get5Side"
-        starting_side:
-          title: Get5Side
-          description: The starting side of the team.
-          allOf:
-            - $ref: "#/components/schemas/Get5Side"
+    Get5StatsTeam:
+      description: Describes a team with its score and player stats. `Team1` or `Team2` in SourceMod.
+      allOf:
+        - $ref: "#/components/schemas/Get5TeamWrapper"
+        - type: object
+          properties:
+            series_score:
+              type: integer
+              minimum: 0
+              description: The team's current series score, i.e. the number of maps they have won in the series. `SeriesScore` in SourceMod.
+            score:
+              type: integer
+              minimum: 0
+              description: The team's total score on the current map. `Score` in SourceMod.
+              example: 14
+            score_ct:
+              type: integer
+              minimum: 0
+              description: The team's score on the CT side on the current map. `ScoreCT` in SourceMod.
+              example: 10
+            score_t:
+              type: integer
+              minimum: 0
+              description: The team's score on the T side on the current map. `ScoreT` in SourceMod.
+              example: 14
+            players:
+              type: array
+              description: The players on the team. `Players` in SourceMod.
+              items:
+                $ref: "#/components/schemas/Get5StatsPlayer"
+            side:
+              title: Get5Side
+              description: The current side of the team. `Side` in SourceMod.
+              allOf:
+                - $ref: "#/components/schemas/Get5Side"
+            starting_side:
+              title: Get5Side
+              description: The starting side of the team. `StartingSide` in SourceMod.
+              allOf:
+                - $ref: "#/components/schemas/Get5Side"
     Get5PlayerBase:
       type: object
       properties:
@@ -1324,10 +1332,10 @@ components:
           minimum: 0
           description: 'The number of assists the player had. `Assists` in SourceMod.'
           example: 5
-        flashbang_assists:
+        flash_assists:
           type: integer
           minimum: 0
-          description: 'The number of flashbang assists the player had. `FlashbangAssists` in SourceMod.'
+          description: 'The number of flashbang assists the player had. `FlashAssists` in SourceMod.'
           example: 3
         team_kills:
           type: integer

--- a/documentation/docs/match_schema.md
+++ b/documentation/docs/match_schema.md
@@ -20,6 +20,7 @@ type SteamID = string // (8)
 type Get5PlayerSet = { [key: SteamID]: string } | SteamID[] // (9)
 
 interface Get5MatchTeam {
+    "id": string | undefined // (38)
     "players": Get5PlayerSet // (24)
     "coaches": Get5PlayerSet | undefined // (23)
     "name": string | undefined // (16)
@@ -164,6 +165,8 @@ interface Get5Match {
     strings consisting of any valid combination of `team1_ban`, `team2_ban`, `team1_pick` and `team2_pick`.
 37. _Optional_<br>Whether to configure the match for [Wingman mode](../wingman). If this is enabled, `players_per_team`
     defaults to `2` instead of `5`.<br><br>**`Default: false`**
+38. _Optional_<br>The ID of the team. This can be used to link the team to an external resource, such as a database ID.
+    The ID is included in the event system for events that include a team.
 
 !!! info "Team assignment priority"
 
@@ -230,6 +233,7 @@ These examples are identical in the way they would work if loaded.
         "fromfile": "addons/sourcemod/get5/team_navi.json"
       },
       "team2": {
+        "id": "3752",
         "name": "Astralis",
         "tag": "Astralis",
         "flag": "DK",
@@ -257,6 +261,7 @@ These examples are identical in the way they would work if loaded.
     `fromfile` example:
     ```json title="addons/sourcemod/get5/team_navi.json"
     {
+      "id": "1348",
       "name": "Natus Vincere",
       "tag": "NaVi",
       "flag": "UA",
@@ -311,6 +316,7 @@ These examples are identical in the way they would work if loaded.
             "fromfile": "addons/sourcemod/get5/team_navi.json"
         },
         "team2": {
+            "id": "3752",
             "name": "Astralis",
             "tag": "Astralis",
             "flag": "DK",
@@ -394,8 +400,9 @@ These examples are identical in the way they would work if loaded.
         }
         "team2"
         {
+            "id" "3752"
             "name" "Astralis"
-            "tag"  "Astralis"
+            "tag" "Astralis"
             "flag" "DK"
             "logo" "astr"
             "matchtext" "Defending Champions"
@@ -424,9 +431,10 @@ These examples are identical in the way they would work if loaded.
     `fromfile` example:
     ```cfg title="addons/sourcemod/get5/team_navi.cfg"
     "Team"
-    { 
+    {
+        "id" "1348"
         "name" "Natus Vincere"
-        "tag"  "NaVi"
+        "tag" "NaVi"
         "flag" "UA"
         "logo" "navi"
         "matchtext" "Challengers"

--- a/documentation/docs/stats_system.md
+++ b/documentation/docs/stats_system.md
@@ -10,6 +10,12 @@
 If you're writing your own plugin, you can collect stats from the game using the
 [forwards](../events_and_forwards) provided by Get5.
 
+## HTTP Events {: #http }
+
+If you want to send stats to a web server, the [HTTP event system](../events_and_forwards#http) will let you collect
+game information at any level of granularity by sending data as JSON over HTTP(S); from grenades thrown, kills, player
+chat messages to round, map or series results.
+
 ## KeyValue System {: #keyvalue }
 
 Get5 will automatically record basic stats for each player for each map in the match. These are stored in an internal
@@ -17,50 +23,97 @@ KeyValues structure, and are available at any time during the match (including t
 `Get5_GetMatchStats` native and the [`get5_dumpstats`](../commands#get5_dumpstats) command.
 
 The root level contains data for the full series; the series winner (if one exists yet) and the series type (bo1, bo3,
-etc).
+etc.) and the team names/IDs.
 
 Under the root level is a level for each map (`map0`, `map1` etc.), which contains the map winner (if one exists yet),
 the map name and the demo file recording.
 
 Under the map level is a section for each team (`team1` and `team2`), which contains the current team score (on
-that map) and the team name.
+that map), the score for each side on that map (CT vs. T) and the side the team started on as well as an object with
+player stats (`players`) for the entire team, saved under each player's SteamID64.
 
-Each player has a section under the team level under the section name of their SteamID 64. It contains all the personal
-level stats: name, kills, deaths, assists, etc.
+#### Example
 
-Partial Example:
+!!! example "`get5_matchstats.cfg`"
 
-```
-"Stats"
-{
-    "series_type"       "bo1"
-    "team1_name"        "EnvyUs"
-    "team2_name"        "Fnatic"
-    "map0"
+    ```
+    "Stats"
     {
-        "mapname"       "de_mirage"
-        "demo_filename" "304_map1_de_mirage.dem"
-        "winner"        "team1"
+        "series_type"  "bo1"
         "team1"
         {
-            "score"          "5"
-            "73613643164646"
+            "id"    "23758"
+            "name"  "EnvyUs"
+        }
+        "team2"
+        {
+            "id"    "15716"
+            "name"  "Fnatic"
+        }
+        "winner"  "team1"
+        "map0"
+        {
+            "mapname"        "de_mirage"
+            "demo_filename"  "304_map1_de_mirage.dem"
+            "winner"         "team1"
+            "team1"
             {
-                "name"    "xyz"
-                "kills"   "0"
-                "deaths"  "1"
-                "assists" "5"
-                "damage"  "352"
+                "players"
+                {
+                    "76561197996426755"
+                    {
+                        "init"                "1" // internal init key, ignore this
+                        "coaching"            "0" // 1 if the player is a coach
+                        "name"                "xyz"
+                        "kills"               "9"
+                        "deaths"              "3"
+                        "assists"             "5"
+                        "flashbang_assists"   "2"
+                        "teamkills"           "0"
+                        "suicides"            "0"
+                        "damage"              "945"
+                        "util_damage"         "34"
+                        "enemies_flashed"     "4"
+                        "friendlies_flashed"  "1"
+                        "knife_kills"         "0"
+                        "headshot_kills"      "3"
+                        "roundsplayed"        "8"
+                        "bomb_defuses"        "1"
+                        "bomb_plants"         "0"
+                        "1kill_rounds"        "1"
+                        "2kill_rounds"        "2"
+                        "3kill_rounds"        "1"
+                        "4kill_rounds"        "0"
+                        "5kill_rounds"        "0"
+                        "v1"                  "3" // 1v1s won
+                        "v2"                  "2"
+                        "v3"                  "1"
+                        "v4"                  "0"
+                        "v5"                  "0"
+                        "firstkill_t"         "0"
+                        "firstkill_ct"        "2"
+                        "firstdeath_t"        "0"
+                        "firstdeath_ct"       "2"
+                        "tradekill"           "4"
+                        "kast"                "8"
+                        "contribution_score"  "23"
+                        "mvp" "4"
+                    }
+                }
+                "score"          "5" // total rounds won
+                "score_ct"       "2" // rounds won on CT
+                "score_t"        "3" // rounds won on T
+                "starting_side"  "3" // 3 for CT, 2 for T  
             }
         }
     }
-}
-```
+    ```
 
-!!! question "What stats are collected?"
+!!! info "KeyValues != JSON"
 
-    See the [get5.inc include file](https://github.com/splewis/get5/blob/master/scripting/include/get5.inc#L1769) for
-    what stats will be recorded and what their keys are in the KeyValue structure.
+    Please note that the [JSON events](../events_and_forwards) have similar - **but not identical** - structure and
+    keys to this file. The KeyValues system is inferior to the JSON-based HTTP system in many ways, and most modern
+    integrations would likely be better off using JSON, especially if data is being sent to a web server.
 
 ## MySQL Statistics {: #mysql }
 

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -142,6 +142,7 @@ ArrayList g_TeamPlayers[MATCHTEAM_COUNT];
 ArrayList g_TeamCoaches[MATCHTEAM_COUNT];
 StringMap g_PlayerNames;
 StringMap g_ChatCommands;
+char g_TeamIDs[MATCHTEAM_COUNT][MAX_CVAR_LENGTH];
 char g_TeamNames[MATCHTEAM_COUNT][MAX_CVAR_LENGTH];
 char g_TeamTags[MATCHTEAM_COUNT][MAX_CVAR_LENGTH];
 char g_FormattedTeamNames[MATCHTEAM_COUNT][MAX_CVAR_LENGTH];
@@ -1067,12 +1068,21 @@ static Action Command_EndMatch(int client, int args) {
   }
 
   // Call game-ending forwards.
-  int team1score = CS_GetTeamScore(Get5TeamToCSTeam(Get5Team_1));
-  int team2score = CS_GetTeamScore(Get5TeamToCSTeam(Get5Team_2));
+  Get5Side team1Side = view_as<Get5Side>(Get5TeamToCSTeam(Get5Team_1));
+  Get5Side team2Side = view_as<Get5Side>(Get5TeamToCSTeam(Get5Team_2));
+  int team1score = CS_GetTeamScore(view_as<int>(team1Side));
+  int team2score = CS_GetTeamScore(view_as<int>(team2Side));
 
-  Get5MapResultEvent mapResultEvent = new Get5MapResultEvent(
-    g_MatchID, g_MapNumber, new Get5Winner(winningTeam, view_as<Get5Side>(Get5TeamToCSTeam(winningTeam))), team1score,
-    team2score);
+  Get5StatsTeam team1 = new Get5StatsTeam(g_TeamIDs[Get5Team_1], g_TeamNames[Get5Team_1], team1score,
+                                          g_TeamSeriesScores[Get5Team_1], team1Side);
+  Get5StatsTeam team2 = new Get5StatsTeam(g_TeamIDs[Get5Team_2], g_TeamNames[Get5Team_2], team2score,
+                                          g_TeamSeriesScores[Get5Team_2], team2Side);
+
+  FillPlayerStats(team1, team2);
+
+  Get5MapResultEvent mapResultEvent =
+    new Get5MapResultEvent(g_MatchID, g_MapNumber,
+                           new Get5Winner(winningTeam, view_as<Get5Side>(Get5TeamToCSTeam(winningTeam))), team1, team2);
 
   LogDebug("Calling Get5_OnMapResult()");
   Call_StartForward(g_OnMapResult);
@@ -1429,12 +1439,14 @@ static Action Event_MatchOver(Event event, const char[] name, bool dontBroadcast
       UnpauseGame();
     }
     // Figure out who won
-    int t1score = CS_GetTeamScore(Get5TeamToCSTeam(Get5Team_1));
-    int t2score = CS_GetTeamScore(Get5TeamToCSTeam(Get5Team_2));
+    Get5Side team1Side = view_as<Get5Side>(Get5TeamToCSTeam(Get5Team_1));
+    Get5Side team2Side = view_as<Get5Side>(Get5TeamToCSTeam(Get5Team_2));
+    int team1score = CS_GetTeamScore(view_as<int>(team1Side));
+    int team2score = CS_GetTeamScore(view_as<int>(team2Side));
     Get5Team winningTeam = Get5Team_None;
-    if (t1score > t2score) {
+    if (team1score > team2score) {
       winningTeam = Get5Team_1;
-    } else if (t2score > t1score) {
+    } else if (team2score > team1score) {
       winningTeam = Get5Team_2;
     }
 
@@ -1446,12 +1458,19 @@ static Action Event_MatchOver(Event event, const char[] name, bool dontBroadcast
     Stats_UpdateMapScore(winningTeam);
     g_TeamSeriesScores[winningTeam]++;
 
-    g_TeamScoresPerMap.Set(g_MapNumber, t1score, view_as<int>(Get5Team_1));
-    g_TeamScoresPerMap.Set(g_MapNumber, t2score, view_as<int>(Get5Team_2));
+    g_TeamScoresPerMap.Set(g_MapNumber, team1score, view_as<int>(Get5Team_1));
+    g_TeamScoresPerMap.Set(g_MapNumber, team2score, view_as<int>(Get5Team_2));
+
+    Get5StatsTeam team1 = new Get5StatsTeam(g_TeamIDs[Get5Team_1], g_TeamNames[Get5Team_1], team1score,
+                                            g_TeamSeriesScores[Get5Team_1], team1Side);
+    Get5StatsTeam team2 = new Get5StatsTeam(g_TeamIDs[Get5Team_2], g_TeamNames[Get5Team_2], team2score,
+                                            g_TeamSeriesScores[Get5Team_2], team2Side);
+
+    FillPlayerStats(team1, team2);
 
     Get5MapResultEvent mapResultEvent = new Get5MapResultEvent(
-      g_MatchID, g_MapNumber, new Get5Winner(winningTeam, view_as<Get5Side>(Get5TeamToCSTeam(winningTeam))), t1score,
-      t2score);
+      g_MatchID, g_MapNumber, new Get5Winner(winningTeam, view_as<Get5Side>(Get5TeamToCSTeam(winningTeam))), team1,
+      team2);
 
     LogDebug("Calling Get5_OnMapResult()");
 
@@ -1640,6 +1659,7 @@ void ResetMatchConfigVariables(bool backup = false) {
   g_MapsLeftInVetoPool.Clear();
   g_TeamScoresPerMap.Clear();
   for (int i = 0; i < MATCHTEAM_COUNT; i++) {
+    g_TeamIDs[i] = "";
     g_TeamNames[i] = "";
     g_TeamTags[i] = "";
     g_FormattedTeamNames[i] = "";
@@ -1981,8 +2001,10 @@ static Action Event_RoundEnd(Event event, const char[] name, bool dontBroadcast)
       }
     }
 
-    Get5StatsTeam team1 = new Get5StatsTeam(g_TeamNames[Get5Team_1], team1Score, team1Side);
-    Get5StatsTeam team2 = new Get5StatsTeam(g_TeamNames[Get5Team_2], team2Score, team2Side);
+    Get5StatsTeam team1 = new Get5StatsTeam(g_TeamIDs[Get5Team_1], g_TeamNames[Get5Team_1], team1Score,
+                                            g_TeamSeriesScores[Get5Team_1], team1Side);
+    Get5StatsTeam team2 = new Get5StatsTeam(g_TeamIDs[Get5Team_2], g_TeamNames[Get5Team_2], team2Score,
+                                            g_TeamSeriesScores[Get5Team_2], team2Side);
 
     FillPlayerStats(team1, team2);
 

--- a/scripting/get5/debug.sp
+++ b/scripting/get5/debug.sp
@@ -133,6 +133,7 @@ static void AddGlobalStateInfo(File f) {
   LOOP_TEAMS(team) {
     GetTeamString(team, buffer, sizeof(buffer));
     f.WriteLine("Team info for %s (%d):", buffer, team);
+    f.WriteLine("g_TeamIDs = %s", g_TeamIDs[team]);
     f.WriteLine("g_TeamNames = %s", g_TeamNames[team]);
     WriteArrayList(f, "g_TeamPlayers", g_TeamPlayers[team]);
     f.WriteLine("g_TeamTags = %s", g_TeamTags[team]);

--- a/scripting/get5/stats.sp
+++ b/scripting/get5/stats.sp
@@ -163,12 +163,19 @@ void Stats_Reset() {
 
 void Stats_InitSeries() {
   Stats_Reset();
-  char seriesType[32];
+  char seriesType[16];
   FormatEx(seriesType, sizeof(seriesType), "bo%d", g_NumberOfMapsInSeries);
   g_StatsKv.SetString(STAT_SERIESTYPE, seriesType);
-  g_StatsKv.SetString(STAT_SERIES_TEAM1NAME, g_TeamNames[Get5Team_1]);
-  g_StatsKv.SetString(STAT_SERIES_TEAM2NAME, g_TeamNames[Get5Team_2]);
+  InitTeam(Get5Team_1);
+  InitTeam(Get5Team_2);
   DumpToFile();
+}
+
+static void InitTeam(Get5Team team) {
+  g_StatsKv.JumpToKey(team == Get5Team_1 ? "team1" : "team2", true);
+  g_StatsKv.SetString(STAT_SERIES_TEAM_ID, g_TeamIDs[team]);
+  g_StatsKv.SetString(STAT_SERIES_TEAM_NAME, g_TeamNames[team]);
+  g_StatsKv.GoBack();
 }
 
 void Stats_ResetRoundValues() {

--- a/scripting/get5/tests.sp
+++ b/scripting/get5/tests.sp
@@ -622,6 +622,7 @@ static void ValidMatchConfigTest(const char[] matchConfig) {
   AssertStrEq("Steam ID Coach 2 Team A", playerId, "76561197946789735");
   AssertStrEq("Name Coach 2 Team A", playerName, "CoachAName2");
 
+  AssertStrEq("Team A ID", g_TeamIDs[Get5Team_1], "TeamAID");
   AssertStrEq("Team A Name", g_TeamNames[Get5Team_1], "Team A Default");
   AssertStrEq("Team A Logo", g_TeamLogos[Get5Team_1], "logofilename");
   AssertStrEq("Team A Flag", g_TeamFlags[Get5Team_1], "US");
@@ -648,6 +649,7 @@ static void ValidMatchConfigTest(const char[] matchConfig) {
 
   AssertEq("Team B Coaches Empty", GetTeamCoaches(Get5Team_2).Length, 0);
 
+  AssertStrEq("Team B ID", g_TeamIDs[Get5Team_2], "TeamBID");
   AssertStrEq("Team B Name", g_TeamNames[Get5Team_2], "Team B Default");
   AssertStrEq("Team B Logo", g_TeamLogos[Get5Team_2], "fromfile_team");
   AssertStrEq("Team B Flag", g_TeamFlags[Get5Team_2], "DE");

--- a/scripting/get5_apistats.sp
+++ b/scripting/get5_apistats.sp
@@ -275,8 +275,8 @@ public void Get5_OnMapResult(const Get5MapResultEvent event) {
 
   Handle req = CreateRequest(k_EHTTPMethodPOST, "match/%s/map/%d/finish", matchId, event.MapNumber);
   if (req != INVALID_HANDLE) {
-    AddIntParam(req, "team1score", event.Team1Score);
-    AddIntParam(req, "team2score", event.Team2Score);
+    AddIntParam(req, "team1score", event.Team1.Score);
+    AddIntParam(req, "team2score", event.Team2.Score);
     AddStringParam(req, "winner", winnerString);
     SteamWorks_SendHTTPRequest(req);
   }

--- a/scripting/get5_mysqlstats.sp
+++ b/scripting/get5_mysqlstats.sp
@@ -91,7 +91,7 @@ public void Get5_OnSeriesInit(const Get5SeriesStartedEvent event) {
   // strings used for get5_scrim and get5_creatematch, so without that condition, those would break
   // the default mysql as only integers are accepted.
   if (strlen(matchId) > 0 && !StrEqual(matchId, "scrim") && !StrEqual(matchId, "manual")) {
-    char matchIdSz[64];
+    char matchIdSz[128];
     db.Escape(matchId, matchIdSz, sizeof(matchIdSz));
 
     FormatEx(queryBuffer, sizeof(queryBuffer), "INSERT INTO `get5_stats_matches` \
@@ -141,7 +141,7 @@ public void Get5_OnGoingLive(const Get5GoingLiveEvent event) {
   char mapNameSz[sizeof(mapName) * 2 + 1];
   db.Escape(mapName, mapNameSz, sizeof(mapNameSz));
 
-  char matchIdSz[64];
+  char matchIdSz[128];
   db.Escape(matchId, matchIdSz, sizeof(matchIdSz));
 
   FormatEx(queryBuffer, sizeof(queryBuffer), "INSERT IGNORE INTO `get5_stats_maps` \
@@ -161,7 +161,7 @@ public void Get5_OnMapResult(const Get5MapResultEvent event) {
   char matchId[64];
   event.GetMatchId(matchId, sizeof(matchId));
 
-  char matchIdSz[64];
+  char matchIdSz[128];
   db.Escape(matchId, matchIdSz, sizeof(matchIdSz));
 
   // Update the map winner
@@ -209,7 +209,7 @@ public void Get5_OnSeriesResult(const Get5SeriesResultEvent event) {
   char winnerString[64];
   GetTeamString(event.Winner.Team, winnerString, sizeof(winnerString));
 
-  char matchIdSz[64];
+  char matchIdSz[128];
   db.Escape(matchId, matchIdSz, sizeof(matchIdSz));
 
   FormatEx(queryBuffer, sizeof(queryBuffer), "UPDATE `get5_stats_matches` \

--- a/scripting/get5_mysqlstats.sp
+++ b/scripting/get5_mysqlstats.sp
@@ -71,27 +71,20 @@ public void Get5_OnSeriesInit(const Get5SeriesStartedEvent event) {
   char team2Name[64];
   char serverId[65];
 
-  char seriesTypeSz[sizeof(seriesType) * 2 + 1];
   char team1NameSz[sizeof(team1Name) * 2 + 1];
   char team2NameSz[sizeof(team2Name) * 2 + 1];
   char serverIdSz[sizeof(serverId) * 2 + 1];
 
-  KeyValues tmpStats = new KeyValues("Stats");
+  FormatEx(seriesType, sizeof(seriesType), "bo%d", event.SeriesLength);
 
-  Get5_GetMatchStats(tmpStats);
-  tmpStats.GetString(STAT_SERIESTYPE, seriesType, sizeof(seriesType));
-  db.Escape(seriesType, seriesTypeSz, sizeof(seriesTypeSz));
+  event.Team1.GetName(team1Name, sizeof(team1Name));
+  event.Team2.GetName(team2Name, sizeof(team2Name));
 
-  tmpStats.GetString(STAT_SERIES_TEAM1NAME, team1Name, sizeof(team1Name));
   db.Escape(team1Name, team1NameSz, sizeof(team1NameSz));
-
-  tmpStats.GetString(STAT_SERIES_TEAM2NAME, team2Name, sizeof(team2Name));
   db.Escape(team2Name, team2NameSz, sizeof(team2NameSz));
 
   Get5_GetServerID(serverId, sizeof(serverId));
   db.Escape(serverId, serverIdSz, sizeof(serverIdSz));
-
-  delete tmpStats;
 
   // Match ID defaults to an empty string, so if it's empty we use auto-increment from MySQL.
   // We also consider "scrim" and "manual" candidates for auto-increment, as those are the fixed
@@ -104,7 +97,7 @@ public void Get5_OnSeriesInit(const Get5SeriesStartedEvent event) {
     FormatEx(queryBuffer, sizeof(queryBuffer), "INSERT INTO `get5_stats_matches` \
             (matchid, series_type, team1_name, team2_name, start_time, server_id) VALUES \
             ('%s', '%s', '%s', '%s', NOW(), '%s')",
-             matchIdSz, seriesTypeSz, team1NameSz, team2NameSz, serverIdSz);
+             matchIdSz, seriesType, team1NameSz, team2NameSz, serverIdSz);
     LogDebug(queryBuffer);
     db.Query(SQLErrorCheckCallback, queryBuffer);
     LogMessage("Starting match with preset ID: %s", matchId);
@@ -112,7 +105,7 @@ public void Get5_OnSeriesInit(const Get5SeriesStartedEvent event) {
     FormatEx(queryBuffer, sizeof(queryBuffer), "INSERT INTO `get5_stats_matches` \
             (series_type, team1_name, team2_name, start_time, server_id) VALUES \
             ('%s', '%s', '%s', NOW(), '%s')",
-             seriesTypeSz, team1NameSz, team2NameSz, serverIdSz);
+             seriesType, team1NameSz, team2NameSz, serverIdSz);
     LogDebug(queryBuffer);
     db.Query(MatchInitCallback, queryBuffer);
   }
@@ -160,44 +153,6 @@ public void Get5_OnGoingLive(const Get5GoingLiveEvent event) {
   db.Query(SQLErrorCheckCallback, queryBuffer);
 }
 
-static void UpdateRoundStats(const char[] matchId, const int mapNumber) {
-  int t1score = 0;
-  int t2score = 0;
-  // Update player stats
-  KeyValues kv = new KeyValues("Stats");
-  Get5_GetMatchStats(kv);
-  char mapKey[32];
-  FormatEx(mapKey, sizeof(mapKey), "map%d", mapNumber);
-  if (kv.JumpToKey(mapKey)) {
-    if (kv.JumpToKey("team1")) {
-      t1score = kv.GetNum("score");
-      if (kv.JumpToKey("players")) {
-        AddPlayerStats(matchId, mapNumber, kv, Get5Team_1);
-        kv.GoBack();
-      }
-      kv.GoBack();
-    }
-    if (kv.JumpToKey("team2")) {
-      t2score = kv.GetNum("score");
-      if (kv.JumpToKey("players")) {
-        AddPlayerStats(matchId, mapNumber, kv, Get5Team_2);
-        kv.GoBack();
-      }
-      kv.GoBack();
-    }
-    kv.GoBack();
-  }
-  delete kv;
-
-  char matchIdSz[64];
-  db.Escape(matchId, matchIdSz, sizeof(matchIdSz));
-  FormatEx(queryBuffer, sizeof(queryBuffer), "UPDATE `get5_stats_maps` \
-        SET team1_score = %d, team2_score = %d WHERE matchid = '%s' and mapnumber = %d",
-           t1score, t2score, matchIdSz, mapNumber);
-  LogDebug(queryBuffer);
-  db.Query(SQLErrorCheckCallback, queryBuffer);
-}
-
 public void Get5_OnMapResult(const Get5MapResultEvent event) {
   if (g_DisableStats) {
     return;
@@ -212,153 +167,23 @@ public void Get5_OnMapResult(const Get5MapResultEvent event) {
   // Update the map winner
   char winnerString[64];
   GetTeamString(event.Winner.Team, winnerString, sizeof(winnerString));
+
+  Transaction t = new Transaction();
+
   FormatEx(queryBuffer, sizeof(queryBuffer), "UPDATE `get5_stats_maps` SET winner = '%s', end_time = NOW() \
         WHERE matchid = '%s' and mapnumber = %d",
            winnerString, matchIdSz, event.MapNumber);
   LogDebug(queryBuffer);
-  db.Query(SQLErrorCheckCallback, queryBuffer);
+  t.AddQuery(queryBuffer);
 
   // Update the series scores
-  int t1_seriesscore, t2_seriesscore, tmp;
-  Get5_GetTeamScores(Get5Team_1, t1_seriesscore, tmp);
-  Get5_GetTeamScores(Get5Team_2, t2_seriesscore, tmp);
-
   FormatEx(queryBuffer, sizeof(queryBuffer), "UPDATE `get5_stats_matches` \
         SET team1_score = %d, team2_score = %d WHERE matchid = '%s'",
-           t1_seriesscore, t2_seriesscore, matchIdSz);
+           event.Team1.SeriesScore, event.Team2.SeriesScore, matchIdSz);
   LogDebug(queryBuffer);
-  db.Query(SQLErrorCheckCallback, queryBuffer);
-}
+  t.AddQuery(queryBuffer);
 
-static void AddPlayerStats(const char[] matchId, const int mapNumber, const KeyValues kv, const Get5Team team) {
-  char name[MAX_NAME_LENGTH];
-  char auth[AUTH_LENGTH];
-  char nameSz[MAX_NAME_LENGTH * 2 + 1];
-  char authSz[AUTH_LENGTH * 2 + 1];
-
-  char matchIdSz[64];
-  db.Escape(matchId, matchIdSz, sizeof(matchIdSz));
-
-  if (kv.GotoFirstSubKey()) {
-    Transaction t = new Transaction();
-    do {
-      if (kv.GetNum(STAT_COACHING, 0) > 0) {
-        continue;  // Don't update stats for coaches.
-      }
-      kv.GetSectionName(auth, sizeof(auth));
-      kv.GetString("name", name, sizeof(name));
-      db.Escape(auth, authSz, sizeof(authSz));
-      db.Escape(name, nameSz, sizeof(nameSz));
-
-      int kills = kv.GetNum(STAT_KILLS);
-      int deaths = kv.GetNum(STAT_DEATHS);
-      int flashbang_assists = kv.GetNum(STAT_FLASHBANG_ASSISTS);
-      int assists = kv.GetNum(STAT_ASSISTS);
-      int teamkills = kv.GetNum(STAT_TEAMKILLS);
-      int damage = kv.GetNum(STAT_DAMAGE);
-      int utility_damage = kv.GetNum(STAT_UTILITY_DAMAGE);
-      int enemies_flashed = kv.GetNum(STAT_ENEMIES_FLASHED);
-      int friendlies_flashed = kv.GetNum(STAT_FRIENDLIES_FLASHED);
-      int headshot_kills = kv.GetNum(STAT_HEADSHOT_KILLS);
-      int knife_kills = kv.GetNum(STAT_KNIFE_KILLS);
-      int roundsplayed = kv.GetNum(STAT_ROUNDSPLAYED);
-      int plants = kv.GetNum(STAT_BOMBPLANTS);
-      int defuses = kv.GetNum(STAT_BOMBDEFUSES);
-      int v1 = kv.GetNum(STAT_V1);
-      int v2 = kv.GetNum(STAT_V2);
-      int v3 = kv.GetNum(STAT_V3);
-      int v4 = kv.GetNum(STAT_V4);
-      int v5 = kv.GetNum(STAT_V5);
-      int k2 = kv.GetNum(STAT_2K);
-      int k3 = kv.GetNum(STAT_3K);
-      int k4 = kv.GetNum(STAT_4K);
-      int k5 = kv.GetNum(STAT_5K);
-      int firstkill_t = kv.GetNum(STAT_FIRSTKILL_T);
-      int firstkill_ct = kv.GetNum(STAT_FIRSTKILL_CT);
-      int firstdeath_t = kv.GetNum(STAT_FIRSTDEATH_T);
-      int firstdeath_ct = kv.GetNum(STAT_FIRSTDEATH_CT);
-      int tradekill = kv.GetNum(STAT_TRADEKILL);
-      int kast = kv.GetNum(STAT_KAST);
-      int contribution_score = kv.GetNum(STAT_CONTRIBUTION_SCORE);
-      int mvp = kv.GetNum(STAT_MVP);
-
-      char teamString[16];
-      GetTeamString(team, teamString, sizeof(teamString));
-
-      // Note that FormatEx() has a 127 argument limit. See SP_MAX_CALL_ARGUMENTS in sourcepawn.
-      // At this time we're at around 33, so this should not be a problem in the foreseeable future.
-      // clang-format off
-      FormatEx(queryBuffer, sizeof(queryBuffer),
-                "INSERT INTO `get5_stats_players` \
-                (`matchid`, `mapnumber`, `steamid64`, `team`, \
-                `rounds_played`, `name`, `kills`, `deaths`, `flashbang_assists`, \
-                `assists`, `teamkills`, `knife_kills`, `headshot_kills`, \
-                `damage`, `utility_damage`, `enemies_flashed`, `friendlies_flashed`, \
-                `bomb_plants`, `bomb_defuses`, \
-                `v1`, `v2`, `v3`, `v4`, `v5`, \
-                `2k`, `3k`, `4k`, `5k`, \
-                `firstkill_t`, `firstkill_ct`, `firstdeath_t`, `firstdeath_ct`, \
-                `tradekill`, `kast`, `contribution_score`, `mvp` \
-                ) VALUES \
-                ('%s', %d, '%s', '%s', \
-                %d, '%s', %d, %d, %d, \
-                %d, %d, %d, %d, \
-                %d, %d, %d, %d, %d, %d, \
-                %d, %d, %d, %d, %d, \
-                %d, %d, %d, %d, \
-                %d, %d, %d, %d, \
-                %d, %d, %d, %d) \
-                ON DUPLICATE KEY UPDATE \
-                `rounds_played` = VALUES(`rounds_played`), \
-                `kills` = VALUES(`kills`), \
-                `deaths` = VALUES(`deaths`), \
-                `flashbang_assists` = VALUES(`flashbang_assists`), \
-                `assists` = VALUES(`assists`), \
-                `teamkills` = VALUES(`teamkills`), \
-                `knife_kills` = VALUES(`knife_kills`), \
-                `headshot_kills` = VALUES(`headshot_kills`), \
-                `damage` = VALUES(`damage`), \
-                `utility_damage` = VALUES(`utility_damage`), \
-                `enemies_flashed` = VALUES(`enemies_flashed`), \
-                `friendlies_flashed` = VALUES(`friendlies_flashed`), \
-                `bomb_plants` = VALUES(`bomb_plants`), \
-                `bomb_defuses` = VALUES(`bomb_defuses`), \
-                `v1` = VALUES(`v1`), \
-                `v2` = VALUES(`v2`), \
-                `v3` = VALUES(`v3`), \
-                `v4` = VALUES(`v4`), \
-                `v5` = VALUES(`v5`), \
-                `2k` = VALUES(`2k`), \
-                `3k` = VALUES(`3k`), \
-                `4k` = VALUES(`4k`), \
-                `5k` = VALUES(`5k`), \
-                `firstkill_t` = VALUES(`firstkill_t`), \
-                `firstkill_ct` = VALUES(`firstkill_ct`), \
-                `firstdeath_t` = VALUES(`firstdeath_t`), \
-                `firstdeath_ct` = VALUES(`firstdeath_ct`), \
-                `tradekill` = VALUES(`tradekill`), \
-                `kast` = VALUES(`kast`), \
-                `contribution_score` = VALUES(`contribution_score`), \
-                `mvp` = VALUES(`mvp`)",
-             matchIdSz, mapNumber, authSz, teamString,
-             roundsplayed, nameSz, kills, deaths, flashbang_assists, 
-             assists, teamkills, knife_kills, headshot_kills, damage, utility_damage,
-             enemies_flashed, friendlies_flashed,
-             plants, defuses, 
-             v1, v2, v3, v4, v5, 
-             k2, k3, k4, k5, 
-             firstkill_t, firstkill_ct, firstdeath_t, firstdeath_ct,
-             tradekill, kast, contribution_score, mvp);
-      // clang-format on
-
-      LogDebug(queryBuffer);
-      t.AddQuery(queryBuffer);
-
-    } while (kv.GotoNextKey());
-    kv.GoBack();
-
-    db.Execute(t, SQL_TransactionSuccessCallback, SQL_TransactionErrorCallback);
-  }
+  db.Execute(t, SQL_TransactionSuccessCallback, SQL_TransactionErrorCallback);
 }
 
 static void SQL_TransactionSuccessCallback(Database d, any data, int numQueries, DBResultSet[] results,
@@ -401,10 +226,126 @@ static void SQLErrorCheckCallback(Handle owner, Handle hndl, const char[] error,
   }
 }
 
-public void Get5_OnRoundStatsUpdated(const Get5RoundStatsUpdatedEvent event) {
-  if (Get5_GetGameState() == Get5State_Live && !g_DisableStats) {
-    char matchId[64];
-    event.GetMatchId(matchId, sizeof(matchId));
-    UpdateRoundStats(matchId, event.MapNumber);
+static void AddPlayerStatToTransaction(const char[] escapedMatchId, const Transaction t, const Get5StatsPlayer player,
+                                       const Get5Team team, const int mapNumber) {
+  char name[MAX_NAME_LENGTH];
+  char auth[AUTH_LENGTH];
+  char nameSz[MAX_NAME_LENGTH * 2 + 1];
+  char authSz[AUTH_LENGTH * 2 + 1];
+
+  player.GetSteamId(auth, sizeof(auth));
+  player.GetName(name, sizeof(name));
+
+  db.Escape(auth, authSz, sizeof(authSz));
+  db.Escape(name, nameSz, sizeof(nameSz));
+
+  char teamString[16];
+  GetTeamString(team, teamString, sizeof(teamString));
+
+  Get5PlayerStats s = player.Stats;
+
+  // Note that FormatEx() has a 127 argument limit. See SP_MAX_CALL_ARGUMENTS in sourcepawn.
+  // At this time we're at around 33, so this should not be a problem in the foreseeable future.
+  // clang-format off
+  FormatEx(queryBuffer, sizeof(queryBuffer),
+            "INSERT INTO `get5_stats_players` \
+            (`matchid`, `mapnumber`, `steamid64`, `team`, \
+            `rounds_played`, `name`, `kills`, `deaths`, `flashbang_assists`, \
+            `assists`, `teamkills`, `knife_kills`, `headshot_kills`, \
+            `damage`, `utility_damage`, `enemies_flashed`, `friendlies_flashed`, \
+            `bomb_plants`, `bomb_defuses`, \
+            `v1`, `v2`, `v3`, `v4`, `v5`, \
+            `2k`, `3k`, `4k`, `5k`, \
+            `firstkill_t`, `firstkill_ct`, `firstdeath_t`, `firstdeath_ct`, \
+            `tradekill`, `kast`, `contribution_score`, `mvp` \
+            ) VALUES \
+            ('%s', %d, '%s', '%s', \
+            %d, '%s', %d, %d, %d, \
+            %d, %d, %d, %d, \
+            %d, %d, %d, %d, %d, %d, \
+            %d, %d, %d, %d, %d, \
+            %d, %d, %d, %d, \
+            %d, %d, %d, %d, \
+            %d, %d, %d, %d) \
+            ON DUPLICATE KEY UPDATE \
+            `rounds_played` = VALUES(`rounds_played`), \
+            `kills` = VALUES(`kills`), \
+            `deaths` = VALUES(`deaths`), \
+            `flashbang_assists` = VALUES(`flashbang_assists`), \
+            `assists` = VALUES(`assists`), \
+            `teamkills` = VALUES(`teamkills`), \
+            `knife_kills` = VALUES(`knife_kills`), \
+            `headshot_kills` = VALUES(`headshot_kills`), \
+            `damage` = VALUES(`damage`), \
+            `utility_damage` = VALUES(`utility_damage`), \
+            `enemies_flashed` = VALUES(`enemies_flashed`), \
+            `friendlies_flashed` = VALUES(`friendlies_flashed`), \
+            `bomb_plants` = VALUES(`bomb_plants`), \
+            `bomb_defuses` = VALUES(`bomb_defuses`), \
+            `v1` = VALUES(`v1`), \
+            `v2` = VALUES(`v2`), \
+            `v3` = VALUES(`v3`), \
+            `v4` = VALUES(`v4`), \
+            `v5` = VALUES(`v5`), \
+            `2k` = VALUES(`2k`), \
+            `3k` = VALUES(`3k`), \
+            `4k` = VALUES(`4k`), \
+            `5k` = VALUES(`5k`), \
+            `firstkill_t` = VALUES(`firstkill_t`), \
+            `firstkill_ct` = VALUES(`firstkill_ct`), \
+            `firstdeath_t` = VALUES(`firstdeath_t`), \
+            `firstdeath_ct` = VALUES(`firstdeath_ct`), \
+            `tradekill` = VALUES(`tradekill`), \
+            `kast` = VALUES(`kast`), \
+            `contribution_score` = VALUES(`contribution_score`), \
+            `mvp` = VALUES(`mvp`)",
+         escapedMatchId, mapNumber, authSz, teamString,
+         s.RoundsPlayed, nameSz, s.Kills, s.Deaths, s.FlashAssists,
+         s.Assists, s.TeamKills, s.KnifeKills, s.HeadshotKills, s.Damage, s.UtilityDamage,
+         s.EnemiesFlashed, s.FriendliesFlashed,
+         s.BombPlants, s.BombDefuses,
+         s.OneV1s, s.OneV2s, s.OneV3s, s.OneV4s, s.OneV5s,
+         s.Kills2, s.Kills3, s.Kills4, s.Kills5,
+         s.FirstKillsT, s.FirstKillsCT, s.FirstDeathsT, s.FirstDeathsCT,
+         s.TradeKills, s.KAST, s.Score, s.MVPs);
+  // clang-format on
+
+  LogDebug(queryBuffer);
+  t.AddQuery(queryBuffer);
+}
+
+public void Get5_OnRoundEnd(const Get5RoundEndedEvent event) {
+  if (Get5_GetGameState() != Get5State_Live || g_DisableStats) {
+    return;
   }
+
+  char matchId[64];
+  event.GetMatchId(matchId, sizeof(matchId));
+  char matchIdSz[128];
+  db.Escape(matchId, matchIdSz, sizeof(matchIdSz));
+
+  Transaction t = new Transaction();
+
+  FormatEx(queryBuffer, sizeof(queryBuffer), "UPDATE `get5_stats_maps` \
+        SET team1_score = %d, team2_score = %d WHERE matchid = '%s' and mapnumber = %d",
+           event.Team1.Score, event.Team2.Score, matchIdSz, event.MapNumber);
+  LogDebug(queryBuffer);
+  t.AddQuery(queryBuffer);
+
+  JSON_Array team1Players = event.Team1.Players;
+  JSON_Array team2Players = event.Team2.Players;
+
+  int i;
+  int size = team1Players.Length;
+  for (i = 0; i < size; i++) {
+    AddPlayerStatToTransaction(matchIdSz, t, view_as<Get5StatsPlayer>(team1Players.GetObject(i)), Get5Team_1,
+                               event.MapNumber);
+  }
+  size = team2Players.Length;
+  for (i = 0; i < size; i++) {
+    AddPlayerStatToTransaction(matchIdSz, t, view_as<Get5StatsPlayer>(team2Players.GetObject(i)), Get5Team_2,
+                               event.MapNumber);
+  }
+
+  db.Execute(t, SQL_TransactionSuccessCallback, SQL_TransactionErrorCallback);
 }

--- a/scripting/include/get5.inc
+++ b/scripting/include/get5.inc
@@ -9,8 +9,8 @@
 // Series stats (root section)
 #define STAT_SERIESWINNER "winner"
 #define STAT_SERIESTYPE "series_type"
-#define STAT_SERIES_TEAM1NAME "team1_name"
-#define STAT_SERIES_TEAM2NAME "team2_name"
+#define STAT_SERIES_TEAM_ID "id"
+#define STAT_SERIES_TEAM_NAME "name"
 #define STAT_SERIES_FORFEIT "forfeit"
 
 // Map stats (under "map0", "map1", etc.)
@@ -252,12 +252,12 @@ methodmap Get5PlayerStats < JSON_Object {
     }
   }
 
-  property int FlashbangAssists {
+  property int FlashAssists {
     public set(int val) {
-      this.SetInt("flashbang_assists", val);
+      this.SetInt("flash_assists", val);
     }
     public get() {
-      return this.GetInt("flashbang_assists");
+      return this.GetInt("flash_assists");
     }
   }
 
@@ -522,7 +522,7 @@ methodmap Get5PlayerStats < JSON_Object {
     }
   }
 
-  public Get5PlayerStats(const int kills, const int deaths, const int assists, const int flashbangAssists,
+  public Get5PlayerStats(const int kills, const int deaths, const int assists, const int flashAssists,
         const int teamKills, const int suicides, const int damage, const int utilityDamage, const int enemiesFlashed,
         const int friendliesFlashed, const int knifeKills, const int headshotKills, const int roundsPlayed,
         const int bombDefuses, const int bombPlants, const int kills1, const int kills2, const int kills3,
@@ -533,7 +533,7 @@ methodmap Get5PlayerStats < JSON_Object {
     self.Kills = kills;
     self.Deaths = deaths;
     self.Assists = assists;
-    self.FlashbangAssists = flashbangAssists;
+    self.FlashAssists = flashAssists;
     self.TeamKills = teamKills;
     self.Suicides = suicides;
     self.Damage = damage;
@@ -603,7 +603,24 @@ methodmap Get5StatsPlayer < Get5PlayerBase {
   }
 }
 
-methodmap Get5StatsTeam < JSON_Object {
+methodmap Get5TeamWrapper < JSON_Object {
+
+  // This allows the property to be null in JSON but empty string in SourceMod.
+  public bool GetId(char[] buffer, const int maxSize) {
+    if (this.GetType("id") != JSON_Type_String) {
+      strcopy(buffer, maxSize, "");
+      return true;
+    } else {
+      return this.GetString("id", buffer, maxSize);
+    }
+  }
+
+  public bool SetId(const char[] value) {
+    if (strlen(value) > 0) {
+      return this.SetString("id", value);
+    }
+    return this.SetObject("id", null);
+  }
 
   public bool GetName(char[] buffer, const int maxSize) {
     return this.GetString("name", buffer, maxSize);
@@ -611,6 +628,25 @@ methodmap Get5StatsTeam < JSON_Object {
 
   public bool SetName(const char[] value) {
     return this.SetString("name", value);
+  }
+
+  public Get5TeamWrapper(const char[] id, const char[] teamName) {
+    Get5TeamWrapper self = view_as<Get5TeamWrapper>(new JSON_Object());
+    self.SetId(id);
+    self.SetName(teamName);
+    return self;
+  }
+}
+
+methodmap Get5StatsTeam < Get5TeamWrapper {
+
+  property int SeriesScore {
+    public get() {
+      return this.GetInt("series_score");
+    }
+    public set(int val) {
+      this.SetInt("series_score", val);
+    }
   }
 
   property int Score {
@@ -672,12 +708,14 @@ methodmap Get5StatsTeam < JSON_Object {
     }
   }
 
-  public Get5StatsTeam(const char[] teamName, const int score, const Get5Side side) {
+  public Get5StatsTeam(const char[] id, const char[] teamName, const int score, const int seriesScore, const Get5Side side) {
     Get5StatsTeam self = view_as<Get5StatsTeam>(new JSON_Object());
+    self.SetId(id);
     self.SetName(teamName);
     self.Score = score;
-    self.Players = new JSON_Array();
+    self.SeriesScore = seriesScore;
     self.Side = side;
+    self.Players = new JSON_Array();
     self.ScoreCT = 0;
     self.ScoreT = 0;
     self.StartingSide = Get5Side_None;
@@ -1273,32 +1311,33 @@ methodmap Get5MapResultEvent < Get5MapEvent {
     }
   }
 
-  property int Team1Score {
+  property Get5StatsTeam Team1 {
     public get() {
-      return this.GetInt("team1_score");
+      return view_as<Get5StatsTeam>(this.GetObject("team1"));
     }
-    public set(int score) {
-      this.SetInt("team1_score", score);
+    public set(Get5StatsTeam team) {
+      this.SetObject("team1", team);
     }
   }
 
-  property int Team2Score {
+  property Get5StatsTeam Team2 {
     public get() {
-      return this.GetInt("team2_score");
+      return view_as<Get5StatsTeam>(this.GetObject("team2"));
     }
-    public set(int score) {
-      this.SetInt("team2_score", score);
+    public set(Get5StatsTeam team) {
+      this.SetObject("team2", team);
     }
   }
 
-  public Get5MapResultEvent(const char[] matchId, const int mapNumber, const Get5Winner winner, int team1Score, int team2Score) {
+  public Get5MapResultEvent(const char[] matchId, const int mapNumber, const Get5Winner winner,
+      const Get5StatsTeam team1, const Get5StatsTeam team2) {
     Get5MapResultEvent self = view_as<Get5MapResultEvent>(new JSON_Object());
     self.SetEvent("map_result");
     self.SetMatchId(matchId);
     self.MapNumber = mapNumber;
     self.Winner = winner;
-    self.Team1Score = team1Score;
-    self.Team2Score = team2Score;
+    self.Team1 = team1;
+    self.Team2 = team2;
     return self;
   }
 }
@@ -1494,26 +1533,40 @@ methodmap Get5MatchUnpausedEvent < Get5MatchPauseEvent {
 
 methodmap Get5SeriesStartedEvent < Get5MatchEvent {
 
-  public bool SetTeam1Name(const char[] value) {
-    return this.SetString("team1_name", value);
-  }
-  public bool GetTeam1Name(char[] buffer, const int maxSize) {
-    return this.GetString("team1_name", buffer, maxSize);
-  }
-
-  public bool SetTeam2Name(const char[] value) {
-    return this.SetString("team2_name", value);
-  }
-  public bool GetTeam2Name(char[] buffer, const int maxSize) {
-    return this.GetString("team2_name", buffer, maxSize);
+  property int SeriesLength {
+    public get() {
+      return this.GetInt("series_length");
+    }
+    public set(int val) {
+      this.SetInt("series_length", val);
+    }
   }
 
-  public Get5SeriesStartedEvent(const char[] matchId, const char[] team1Name, const char[] team2Name) {
+  property Get5TeamWrapper Team1 {
+    public get() {
+      return view_as<Get5TeamWrapper>(this.GetObject("team1"));
+    }
+    public set(Get5TeamWrapper team) {
+      this.SetObject("team1", team);
+    }
+  }
+
+  property Get5TeamWrapper Team2 {
+    public get() {
+      return view_as<Get5TeamWrapper>(this.GetObject("team2"));
+    }
+    public set(Get5TeamWrapper team) {
+      this.SetObject("team2", team);
+    }
+  }
+
+  public Get5SeriesStartedEvent(const char[] matchId, const int length, const Get5TeamWrapper team1, const Get5TeamWrapper team2) {
     Get5SeriesStartedEvent self = view_as<Get5SeriesStartedEvent>(new JSON_Object());
     self.SetEvent("series_start");
     self.SetMatchId(matchId);
-    self.SetTeam1Name(team1Name);
-    self.SetTeam2Name(team2Name);
+    self.SeriesLength = length;
+    self.Team1 = team1;
+    self.Team2 = team2;
     return self;
   }
 }


### PR DESCRIPTION
Improves availability of stats information in the JSON events.

The MySQL plugin now exclusively reacts to data sent to it using the JSON events; it no longer needs to pull the stats KeyValues in and copy it. It also now uses transactions in more places where it runs multiple queries.

Added full player stats to `Get5_OnMapResult`, similarly to `Get5_OnRoundEnd`.

Breaking due to various changes to the JSON events/forwards and the stats KeyValues.

You can now provide an `id` parameter to a team in match configurations, which is sent back via events/forwards when referencing a team.

CC @LukasW1337