### PR TITLE
Detect current map correctly when using scrim command on workshop maps

### DIFF
--- a/scripting/get5/matchconfig.sp
+++ b/scripting/get5/matchconfig.sp
@@ -1413,7 +1413,7 @@ Action Command_CreateScrim(int client, int args) {
 
   char matchid[MATCH_ID_LENGTH] = "scrim";
   char matchMap[PLATFORM_MAX_PATH];
-  GetCleanMapName(matchMap, sizeof(matchMap));
+  GetCurrentMap(matchMap, sizeof(matchMap));
   char otherTeamName[MAX_CVAR_LENGTH] = "Away";
 
   if (args >= 1) {


### PR DESCRIPTION
The `get5_scrim` command would cause the map to reload on workshop maps due to cleaning the map name. This fixes that.