### PR TITLE
Fix ban of `de_cbble` + add test for workshop maps

### DIFF
--- a/scripting/get5/mapveto.sp
+++ b/scripting/get5/mapveto.sp
@@ -450,5 +450,10 @@ bool RemoveMapFromMapPool(const ArrayList mapPool, const char[] str, char[] buff
     mapPool.Erase(eraseIndex);
     return true;
   }
+  if (StrContains(str, "cobble", false) > -1) {
+    // Because Cobblestone is the only map that's actually misspelled, we re-run the code if the input contained
+    // "cobble" but there was no match, this time using "cbble" instead, which will match de_cbble.
+    return RemoveMapFromMapPool(mapPool, "cbble", buffer, bufferSize);
+  }
   return false;
 }

--- a/scripting/get5/tests.sp
+++ b/scripting/get5/tests.sp
@@ -408,6 +408,10 @@ static void MapVetoLogicTest() {
              RemoveMapFromMapPool(mapPool, "cobblestone", error, sizeof(error)));
   AssertEq("Check map pool size after cobblestone", 1, mapPool.Length);
 
+  mapPool.PushString("workshop/1193875520/de_aztec");
+  AssertTrue("Check banning workshop map", RemoveMapFromMapPool(mapPool, "aztec", error, sizeof(error)));
+  AssertEq("Check map pool size after workshop ban", 1, mapPool.Length);
+
   delete mapPool;
 }
 

--- a/scripting/get5/tests.sp
+++ b/scripting/get5/tests.sp
@@ -402,6 +402,12 @@ static void MapVetoLogicTest() {
              RemoveMapFromMapPool(mapPool, "dust", error, sizeof(error)));
   AssertEq("Check map pool match precise match, size 1", 1, mapPool.Length);
 
+  // Cobblestone is misspelled, so we have a special case for that.
+  mapPool.PushString("de_cbble");
+  AssertTrue("Check cobblestone map removed on cobble",
+             RemoveMapFromMapPool(mapPool, "cobblestone", error, sizeof(error)));
+  AssertEq("Check map pool size after cobblestone", 1, mapPool.Length);
+
   delete mapPool;
 }
 


### PR DESCRIPTION
Because this map is the only (as far as I know) actually *misspelled* official map, I've added a slight hack that, in the case a `!ban` command does not match any map and the string you sent contains the word `cobble` (case insensitively), it will re-run the search for a map using the string `cbble` instead, which will match `de_cbble`. I also added a test for this.