### PR TITLE
Fix "penetrated" field type on document

### DIFF
--- a/documentation/docs/event_schema.yml
+++ b/documentation/docs/event_schema.yml
@@ -670,7 +670,7 @@ webhooks:
                       description: Indicates if the player was killed through smoke. `ThruSmoke`
                         in SourceMod.
                     penetrated:
-                      type: boolean
+                      type: number
                       description: Indicates if the player was killed through an object
                         (another player or walls). `Penetrated` in SourceMod.
                     attacker_blind:


### PR DESCRIPTION
Fix "penetrated" field type on player_death event.