### PR TITLE
Fix memory leaks and heap size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,11 +179,8 @@ details.
 ### New Features / Changes 🎉
 
 1. Get5 is now built with SourceMod 1.11.
-2. The JSON "pretty print" spacing string has changed from 4 spaces to 1 tab. This is strictly because there is a 16KB
-   max buffer size in SourceMod, which we come dangerously close to when posting the full player stats via JSON. If you
-   play 6v6 or 7v7, you may need to
-   set [`get5_pretty_print_json 0`](https://splewis.github.io/get5/dev/configuration/#get5_pretty_print_json) to
-   avoid hitting the limit. You **will** see an error in console if this happens.
+2. The JSON "pretty print" spacing string has changed from 4 spaces to 1 tab. This is strictly to reduce the size of the
+   JSON payload and has no practical effect on the objects.
 3. The `get5_mysqlstats` extension now uses a transaction to update stat rows for each player. This improves performance
    via reduced I/O between the game server and the database server. It now also runs on the JSON methodmaps provided to
    forwards instead of copying the KeyValue stat object.

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -35,11 +35,12 @@
 #pragma semicolon 1
 #pragma newdecls required
 /**
- * Increases stack space to 32000 cells (or 128KB, a cell is 4 bytes)
- * This is to prevent "Not enough space on the heap" error when dumping match stats
- * Default heap size is 4KB
+ * Increases stack space to 131072 cells (or 512KB; a cell is 4 bytes).
+ * This is to prevent "Not enough space on the heap" error when dumping match stats while also
+ * allowing a 64KB static buffer for JSON encode output for HTTP events.
+ * Default heap size is 1024 cells (4KB).
  */
-#pragma dynamic 32000
+#pragma dynamic 131072
 
 #include "get5/util.sp"
 
@@ -360,8 +361,7 @@ public void OnPluginStart() {
   InitDebugLog(DEBUG_CVAR, "get5");
   LogDebug("OnPluginStart version=%s", PLUGIN_VERSION);
 
-  // Because we JSON encode the entire match stats on round end, we change from 4 spaces to a tab when pretty-printing.
-  // It saves a significant number of bytes, and we're limited to 16K. See SendEventJSONToURL().
+  // Make JSON payloads smaller by using 1 tab instead of 4 spaces to pretty print.
   JSON_PP_INDENT = "\t";
 
   // Because we use SDKHooks for damage, we need to re-hook clients that are already on the server
@@ -1052,6 +1052,10 @@ static Action Command_EndMatch(int client, int args) {
     return Plugin_Handled;
   }
 
+  // Clear ongoing grenade containers, if any. Requires live state or the events will be lost,
+  // so we do this before changing the game state below.
+  Stats_ResetGrenadeContainers();
+
   Get5Team winningTeam = Get5Team_None;  // defaults to tie
   if (args >= 1) {
     char forcedWinningTeam[8];
@@ -1738,13 +1742,10 @@ void ResetMatchCvarsAndHostnameAndKickPlayers(bool kickPlayers) {
 
 static Action Event_RoundPreStart(Event event, const char[] name, bool dontBroadcast) {
   LogDebug("Event_RoundPreStart");
+  Stats_ResetGrenadeContainers();  // Always do this. If not in live, the events are simply
+  // discarded and this just prevents memory leaks.
   if (g_GameState == Get5State_None) {
     return Plugin_Continue;
-  }
-
-  if (g_GameState == Get5State_Live) {
-    // End lingering grenade trackers from previous round.
-    Stats_ResetGrenadeContainers();
   }
 
   if (g_PendingSideSwap) {
@@ -2256,9 +2257,9 @@ void EventLogger_LogAndDeleteEvent(Get5Event event) {
 
   // We could use json_encode_size here from sm-json, but since we fire events *all the time*
   // and the function to calculate the buffer size is a lot of code, we just statically allocate
-  // a 16k buffer here and reuse that.
-  static char buffer[16384];
-  event.Encode(buffer, 16384, options);
+  // a 64K buffer here and reuse that.
+  static char buffer[65536];
+  event.Encode(buffer, 65536, options);
 
   char logPath[PLATFORM_MAX_PATH];
   if (FormatCvarString(g_EventLogFormatCvar, logPath, sizeof(logPath))) {

--- a/scripting/get5/events.sp
+++ b/scripting/get5/events.sp
@@ -14,13 +14,6 @@ void SendEventJSONToURL(const char[] event) {
     return;
   }
 
-  int contentLength = strlen(event);
-  if (contentLength >= 16383) {
-    LogError(
-      "JSON event size exceeds the maximum supported value of 16382 bytes and cannot be sent to your log URL. You should consider setting get5_pretty_print_json 0 to reduce the JSON size.");
-    return;
-  }
-
   static char error[PLATFORM_MAX_PATH];
   Handle eventRequest = CreateGet5HTTPRequest(k_EHTTPMethodPOST, eventUrl, error);
   if (eventRequest == INVALID_HANDLE) {
@@ -41,7 +34,7 @@ void SendEventJSONToURL(const char[] event) {
     return;
   }
 
-  SteamWorks_SetHTTPRequestRawPostBody(eventRequest, "application/json", event, contentLength);
+  SteamWorks_SetHTTPRequestRawPostBody(eventRequest, "application/json", event, strlen(event));
   SteamWorks_SetHTTPRequestNetworkActivityTimeout(eventRequest, 15);  // Default 60 is a bit much.
   SteamWorks_SetHTTPCallbacks(eventRequest, EventRequestCallback);
   SteamWorks_SendHTTPRequest(eventRequest);


### PR DESCRIPTION
So it turns out there were some pretty nasty memory leaks in 0.13 and 0.14 prereleases, all (I think) of which I have fixed here. This also changes the JSON size limit issue by simply increasing the heap size even further, this way up to 512KB.