### PR TITLE
Fix warmup stuck at 0:01 issue by forcing map reload on match load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,10 @@ details.
    immediately following the end of the series, but now waits until the restore timer fires. Get5 will be in `post_game`
    until the timer runs out, similarly to when waiting for the next map. This means that GOTV broadcasts will have a
    chance to finish before Get5 releases the server.
+7. The map is now **always** reloaded when a match configuration is loaded, even if the server is already on the correct
+   map. Similarly, if doing in-game map selection (veto), the map is always changed to the first map in the series, even
+   if the server is already on that map. This reverts this change
+   from [0.13](https://github.com/splewis/get5/blob/development/CHANGELOG.md#0130).
 
 ### New Features / Changes 🎉
 

--- a/scripting/get5/mapveto.sp
+++ b/scripting/get5/mapveto.sp
@@ -89,36 +89,13 @@ static void FinishVeto() {
     Get5_MessageToAll("%t", "MapIsInfoMessage", i + 1 - mapNumber, map);
   }
 
-  char currentMapName[PLATFORM_MAX_PATH];
-  GetCleanMapName(currentMapName, sizeof(currentMapName));
-
-  char mapToPlay[PLATFORM_MAX_PATH];
-  g_MapsToPlay.GetString(0, mapToPlay, sizeof(mapToPlay));
-
-  // In case the sides don't match after selection, we check it here before writing the backup.
-  // Also required if the map doesn't need to change.
-  SetStartingTeams();
-  SetMatchTeamCvars();
-
-  if (!StrEqual(currentMapName, mapToPlay)) {
-    ResetReadyStatus();
-    float delay = 10.0;
-    g_MapChangePending = true;
-    if (g_DisplayGotvVetoCvar.BoolValue) {
-      // Players must wait for GOTV to end before we can change map, but we don't need to record that.
-      g_PendingMapChangeTimer = CreateTimer(float(GetTvDelay()) + delay, Timer_NextMatchMap);
-    } else {
-      g_PendingMapChangeTimer = CreateTimer(delay, Timer_NextMatchMap);
-    }
-  } else {
-    LOOP_CLIENTS(i) {
-      if (IsPlayer(i)) {
-        CheckClientTeam(i);
-      }
-    }
+  float delay = 7.0;
+  g_MapChangePending = true;
+  if (g_DisplayGotvVetoCvar.BoolValue) {
+    delay = float(GetTvDelay()) + delay;
   }
+  g_PendingMapChangeTimer = CreateTimer(delay, Timer_NextMatchMap);
   ChangeState(Get5State_Warmup);
-  WriteBackup();  // Write first pre-live backup after veto.
 }
 
 // Main Veto Controller


### PR DESCRIPTION
So, it would seem that the only way to prevent https://github.com/splewis/get5/issues/976 from happening is to make sure the map is reloaded when a match is loaded, so we do this now.

This also means that the change from https://github.com/splewis/get5/blob/development/CHANGELOG.md#0130, where the map is not reloaded if the first map post-veto is the same as the one the server is on is reverted; it will always reload.