### PR TITLE
0.14.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Whenever you update your Get5 plugin, remember to **always** update the `transla
 Please see the [installation instructions](https://splewis.github.io/get5/latest/installation/#installation) for
 details.
 
+# 0.14.7
+
+#### 2023-05-06
+
+Bugfix.
+
+1. Fix missing loading of `cvars` if also using `veto_mode` with a KeyValues match configuration.
+
 # 0.14.6
 
 #### 2023-04-29

--- a/scripting/get5/matchconfig.sp
+++ b/scripting/get5/matchconfig.sp
@@ -964,6 +964,7 @@ static bool LoadMatchFromKeyValue(KeyValues kv, char[] error) {
       if (!LoadVetoDataKeyValues(kv, error)) {
         return false;
       }
+      kv.GoBack();
     } else {
       GenerateDefaultVetoSetup(g_MapPoolList, g_MapBanOrder, g_NumberOfMapsInSeries, g_LastVetoTeam);
     }

--- a/scripting/get5/version.sp
+++ b/scripting/get5/version.sp
@@ -1,4 +1,4 @@
-#define PLUGIN_VERSION "0.14.6-dev"
+#define PLUGIN_VERSION "0.14.7-dev"
 // This MUST be the latest version in x.y.z semver format followed by -dev.
 // If this is not consistently applied, the update-checker might malfunction.
 // In official releases, the CI flow will remove the -dev suffix when compiling the plugin.


### PR DESCRIPTION
Fixes missing loading of `cvars` when using `veto_mode` in KeyValues format.