### PR TITLE
Remain in post_game until GOTV broadcast/convar reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ details.
 1. The `Get5_OnPlayerSay` event now includes messages sent from Console (or potentially GOTV). You should filter out
    these messages on your end if you don't want to react to them. Note that console is always `user_id` 0 and GOTV's
    name is always `GOTV`. Alternatively, you can ignore all messages with an empty `steamid`.
-2. The [stats system](https://splewis.github.io/get5/latest/stats_system/#keyvalue) has been updated. This means that
+2. The [stats system](https://splewis.github.io/get5/dev/stats_system/#keyvalue) has been updated. This means that
    the structure has been modified to allow for more information, specifically the starting side and score for each side
    for each team.
 
@@ -92,6 +92,10 @@ details.
    This affects the `Get5_OnRoundEnd` forward as well, so if you have a plugin that reads this data, you must update it.
    For full details and the SourceMod properties, see
    the [event documentation](https://splewis.github.io/get5/dev/events_and_forwards/#events).
+4. Get5 no longer sets its [game state](https://splewis.github.io/get5/dev/commands/#get5_status) to `none`
+   immediately following the end of the series, but now waits until the restore timer fires. Get5 will be in `post_game`
+   until the timer runs out, similarly to when waiting for the next map. This means that GOTV broadcasts will have a
+   chance to finish before Get5 releases the server.
 
 ### New Features / Changes 🎉
 
@@ -99,13 +103,19 @@ details.
 2. The JSON "pretty print" spacing string has changed from 4 spaces to 1 tab. This is strictly because there is a 16KB
    max buffer size in SourceMod, which we come dangerously close to when posting the full player stats via JSON. If you
    play 6v6 or 7v7, you may need to
-   set [`get5_pretty_print_json 0`](https://splewis.github.io/get5/latest/configuration/#get5_pretty_print_json) to
+   set [`get5_pretty_print_json 0`](https://splewis.github.io/get5/dev/configuration/#get5_pretty_print_json) to
    avoid hitting the limit. You **will** see an error in console if this happens.
 3. The `get5_mysqlstats` extension now uses a transaction to update stat rows for each player. This improves performance
    via reduced I/O between the game server and the database server.
 4. The [documentation of events](https://splewis.github.io/get5/dev/events_and_forwards/#events) is now rendered
    on `https://redocly.github.io` instead of being embedded in the Get5 documentation website. This allows for more
    space and makes it easier to browse/read.
+5. The team configuration
+   parameters ([`mp_teamname_1`](https://totalcsgo.com/command/mpteamname1),
+   [`mp_teamflag_1`](https://totalcsgo.com/command/mpteamflag1),
+   [`mp_teamlogo_1`](https://totalcsgo.com/command/mpteamlogo1) etc.) are now reset to blank when Get5 ends a series.
+   Previously, these parameters would linger and would have to be manually reset or replaced by loading a new match
+   configuration.
 
 # 0.13.0
 

--- a/documentation/docs/commands.md
+++ b/documentation/docs/commands.md
@@ -284,8 +284,9 @@ during ready-up phases.
        <br><br>**`live`**<br>The game is live.
        <br><br>**`pending_restore`**<br>A [backup](../backup) for a different map was loaded and the game is either
        pending a map change or waiting for users to [`!ready`](../commands#ready) to restore to a live round.
-       <br><br>**`post_game`**<br>The map has ended and the countdown to the next map is ongoing. This stage will only
-       occur in multi-map series, as single-map matches end immediately.
+       <br><br>**`post_game`**<br>The map has ended and the countdown to the next map or
+       [server config restoration](../configuration#get5_reset_cvars_on_end) is ongoing. If the server is broadcasting 
+       [GOTV](../gotv/#broadcast), it will remain in `post_game` at least until the broadcast has ended.
     3. Whether the game is currently [paused](../pausing).
     4. The match configuration file currently loaded. `Example: "addons/sourcemod/configs/get5/match_config.json"`. Note
        that this points to the URL of the match configuration when a match was loaded

--- a/documentation/docs/event_schema.yml
+++ b/documentation/docs/event_schema.yml
@@ -26,7 +26,8 @@ paths:
         - Series Flow
       summary: Get5_OnGameStateChanged
       description: |
-        Fired when the game state changes.
+        Fired when the game state changes. You can listen for this event and mark a server as available when it sends
+        `none` as its game state; this is always sent *after* both the series *and* the GOTV broadcast have ended.
       requestBody:
         content:
           application/json:
@@ -273,8 +274,7 @@ paths:
         - Series Flow
       summary: Get5_OnSeriesResult
       description: |
-        Fired when a series is over. `winner` indicates team and side 0 if there was no winner in cases of a draw or
-        if the series was forcefully canceled.
+        Fired when a series ends.
       requestBody:
         content:
           application/json:
@@ -305,9 +305,8 @@ paths:
                       minimum: 0
                       example: 45
                       description: |
-                        The number of seconds until Get5 restores any changed ConVars after the series has ended. This is
-                        the GOTV broadcast delay plus a few seconds. If you use this event to relinquish a server instance,
-                        you should wait until this time has passed before starting a new match or shutting down the server.
+                        The number of seconds until Get5 restores any changed ConVars and resets its game state to
+                        `none` after the series has ended.
       responses: { }
   "/Get5_OnKnifeRoundStarted":
     post:

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -720,9 +720,11 @@ static Action Timer_InfoMessages(Handle timer) {
     PrintVetoHelpMessage();
   } else if (g_GameState == Get5State_WaitingForKnifeRoundDecision) {
     PromptForKnifeDecision();
-  } else if (g_GameState == Get5State_PostGame && GetTvDelay() > 0) {
-    // Handle postgame
-    Get5_MessageToAll("%t", "WaitingForGOTVBroadcastEnding");
+  } else if (g_GameState == Get5State_PostGame) {
+    if (g_ResetCvarsTimer == INVALID_HANDLE && GetTvDelay() > 0) {
+      // Only print this if the reset timer isn't running, which would mean it's the last map.
+      Get5_MessageToAll("%t", "WaitingForGOTVBroadcastEnding");
+    }
   }
   return Plugin_Continue;
 }

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -1570,10 +1570,10 @@ void EndSeries(Get5Team winningTeam, bool printWinnerMessage, float restoreDelay
   Call_Finish();
 
   EventLogger_LogAndDeleteEvent(event);
-  ChangeState(Get5State_None);
 
   if (restoreDelay < 0.1) {
     ResetMatchCvarsAndHostnameAndKickPlayers(kickPlayers);
+    ChangeState(Get5State_None);
   } else {
     // If we restore cvars immediately, it might change the tv_ params or set the
     // mp_match_restart_delay to something lower, which is noticed by the game and may trigger a map
@@ -1581,6 +1581,7 @@ void EndSeries(Get5Team winningTeam, bool printWinnerMessage, float restoreDelay
     // has passed. We also don't want to kick players until after the specified delay, as it will kick
     // casters potentially before GOTV ends.
     g_ResetCvarsTimer = CreateTimer(restoreDelay, Timer_RestoreMatchCvarsAndKickPlayers, kickPlayers);
+    ChangeState(Get5State_PostGame);
   }
 
   // If the match is ended during pending map change;
@@ -1686,6 +1687,7 @@ static Action Timer_RestoreMatchCvarsAndKickPlayers(Handle timer, bool kickPlaye
     return Plugin_Handled;
   }
   ResetMatchCvarsAndHostnameAndKickPlayers(kickPlayers);
+  ChangeState(Get5State_None);
   g_ResetCvarsTimer = INVALID_HANDLE;
   return Plugin_Handled;
 }
@@ -2064,6 +2066,14 @@ static void SetServerStateOnStartup(bool force) {
   // when first player joins, but as a safeguard we don't want to move a live game into warmup on
   // player connect.
   if (!force && g_GameState == Get5State_Live) {
+    return;
+  }
+
+  // If the map is forcefully changed/reloaded while waiting for a cvar restore in postgame, we call the function
+  // manually.
+  if (g_GameState == Get5State_PostGame && g_ResetCvarsTimer != INVALID_HANDLE) {
+    LogDebug("Triggering ConVar reset timer as the map was changed unexpectedly.");
+    TriggerTimer(g_ResetCvarsTimer);
     return;
   }
   // If the server is in preveto or pending backup when someone joins or the configs exec, it should


### PR DESCRIPTION
Previously, we would go directly to `game_state: none` when the series ended, which can be problematic for automated systems, as this would indicate that a server is available for use, while it could be still broadcasting GOTV of a previous match.

Now, we remain in `post_game` until GOTV broadcast has finished, just like when waiting for the next map in a multi-map series.