### PR TITLE
Don't reset g_ReadyTimeWaitingUsed on map start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Whenever you update your Get5 plugin, remember to **always** update the `transla
 Please see the [installation instructions](https://splewis.github.io/get5/latest/installation/#installation) for
 details.
 
+# 0.14.2
+
+#### 2023-04-10
+
+Minor bugfix.
+
+1. Prevent first joining player from resetting the ready waiting timer back to zero.
+
 # 0.14.1
 
 #### 2023-04-08
@@ -19,7 +27,7 @@ Hotfix of stuff that should have been in 0.14.0.
 
 # 0.14.0
 
-*Note: Removed from releases. Please use 0.14.1 instead. All changes below still apply.*
+*Note: Removed from releases. Please use 0.14.2 instead. All changes below still apply.*
 
 #### 2023-04-08
 

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -883,7 +883,6 @@ public void OnMapStart() {
   LogDebug("OnMapStart");
   g_MapChangePending = false;
   g_DoingBackupRestoreNow = false;
-  g_ReadyTimeWaitingUsed = 0;
   g_KnifeWinnerTeam = Get5Team_None;
   g_HasKnifeRoundStarted = false;
   g_MapReloadRequired = false;

--- a/scripting/get5/version.sp
+++ b/scripting/get5/version.sp
@@ -1,4 +1,4 @@
-#define PLUGIN_VERSION "0.14.1-dev"
+#define PLUGIN_VERSION "0.14.2-dev"
 // This MUST be the latest version in x.y.z semver format followed by -dev.
 // If this is not consistently applied, the update-checker might malfunction.
 // In official releases, the CI flow will remove the -dev suffix when compiling the plugin.


### PR DESCRIPTION
The timer was resetting when the map reloads, which happens when a player joins an empty server. This would let a player keep a server alive indefinitely by repeatedly connecting and disconnecting.

Closes https://github.com/splewis/get5/issues/1010.