### PR TITLE
Reset team config on match end

### DIFF
--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -119,10 +119,11 @@ disable.<br>**`Default: ""`**
 
 ####`get5_reset_cvars_on_end`
 :  Whether the `cvars` of a [match configuration](../match_schema#schema) as well as
-the [Get5-determined hostname](#get5_hostname_format) are reset to their original values when a series ends. You may
-want to disable this if you only run Get5 on your servers and use `cvars` to
-configure [demos](../gotv), [backups](../backup) or [remote URL logging](../events_and_forwards#http) on a per-match
-basis, as reverting some of those parameters can be problematic.<br>**`Default: 1`**
+the [Get5-determined hostname](#get5_hostname_format) are reset to their original values when a series ends. This also
+causes team-specific configuration options (name, flag, logo etc.) to be set to empty on match end. You may want to
+disable this if you only run Get5 on your servers and use `cvars` to configure [demos](../gotv), [backups](../backup)
+or [remote URL logging](../events_and_forwards#http) on a per-match basis, as reverting some of those parameters can be
+problematic.<br>**`Default: 1`**
 
 ####`get5_debug`
 :   Enable or disable verbose debug output from Get5. Intended for development and debugging purposes

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -1702,6 +1702,7 @@ void ResetMatchCvarsAndHostnameAndKickPlayers(bool kickPlayers) {
   if (g_ResetCvarsOnEndCvar.BoolValue) {
     RestoreCvars(g_MatchConfigChangedCvars);
     ResetHostname();
+    ResetTeamConfigs();
   } else {
     CloseCvarStorage(g_MatchConfigChangedCvars);
   }

--- a/scripting/get5/matchconfig.sp
+++ b/scripting/get5/matchconfig.sp
@@ -1665,6 +1665,20 @@ void ResetHostname() {
   g_HostnamePreGet5 = "";
 }
 
+void ResetTeamConfigs() {
+  SetConVarStringSafe("mp_teamname_1", "");
+  SetConVarStringSafe("mp_teamflag_1", "");
+  SetConVarStringSafe("mp_teamlogo_1", "");
+  SetConVarStringSafe("mp_teammatchstat_1", "");
+  SetConVarStringSafe("mp_teamscore_1", "");
+
+  SetConVarStringSafe("mp_teamname_2", "");
+  SetConVarStringSafe("mp_teamflag_2", "");
+  SetConVarStringSafe("mp_teamlogo_2", "");
+  SetConVarStringSafe("mp_teammatchstat_2", "");
+  SetConVarStringSafe("mp_teamscore_2", "");
+}
+
 void UpdateHostname() {
   char formattedHostname[128];
   if (FormatCvarString(g_SetHostnameCvar, formattedHostname, sizeof(formattedHostname), false)) {

--- a/scripting/get5/tests.sp
+++ b/scripting/get5/tests.sp
@@ -21,17 +21,7 @@ static void Get5_Test() {
   SetConVarStringSafe("mp_teammatchstat_txt", "");
   SetConVarStringSafe("mp_teamprediction_pct", "0");
 
-  SetConVarStringSafe("mp_teamname_1", "");
-  SetConVarStringSafe("mp_teamflag_1", "");
-  SetConVarStringSafe("mp_teamlogo_1", "");
-  SetConVarStringSafe("mp_teammatchstat_1", "");
-  SetConVarStringSafe("mp_teamscore_1", "");
-
-  SetConVarStringSafe("mp_teamname_2", "");
-  SetConVarStringSafe("mp_teamflag_2", "");
-  SetConVarStringSafe("mp_teamlogo_2", "");
-  SetConVarStringSafe("mp_teammatchstat_2", "");
-  SetConVarStringSafe("mp_teamscore_2", "");
+  ResetTeamConfigs();
 
   ValidMatchConfigTest("addons/sourcemod/configs/get5/tests/default_valid.json");
   ValidMatchConfigTest("addons/sourcemod/configs/get5/tests/default_valid.cfg");


### PR DESCRIPTION
Avoids lingering team info after a match has ended, which would have to be manually cleaned up if the server is subsequently being used for something other than Get5.