### PR TITLE
Fix FCVAR flags and bump 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,39 @@ Whenever you update your Get5 plugin, remember to **always** update the `transla
 Please see the [installation instructions](https://splewis.github.io/get5/latest/installation/#installation) for
 details.
 
+# 0.15.0
+
+#### 2023-07-01
+
+This update changes the behavior of configuration parameters to make parameters apply consistently. Previously, only
+some configuration parameters would reset on map change while others would not.
+
+### Breaking Changes 🛠
+
+The [`FCVAR_DONTRECORD`](https://wiki.alliedmods.net/SourcePawn_Basics_-_Customization_through_ConVars) flag has been
+removed from all parameters, which means they all reset to the value stored in the
+[main configuration file](https://splewis.github.io/get5/latest/configuration/#main-config) when the map
+changes. In practice this means that any value you change during the course of a map via the console will *not* persist
+through a map change. If you want configuration parameters to be match-specific, you must either change them in the main
+config file *or* include them in the `cvars` section of your
+[match configuration](https://splewis.github.io/get5/latest/match_schema/#schema), which is loaded immediately following
+a map change. If you already use `cvars` and don't set parameters via console, you can safely update to 0.15.0.
+
+The following configuration parameters are now `FCVAR_PROTECTED`, which means you can only **set** their values, never
+read them back from the console (it will output `1` if set and `0` if empty):
+
+1. [`get5_remote_backup_url`](https://splewis.github.io/get5/latest/configuration/#get5_remote_backup_url)
+2. [`get5_remote_backup_header_key`](https://splewis.github.io/get5/latest/configuration/#get5_remote_backup_header_key)
+3. [`get5_remote_backup_header_value`](https://splewis.github.io/get5/latest/configuration/#get5_remote_backup_header_value)
+
+4. [`get5_demo_upload_url`](https://splewis.github.io/get5/latest/configuration/#get5_demo_upload_url)
+5. [`get5_demo_upload_header_key`](https://splewis.github.io/get5/latest/configuration/#get5_demo_upload_header_key)
+6. [`get5_demo_upload_header_value`](https://splewis.github.io/get5/latest/configuration/#get5_demo_upload_header_value)
+
+7. [`get5_remote_log_url`](https://splewis.github.io/get5/latest/configuration/#get5_remote_log_url)
+8. [`get5_remote_log_header_key`](https://splewis.github.io/get5/latest/configuration/#get5_remote_log_header_key)
+9. [`get5_remote_log_header_value`](https://splewis.github.io/get5/latest/configuration/#get5_remote_log_header_value)
+
 # 0.14.7
 
 #### 2023-05-06

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Discord Chat](https://img.shields.io/discord/926309849673895966?label=Discord)](https://discord.gg/zmqEa4keCk)
 [![Downloads](https://img.shields.io/github/downloads/splewis/get5/total?label=Downloads)](https://github.com/splewis/get5/releases/latest)
 
-## Status: Supported, actively developed.
+## Status: Supported. Development paused pending more information about CS2.
 
 Get5 is a standalone SourceMod plugin for CS:GO servers for running matches.
 

--- a/documentation/docs/commands.md
+++ b/documentation/docs/commands.md
@@ -280,7 +280,7 @@ defaults below.
 
 - `--no_series_clinch` or `-nsc`
     - Configures the series to play all maps, even if a team has practically won. I.e. plays all 3 maps of a Bo3.
-      Irrelevant if `--num_maps` is 1.
+      Irrelevant if `--num_maps` <= 2.
     - Type: `Boolean` (no arguments)
     - Default: `false`
 

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -539,15 +539,17 @@ exist.<br>**`Default: ""`**
 ####`get5_remote_backup_url`
 :   If defined, Get5 will [automatically send backups](../backup#upload) to this URL in an HTTP `POST` request. If no
 protocol is provided, `http://` will be prepended to this value. Requires the
-[SteamWorks](../installation#steamworks) extension.<br>**`Default: ""`**
+[SteamWorks](../installation#steamworks) extension.<br>**`Default: ""`**<br>**FCVAR_PROTECTED** :material-lock:
 
 ####`get5_remote_backup_header_key`
 :   If this **and** [`get5_remote_backup_header_value`](#get5_remote_backup_header_value) are defined, this header name
 and value will be used for your [backup upload HTTP request](#get5_remote_backup_url).<br>**`Default: "Authorization"`**
+<br>**FCVAR_PROTECTED** :material-lock:
 
 ####`get5_remote_backup_header_value`
 :   If this **and** [`get5_remote_backup_header_key`](#get5_remote_backup_header_key) are defined, this header name and
 value will be used for your [backup upload HTTP request](#get5_remote_backup_url).<br>**`Default: ""`**
+<br>**FCVAR_PROTECTED** :material-lock:
 
 ## Formats & Paths
 
@@ -640,7 +642,7 @@ to `csgo/cfg`.<br>**`Default: "get5/cvars.json"`**
 ####`get5_demo_upload_url`
 :   If defined, Get5 will [automatically send a recorded demo](../gotv#upload) to this URL in an HTTP `POST` request
 once a recording stops. If no protocol is provided, `http://` will be prepended to this value. Requires the
-[SteamWorks](../installation#steamworks) extension.<br>**`Default: ""`**
+[SteamWorks](../installation#steamworks) extension.<br>**`Default: ""`**<br>**FCVAR_PROTECTED** :material-lock:
 
 ####`get5_demo_upload_use_put`
 :   If enabled, the demo upload HTTP request will use `PUT` instead of `POST`.<br>**`Default: 0`**
@@ -651,10 +653,12 @@ once a recording stops. If no protocol is provided, `http://` will be prepended 
 ####`get5_demo_upload_header_key`
 :   If this **and** [`get5_demo_upload_header_value`](#get5_demo_upload_header_value) are defined, this header name and
 value will be used for your [demo upload HTTP request](#get5_demo_upload_url).<br>**`Default: "Authorization"`**
+<br>**FCVAR_PROTECTED** :material-lock:
 
 ####`get5_demo_upload_header_value`
 :   If this **and** [`get5_demo_upload_header_key`](#get5_demo_upload_header_key) are defined, this header name and
 value will be used for your [demo upload HTTP request](#get5_demo_upload_url).<br>**`Default: ""`**
+<br>**FCVAR_PROTECTED** :material-lock:
 
 ####`get5_demo_delete_after_upload`
 :   Whether to delete the demo file from the game server after
@@ -682,16 +686,17 @@ empty string to disable recording demos.<br>**`Default: "{TIME}_{MATCHID}_map{MA
 
 ####`get5_remote_log_url`
 :   The URL to send all [events](../events_and_forwards#http) to. Requires the [SteamWorks](../installation#steamworks)
-extension. Set to empty string to disable.<br>**`Default: ""`**
+extension. Set to empty string to disable.<br>**`Default: ""`**<br>**FCVAR_PROTECTED** :material-lock:
 
 ####`get5_remote_log_header_key`
 :   If this **and** [`get5_remote_log_header_value`](#get5_remote_log_header_value) are defined, this
-header name and value will be used for your [event HTTP requests](../events_and_forwards#http).<br>*
-*`Default: "Authorization"`**
+header name and value will be used for your [event HTTP requests](../events_and_forwards#http).
+<br>**`Default: "Authorization"`**<br>**FCVAR_PROTECTED** :material-lock:
 
 ####`get5_remote_log_header_value`
 :   If this **and** [`get5_remote_log_header_key`](#get5_remote_log_header_key) are defined, this header
 name and value will be used for your [event HTTP requests](../events_and_forwards#http).<br>**`Default: ""`**
+<br>**FCVAR_PROTECTED** :material-lock:
 
 ## Substitution Variables
 

--- a/scripting/get5.sp
+++ b/scripting/get5.sp
@@ -426,19 +426,19 @@ public void OnPluginStart() {
   g_StopCommandEnabledCvar              = CreateConVar("get5_stop_command_enabled", "1", "Whether clients can use the !stop command to restore to the beginning of the current round.");
   g_StopCommandNoDamageCvar             = CreateConVar("get5_stop_command_no_damage", "0", "Whether the stop command becomes unavailable if a player damages a player from the opposing team.");
   g_StopCommandTimeLimitCvar            = CreateConVar("get5_stop_command_time_limit", "0", "The number of seconds into a round after which a team can no longer request/confirm to stop and restart the round.");
-  g_RemoteBackupURLCvar                 = CreateConVar("get5_remote_backup_url", "", "A URL to send backup files to over HTTP. Leave empty to disable.");
-  g_RemoteBackupURLHeaderKeyCvar        = CreateConVar("get5_remote_backup_header_key", "Authorization", "If defined, a custom HTTP header with this name is added to the backup HTTP request.", FCVAR_DONTRECORD);
-  g_RemoteBackupURLHeaderValueCvar      = CreateConVar("get5_remote_backup_header_value", "", "If defined, the value of the custom header added to the backup HTTP request.", FCVAR_DONTRECORD | FCVAR_PROTECTED);
+  g_RemoteBackupURLCvar                 = CreateConVar("get5_remote_backup_url", "", "A URL to send backup files to over HTTP. Leave empty to disable.", FCVAR_PROTECTED);
+  g_RemoteBackupURLHeaderKeyCvar        = CreateConVar("get5_remote_backup_header_key", "Authorization", "If defined, a custom HTTP header with this name is added to the backup HTTP request.", FCVAR_PROTECTED);
+  g_RemoteBackupURLHeaderValueCvar      = CreateConVar("get5_remote_backup_header_value", "", "If defined, the value of the custom header added to the backup HTTP request.", FCVAR_PROTECTED);
 
   // Demos
   g_DemoUploadDeleteAfterCvar           = CreateConVar("get5_demo_delete_after_upload", "0", "Whether to delete the demo from the game server after a successful upload.");
   g_DemoNameFormatCvar                  = CreateConVar("get5_demo_name_format", "{TIME}_{MATCHID}_map{MAPNUMBER}_{MAPNAME}", "The format to use for demo files. Do not remove the {TIME} placeholder if you use the backup system. Set to empty string to disable automatic demo recording.");
   g_DemoPathCvar                        = CreateConVar("get5_demo_path", "", "The folder to save demo files in, relative to the csgo directory. If defined, it must not start with a slash and must end with a slash. Set to empty string to use the csgo root.");
-  g_DemoUploadHeaderKeyCvar             = CreateConVar("get5_demo_upload_header_key", "Authorization", "If defined, a custom HTTP header with this name is added to the demo upload HTTP request.", FCVAR_DONTRECORD);
-  g_DemoUploadHeaderValueCvar           = CreateConVar("get5_demo_upload_header_value", "", "If defined, the value of the custom header added to the demo upload HTTP request.", FCVAR_DONTRECORD | FCVAR_PROTECTED);
-  g_DemoUploadURLCvar                   = CreateConVar("get5_demo_upload_url", "", "If defined, recorded demos will be uploaded to this URL over HTTP. If no protocol is provided, 'http://' is prepended to this value.", FCVAR_DONTRECORD);
-  g_DemoUploadUsePUTCvar                = CreateConVar("get5_demo_upload_use_put", "0", "If enabled, the demo upload HTTP request will use PUT instead of POST.", FCVAR_DONTRECORD);
-  g_DemoUploadTimeoutCvar               = CreateConVar("get5_demo_upload_timeout", "180", "The timeout of the demo upload HTTP request, in seconds.", FCVAR_DONTRECORD);
+  g_DemoUploadHeaderKeyCvar             = CreateConVar("get5_demo_upload_header_key", "Authorization", "If defined, a custom HTTP header with this name is added to the demo upload HTTP request.", FCVAR_PROTECTED);
+  g_DemoUploadHeaderValueCvar           = CreateConVar("get5_demo_upload_header_value", "", "If defined, the value of the custom header added to the demo upload HTTP request.", FCVAR_PROTECTED);
+  g_DemoUploadURLCvar                   = CreateConVar("get5_demo_upload_url", "", "If defined, recorded demos will be uploaded to this URL over HTTP. If no protocol is provided, 'http://' is prepended to this value.", FCVAR_PROTECTED);
+  g_DemoUploadUsePUTCvar                = CreateConVar("get5_demo_upload_use_put", "0", "If enabled, the demo upload HTTP request will use PUT instead of POST.");
+  g_DemoUploadTimeoutCvar               = CreateConVar("get5_demo_upload_timeout", "180", "The timeout of the demo upload HTTP request, in seconds.");
 
   // Surrender/Forfeit
   g_ForfeitCountdownTimeCvar            = CreateConVar("get5_forfeit_countdown", "180", "The grace-period (in seconds) for rejoining the server to avoid a loss by forfeit.", 0, true, 30.0);
@@ -451,9 +451,9 @@ public void OnPluginStart() {
 
   // Events
   g_EventLogFormatCvar                  = CreateConVar("get5_event_log_format", "", "Path to use when writing match event logs to disk. Use \"\" to disable.");
-  g_EventLogRemoteHeaderKeyCvar         = CreateConVar("get5_remote_log_header_key", "Authorization", "If defined, a custom HTTP header with this name is added to the HTTP requests for events.", FCVAR_DONTRECORD);
-  g_EventLogRemoteHeaderValueCvar       = CreateConVar("get5_remote_log_header_value", "", "If defined, the value of the custom header added to the events sent over HTTP.", FCVAR_DONTRECORD | FCVAR_PROTECTED);
-  g_EventLogRemoteURLCvar               = CreateConVar("get5_remote_log_url", "", "If defined, all events are sent to this URL over HTTP. If no protocol is provided, 'http://' is prepended to this value.", FCVAR_DONTRECORD);
+  g_EventLogRemoteHeaderKeyCvar         = CreateConVar("get5_remote_log_header_key", "Authorization", "If defined, a custom HTTP header with this name is added to the HTTP requests for events.", FCVAR_PROTECTED);
+  g_EventLogRemoteHeaderValueCvar       = CreateConVar("get5_remote_log_header_value", "", "If defined, the value of the custom header added to the events sent over HTTP.", FCVAR_PROTECTED);
+  g_EventLogRemoteURLCvar               = CreateConVar("get5_remote_log_url", "", "If defined, all events are sent to this URL over HTTP. If no protocol is provided, 'http://' is prepended to this value.", FCVAR_PROTECTED);
 
   // Damage info
   g_DamagePrintCvar                     = CreateConVar("get5_print_damage", "1", "Whether damage reports are printed to chat on round end.");

--- a/scripting/get5/version.sp
+++ b/scripting/get5/version.sp
@@ -1,4 +1,4 @@
-#define PLUGIN_VERSION "0.14.7-dev"
+#define PLUGIN_VERSION "0.15.0-dev"
 // This MUST be the latest version in x.y.z semver format followed by -dev.
 // If this is not consistently applied, the update-checker might malfunction.
 // In official releases, the CI flow will remove the -dev suffix when compiling the plugin.


### PR DESCRIPTION
Fixes some inconsistencies with FCVAR flags.

Minor bump because it's technically a breaking change, although fairly easy to update to with no consequences for most uses.